### PR TITLE
Update cif_predictor.py

### DIFF
--- a/funasr/models/paraformer/cif_predictor.py
+++ b/funasr/models/paraformer/cif_predictor.py
@@ -504,7 +504,7 @@ def cif_v1_export(hidden, alphas, threshold: float):
     frames = torch.zeros(batch_size, len_time, hidden_size, dtype=dtype, device=device)
     fires = torch.zeros(batch_size, len_time, dtype=dtype, device=device)
 
-    prefix_sum = torch.cumsum(alphas, dim=1)
+    prefix_sum = torch.cumsum(alphas, dim=1, dtype=torch.float64).to(torch.float32) # cumsum precision degradation cause wrong result in extreme 
     prefix_sum_floor = torch.floor(prefix_sum)
     dislocation_prefix_sum = torch.roll(prefix_sum, 1, dims=1)
     dislocation_prefix_sum_floor = torch.floor(dislocation_prefix_sum)
@@ -671,7 +671,7 @@ def cif_wo_hidden_v1(alphas, threshold, return_fire_idxs=False):
 
     fires = torch.zeros(batch_size, len_time, dtype=dtype, device=device)
 
-    prefix_sum = torch.cumsum(alphas, dim=1)
+    prefix_sum = torch.cumsum(alphas, dim=1, dtype=torch.float64).to(torch.float32) # cumsum precision degradation cause wrong result in extreme 
     prefix_sum_floor = torch.floor(prefix_sum)
     dislocation_prefix_sum = torch.roll(prefix_sum, 1, dims=1)
     dislocation_prefix_sum_floor = torch.floor(dislocation_prefix_sum)

--- a/funasr/models/paraformer/cif_predictor.py
+++ b/funasr/models/paraformer/cif_predictor.py
@@ -718,7 +718,7 @@ def cif_v1(hidden, alphas, threshold):
 
     frames = frames - shift_frames + shift_remain_frames - remain_frames
 
-    max_label_len = batch_len.max()
+    max_label_len = torch.round(alphas.sum(-1)).int().max() # torch.round to calculate the max length
 
     frame_fires = torch.zeros(
         batch_size, max_label_len, hidden_size, dtype=dtype, device=device

--- a/funasr/models/paraformer/cif_predictor.py
+++ b/funasr/models/paraformer/cif_predictor.py
@@ -539,7 +539,8 @@ def cif_v1_export(hidden, alphas, threshold: float):
 
     frames = frames - shift_frames + shift_remain_frames - remain_frames
 
-    max_label_len = batch_len.max()
+    max_label_len = alphas.sum(dim=-1)
+    max_label_len = torch.floor(max_label_len).max().to(dtype=torch.int64)
 
     frame_fires = torch.zeros(
         batch_size, max_label_len, hidden_size, dtype=dtype, device=device


### PR DESCRIPTION
Modify the max_label_len to match the length in training. Please check whether the training process and result is correct. If there is something wrong, I suggest back the cif_v1 to cif in https://github.com/dtlzhuangz/FunASR/blob/main/funasr/models/paraformer/cif_predictor.py#L248.