### PR TITLE
fix: fix input download logic

### DIFF
--- a/funasr/utils/load_utils.py
+++ b/funasr/utils/load_utils.py
@@ -76,7 +76,7 @@ def load_audio_text_image_video(
                 for audio in data_or_path_or_list
             ]
     if isinstance(data_or_path_or_list, str) and data_or_path_or_list.startswith(
-        "http"
+            ("http://", "https://")
     ):  # download url to local file
         data_or_path_or_list = download_from_url(data_or_path_or_list)
 


### PR DESCRIPTION
When I use funasr for asr and the input audio content starts with "http", an error is occured. SInce the string input to punc model is start with "http", it is be treated as an url and try to download from it. I try to fix it by detail the decision rule.

## Error detail
Input audio: [audio.zip](https://github.com/user-attachments/files/16286955/audio.zip)
``` shell
You are using the latest version of funasr-1.1.2
2024-07-19 00:55:30,640 - modelscope - INFO - Use user-specified model revision: v2.0.4
2024-07-19 00:55:33,696 - modelscope - INFO - Use user-specified model revision: v2.0.4
2024-07-19 00:55:34,460 - modelscope - INFO - Use user-specified model revision: v2.0.4
rtf_avg: 0.012: 100%|██████████| 1/1 [00:00<00:00,  7.10it/s]
  0%|          | 0/1 [00:00<?, ?it/s]
  0%|          | 0/1 [00:00<?, ?it/s]
100%|██████████| 1/1 [00:00<00:00,  1.64it/s]
{'load_data': '0.000', 'extract_feat': '0.003', 'forward': '0.609', 'batch_size': '1', 'rtf': '0.051'}, : 100%|██████████| 1/1 [00:00<00:00,  1.64it/s]
rtf_avg: 0.051: 100%|██████████| 1/1 [00:00<00:00,  1.64it/s]
  0%|          | 0/1 [00:00<?, ?it/s]Traceback (most recent call last):
  File "F:\codes\test_funasr\test_funasr.py", line 16, in <module>
    res = model.generate(input=r'audio.wav',
  File "f:\codes\funasr\funasr\auto\auto_model.py", line 263, in generate
    return self.inference_with_vad(input, input_len=input_len, **cfg)
  File "f:\codes\funasr\funasr\auto\auto_model.py", line 493, in inference_with_vad
    punc_res = self.inference(
  File "f:\codes\funasr\funasr\auto\auto_model.py", line 300, in inference
    res = model.inference(**batch, **kwargs)
  File "f:\codes\funasr\funasr\models\ct_transformer\model.py", line 257, in inference
    text = load_audio_text_image_video(data_in, data_type=kwargs.get("kwargs", "text"))[0]
  File "f:\codes\funasr\funasr\utils\load_utils.py", line 72, in load_audio_text_image_video
    return [
  File "f:\codes\funasr\funasr\utils\load_utils.py", line 73, in <listcomp>
    load_audio_text_image_video(
  File "f:\codes\funasr\funasr\utils\load_utils.py", line 81, in load_audio_text_image_video
    data_or_path_or_list = download_from_url(data_or_path_or_list)
  File "f:\codes\funasr\funasr\download\file.py", line 27, in download_from_url
    assert file_path is not None, f"failed to download: {url}"
AssertionError: failed to download: http 及 超 文 本 传 输 协 议 hyper text transfer protocol 是 用 于 在 万 维 网 word wide web 上 传 输 数 据 的 应 用 层 协 议
  0%|          | 0/1 [00:00<?, ?it/s]
  0%|          | 0/1 [00:00<?, ?it/s]
Process finished with exit code 1
```

## Ouput after fix
``` shell
[{'key': 'audio', 'text': ' Http及超文本传输协议hyper text transfer protocol是用于在万维网word wide web上传输数据的应用层协议。', 'timestamp': [[70, 990], [1330, 1570], [1670, 1830], [1830, 2010], [2010, 2250], [2350, 2550], [2550, 2790], [2810, 3030], [3030, 3270], [3550, 4050], [4050, 4450], [4470, 5090], [5090, 5950], [6170, 6410], [6410, 6530], [6530, 6710], [6710, 6910], [6910, 7070], [7070, 7310], [7310, 7550], [7870, 8390], [8410, 8730], [8730, 9210], [9230, 9470], [9610, 9810], [9810, 10050], [10130, 10290], [10290, 10470], [10470, 10610], [10610, 10770], [10770, 10950], [10950, 11190], [11230, 11430], [11430, 11695]]}]
```



