### PR TITLE
[fix] fix empty asr result

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -388,6 +388,7 @@ class AutoModel:
                 ):
                     max_len_in_batch = max(max_len_in_batch, sample_length)
                     end_idx += 1
+                    results_sorted.append({'key': 'bad_data', 'text': '', 'timestamp': []})
                     continue
 
                 speech_j, speech_lengths_j = slice_padding_audio_samples(
@@ -417,7 +418,7 @@ class AutoModel:
                 end_idx += 1
                 max_len_in_batch = sample_length
                 if len(results) < 1:
-                    continue
+                    results.append({'key': 'bad_data', 'text': '', 'timestamp': []})
                 results_sorted.extend(results)
 
             # end_asr_total = time.time()


### PR DESCRIPTION
https://github.com/modelscope/FunASR/blob/main/funasr/auto/auto_model.py#L430-L434

```py
            restored_data = [0] * n
            for j in range(n):
                index = sorted_data[j][1]
                restored_data[index] = results_sorted[j]
            result = {}

```

This for-loop always assumes `results_sorted` with `n` segments, however, some segments might be skipped due to length filtering ([line384~line391](https://github.com/modelscope/FunASR/blob/main/funasr/auto/auto_model.py#L384-L391)) OR empty results ([line419](https://github.com/modelscope/FunASR/blob/main/funasr/auto/auto_model.py#L419-L420)). This can lead to a `list index out of range` error when attempting to assign values (`restored_data[index] = results_sorted[j]`) if `len(results_sorted) < n`


A simple solution is to append an empty result instead of skip it, ensuring that the length of `results_sorted` remains equal to `n`