### PR TITLE
数据并行可能导致的模型训练报错

### DIFF
--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -555,9 +555,8 @@ class SenseVoiceEncoderSmall(nn.Module):
         ilens: torch.Tensor,
     ):
         """Embed positions in tensor."""
-        maxlen = xs_pad.shape[1].to(ilens.device)
+        maxlen = torch.tensor(xs_pad.shape[1]).to(ilens.device)
         masks = sequence_mask(ilens, maxlen = maxlen, device=ilens.device)[:, None, :]
-
 
         xs_pad *= self.output_size() ** 0.5
 

--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -555,7 +555,9 @@ class SenseVoiceEncoderSmall(nn.Module):
         ilens: torch.Tensor,
     ):
         """Embed positions in tensor."""
-        masks = sequence_mask(ilens, device=ilens.device)[:, None, :]
+        maxlen = xs_pad.shape[1].to(ilens.device)
+        masks = sequence_mask(ilens, maxlen = maxlen, device=ilens.device)[:, None, :]
+
 
         xs_pad *= self.output_size() ** 0.5
 

--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -555,7 +555,7 @@ class SenseVoiceEncoderSmall(nn.Module):
         ilens: torch.Tensor,
     ):
         """Embed positions in tensor."""
-        maxlen = torch.tensor(xs_pad.shape[1]).to(ilens.device)
+        maxlen = xs_pad.shape[1]
         masks = sequence_mask(ilens, maxlen = maxlen, device=ilens.device)[:, None, :]
 
         xs_pad *= self.output_size() ** 0.5


### PR DESCRIPTION
标题：修复数据并行时 ilens 和 xs_pad 时间步不一致问题
描述：
本次更新解决了在数据并行处理中可能出现的 ilens（最大时间步）和 xs_pad（填充后的输入数据）时间步不一致的问题。这个问题源于数据加载器（dataloader）对数据进行填充（padding）时的行为。
问题描述：

在数据并行中，不同 GPU 上的 ilens 最大值可能与 xs_pad 的第二维度（时间步）不同。
这是因为 dataloader 对数据进行了 padding，可能导致实际的时间步超过了分配给特定 GPU 的 max_len。

举例说明：

假设使用两个 GPU 进行并行处理。
一个批次中的最大长度为 560。
GPU1 被分配的 max_len 为 550。
尽管 GPU1 的 max_len 为 550，但由于 padding，其实际 time_step 仍被填充到 560。

这个不一致可能会导致后续处理中的错误或不准确的结果。本次修复确保了 ilens 和 xs_pad 的时间步保持一致，提高了模型训练和推理的准确性和稳定性。