### PR TITLE
Fix: Return tuple ('', []) when char_list is empty to prevent ValueError

### DIFF
--- a/runtime/python/onnxruntime/funasr_onnx/utils/timestamp_utils.py
+++ b/runtime/python/onnxruntime/funasr_onnx/utils/timestamp_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def time_stamp_lfr6_onnx(us_cif_peak, char_list, begin_time=0.0, total_offset=-1.5):
     if not len(char_list):
-        return []
+        return "", []
     START_END_THRESHOLD = 5
     MAX_TOKEN_DURATION = 30
     TIME_RATE = 10.0 * 6 / 1000 / 3  #  3 times upsampled


### PR DESCRIPTION
This commit fixes an issue where an empty char_list causes a ValueError due to insufficient values to unpack. The function now returns a tuple ('', []) when char_list is empty.