### PR TITLE
fix model name bug

### DIFF
--- a/examples/industrial_data_pretraining/qwen_audio/demo_chat.py
+++ b/examples/industrial_data_pretraining/qwen_audio/demo_chat.py
@@ -7,7 +7,7 @@
 
 from funasr import AutoModel
 
-model = AutoModel(model="Qwen-Audio-Chat")
+model = AutoModel(model="Qwen/Qwen-Audio-Chat")
 
 audio_in = "https://github.com/QwenLM/Qwen-Audio/raw/main/assets/audio/1272-128104-0000.flac"
 


### PR DESCRIPTION
原版的模型参数是：
`model = AutoModel(model="Qwen-Audio-Chat")
`

会发生报错：
`
Repository Not Found for url: https://huggingface.co/Qwen-Audio-Chat/resolve/main/config.json.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
Invalid username or password.

The above exception was the direct cause of the following exception:
...
OSError: Qwen-Audio-Chat is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
If this is a private repository, make sure to pass a token having permission to this repo either by logging in with `huggingface-cli login` or by passing `token=<your_token>`
`

需要改成：

`model = AutoModel(model="Qwen/Qwen-Audio-Chat")
`