### PR TITLE
fix list index out of range error

### DIFF
--- a/funasr/utils/postprocess_utils.py
+++ b/funasr/utils/postprocess_utils.py
@@ -125,9 +125,11 @@ def abbr_dispose(words: List[Any], time_stamp: List[List] = None) -> List[Any]:
             if time_stamp is not None:
                 end = time_stamp[ts_nums[num]][1]
                 ts_lists.append([begin, end])
-        else:
-            word_lists.append(words[num])
-            if time_stamp is not None and words[num] != " ":
+        else:            
+            # length of time_stamp may not equal to length of words because of the (somehow improper) threshold set in timestamp_tools.py line 46, e.g., length of time_stamp can be zero but length of words is not.
+            # Moreover, move "word_lists.append(words[num])" into if clause, to keep length of word_lists and length of ts_lists equal.
+            if time_stamp is not None and ts_nums[num]<len(time_stamp) and words[num] != " ":
+                word_lists.append(words[num])
                 begin = time_stamp[ts_nums[num]][0]
                 end = time_stamp[ts_nums[num]][1]
                 ts_lists.append([begin, end])

--- a/funasr/utils/timestamp_tools.py
+++ b/funasr/utils/timestamp_tools.py
@@ -84,7 +84,8 @@ def ts_prediction_lfr6_standard(
         timestamp_list.append([_end * TIME_RATE, num_frames * TIME_RATE])
         new_char_list.append("<sil>")
     else:
-        timestamp_list[-1][1] = num_frames * TIME_RATE
+        if len(timestamp_list)>0:
+            timestamp_list[-1][1] = num_frames * TIME_RATE
     if vad_offset:  # add offset time in model with vad
         for i in range(len(timestamp_list)):
             timestamp_list[i][0] = timestamp_list[i][0] + vad_offset / 1000.0


### PR DESCRIPTION
list index out of range case 1:
2024-10-08T15:04:42.378018915+08:00 INFO:logger:Traceback (most recent call last):
2024-10-08T15:04:42.378026694+08:00   File "app.py", line 387, in pipeline
2024-10-08T15:04:42.378030230+08:00     reg = step1_asr(media_url)
2024-10-08T15:04:42.378033100+08:00   File "app.py", line 120, in step1_asr
2024-10-08T15:04:42.378035860+08:00     res = asr_model.generate(filename)
2024-10-08T15:04:42.378038943+08:00   File "/usr/local/services/asr/src/asr_model.py", line 371, in generate
2024-10-08T15:04:42.378041871+08:00     return self.inference_with_vad(input, input_len=input_len, **cfg)
2024-10-08T15:04:42.378045201+08:00   File "/usr/local/services/asr/src/asr_model.py", line 534, in inference_with_vad
2024-10-08T15:04:42.378048683+08:00     results = self.inference(
2024-10-08T15:04:42.378054236+08:00   File "/usr/local/services/asr/src/asr_model.py", line 411, in inference
2024-10-08T15:04:42.378057447+08:00     res = model.inference(**batch, **kwargs, cache={})  #nixon
2024-10-08T15:04:42.378060921+08:00   File "/usr/local/lib/python3.8/site-packages/funasr/models/seaco_paraformer/model.py", line 489, in inference
2024-10-08T15:04:42.378063817+08:00     postprocess_utils.sentence_postprocess(token, timestamp)
2024-10-08T15:04:42.378066886+08:00   File "/usr/local/lib/python3.8/site-packages/funasr/utils/postprocess_utils.py", line 247, in sentence_postprocess
2024-10-08T15:04:42.378069820+08:00     word_lists, ts_lists = abbr_dispose(word_lists, ts_lists)
2024-10-08T15:04:42.378072971+08:00   File "/usr/local/lib/python3.8/site-packages/funasr/utils/postprocess_utils.py", line 141, in abbr_dispose
2024-10-08T15:04:42.378075885+08:00     begin = time_stamp[ts_nums[num]][0]
2024-10-08T15:04:42.378078787+08:00 IndexError: list index out of range

```python
# length of time_stamp may not equal to length of words 
# because of the (somehow improper) threshold set in timestamp_tools.py line 46,
# e.g., length of time_stamp can be zero but length of words is not.
# Moreover, move "word_lists.append(words[num])" into if clause, to keep length of word_lists and length of ts_lists equal.

# time_stamp 的长度可能不等于 words 的长度，
# 因为 timestamp_tools.py 文件第 46 行设置了（某些情况下不合适的）阈值，
# 例如，time_stamp 的长度可以为零，但 words 的长度不是。
# 此外，将 "word_lists.append(words[num])" 移动到 if 语句中，以保持 word_lists 的长度和 ts_lists 的长度相等。
```

list index out of range case 2:
File "/usr/local/lib/python3.8/site-packages/funasr/utils/timestamp_tools.py", line 93, in ts_prediction_lfr6_standar
timestamp_list[-1][1] = num_frames * TIME_RATE
IndexError: list index out of range

timestamp_list 可能为空