### PR TITLE
fix bug, 1 fix cuda oom, 2 fix choose a window size 400 that is [2, 0]

### DIFF
--- a/funasr/frontends/wav_frontend.py
+++ b/funasr/frontends/wav_frontend.py
@@ -134,7 +134,7 @@ class WavFrontend(nn.Module):
             mat = kaldi.fbank(
                 waveform,
                 num_mel_bins=self.n_mels,
-                frame_length=self.frame_length,
+                frame_length=min(self.frame_length,waveform_length/self.fs*1000),
                 frame_shift=self.frame_shift,
                 dither=self.dither,
                 energy_floor=0.0,


### PR DESCRIPTION
**### 修改1:** 
找到/funasr/fronteds/wav_fronted.py/WavFonted 类的forward 方法

转到第137行，在调用kaldi.fbank方法中，修改代码为：
```

   mat = kaldi.fbank(
         waveform,
         num_mel_bins=self.n_mels,
         frame_length=min(self.frame_length,waveform_length/self.fs*1000),
         frame_shift=self.frame_shift,
         dither=self.dither,
         energy_floor=0.0,
         window_type=self.window,
         sample_frequency=self.fs,
         snip_edges=self.snip_edges,
     )
```

可以解决多进程ASR服务出现choose a window size 400 that is [2, 0]的问题。

**### 修改2: 找到funasr/models/sanm/attention.py**

将文件内所有的self.attn 修改为attn

将attn从类的变量修改为局部变量，可以解决多次调用asr_model的generate()方法时，因为类变量在GPU中销毁时间不确定及其他不明原因导致的cuda OOM问题。

修改2 对应的bug信息如下：
INFO:logger:Traceback (most recent call last):
  File "app.py", line 364, in pipeline
    reg = step1_asr(media_url, my_batch_size_s, my_merge_length_s,my_batch_size_threshold_s,my_max_single_segment_time)
  File "app.py", line 120, in step1_asr
    res = asr_model.generate(filename,batch_size_s=my_batch_size_s,
  File "/data/nixon/asr/src/asr_model.py", line 371, in generate
    return self.inference_with_vad(input, input_len=input_len, **cfg)
  File "/data/nixon/asr/src/asr_model.py", line 533, in inference_with_vad
    results = self.inference(
  File "/data/nixon/asr/src/asr_model.py", line 411, in inference
    res = model.inference(**batch, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/seaco_paraformer/model.py", line 407, in inference
    encoder_out, encoder_out_lens = self.encode(speech, speech_lengths)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/paraformer/model.py", line 262, in encode
    encoder_out, encoder_out_lens, _ = self.encoder(speech, speech_lengths)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/sanm/encoder.py", line 404, in forward
    encoder_outs = self.encoders(xs_pad, masks)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/transformer/utils/repeat.py", line 32, in forward
    args = m(*args)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/sanm/encoder.py", line 122, in forward
    self.self_attn(
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/sanm/attention.py", line 310, in forward
    att_outs = self.forward_attention(v_h, scores, mask, mask_att_chunk_encoder)
  File "/root/conda/envs/audio/lib/python3.8/site-packages/funasr/models/sanm/attention.py", line 278, in forward_attention
    self.attn = torch.softmax(scores, dim=-1).masked_fill(
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 342.00 MiB. GPU

