### PR TITLE
fix onnxruntime memoryleak when load vad model

### DIFF
--- a/runtime/onnxruntime/src/fsmn-vad.cpp
+++ b/runtime/onnxruntime/src/fsmn-vad.cpp
@@ -60,18 +60,19 @@ void FsmnVad::ReadModel(const char* vad_model) {
         LOG(ERROR) << "Error when load vad onnx model: " << e.what();
         exit(-1);
     }
-    GetInputOutputInfo(vad_session_, &vad_in_names_, &vad_out_names_);
+    GetInputOutputInfo(vad_session_, &vad_in_names_, &vad_out_names_, &vad_allocator);
 }
 
 void FsmnVad::GetInputOutputInfo(
         const std::shared_ptr<Ort::Session> &session,
-        std::vector<const char *> *in_names, std::vector<const char *> *out_names) {
+        std::vector<const char *> *in_names, std::vector<const char *> *out_names,
+        Ort::AllocatorWithDefaultOptions *allocator) {
     Ort::AllocatorWithDefaultOptions allocator;
     // Input info
     int num_nodes = session->GetInputCount();
     in_names->resize(num_nodes);
     for (int i = 0; i < num_nodes; ++i) {
-        std::unique_ptr<char, Ort::detail::AllocatedFree> name = session->GetInputNameAllocated(i, allocator);
+        std::unique_ptr<char, Ort::detail::AllocatedFree> name = session->GetInputNameAllocated(i, *allocator);
         Ort::TypeInfo type_info = session->GetInputTypeInfo(i);
         auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
         ONNXTensorElementDataType type = tensor_info.GetElementType();
@@ -90,7 +91,7 @@ void FsmnVad::GetInputOutputInfo(
     num_nodes = session->GetOutputCount();
     out_names->resize(num_nodes);
     for (int i = 0; i < num_nodes; ++i) {
-        std::unique_ptr<char, Ort::detail::AllocatedFree> name = session->GetOutputNameAllocated(i, allocator);
+        std::unique_ptr<char, Ort::detail::AllocatedFree> name = session->GetOutputNameAllocated(i, *allocator);
         Ort::TypeInfo type_info = session->GetOutputTypeInfo(i);
         auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
         ONNXTensorElementDataType type = tensor_info.GetElementType();
@@ -310,6 +311,8 @@ void FsmnVad::Test() {
 }
 
 FsmnVad::~FsmnVad() {
+    for (auto vad_in_name_item : vad_in_names_) vad_in_name_item.Free((void*)vad_in_name_item);
+    for (auto vad_out_name_item : vad_out_names_) vad_out_name_item.Free((void*)vad_out_name_item);
 }
 
 FsmnVad::FsmnVad():env_(ORT_LOGGING_LEVEL_ERROR, ""),session_options_{} {

--- a/runtime/onnxruntime/src/fsmn-vad.cpp
+++ b/runtime/onnxruntime/src/fsmn-vad.cpp
@@ -311,8 +311,8 @@ void FsmnVad::Test() {
 }
 
 FsmnVad::~FsmnVad() {
-    for (auto vad_in_name_item : vad_in_names_) vad_in_name_item.Free((void*)vad_in_name_item);
-    for (auto vad_out_name_item : vad_out_names_) vad_out_name_item.Free((void*)vad_out_name_item);
+    for (auto vad_in_name_item : vad_in_names_) vad_allocator.Free((void*)vad_in_name_item);
+    for (auto vad_out_name_item : vad_out_names_) vad_allocator.Free((void*)vad_out_name_item);
 }
 
 FsmnVad::FsmnVad():env_(ORT_LOGGING_LEVEL_ERROR, ""),session_options_{} {

--- a/runtime/onnxruntime/src/fsmn-vad.cpp
+++ b/runtime/onnxruntime/src/fsmn-vad.cpp
@@ -67,7 +67,6 @@ void FsmnVad::GetInputOutputInfo(
         const std::shared_ptr<Ort::Session> &session,
         std::vector<const char *> *in_names, std::vector<const char *> *out_names,
         Ort::AllocatorWithDefaultOptions *allocator) {
-    Ort::AllocatorWithDefaultOptions allocator;
     // Input info
     int num_nodes = session->GetInputCount();
     in_names->resize(num_nodes);

--- a/runtime/onnxruntime/src/fsmn-vad.h
+++ b/runtime/onnxruntime/src/fsmn-vad.h
@@ -34,6 +34,7 @@ public:
     std::shared_ptr<Ort::Session> vad_session_ = nullptr;
     Ort::Env env_;
     Ort::SessionOptions session_options_;
+    Ort::AllocatorWithDefaultOptions vad_allocator;
     std::vector<const char *> vad_in_names_;
     std::vector<const char *> vad_out_names_;
     std::vector<std::vector<float>> in_cache_;
@@ -56,7 +57,8 @@ private:
 
     static void GetInputOutputInfo(
             const std::shared_ptr<Ort::Session> &session,
-            std::vector<const char *> *in_names, std::vector<const char *> *out_names);
+            std::vector<const char *> *in_names, std::vector<const char *> *out_names,
+            Ort::AllocatorWithDefaultOptions *allocator);
 
     void FbankKaldi(float sample_rate, std::vector<std::vector<float>> &vad_feats,
                     std::vector<float> &waves);


### PR DESCRIPTION
关于 issue#1620，找到一个方法去修复一下，原因应该是 GetInputNameAllocated 没有及时释放。
看有没有问题