### PR TITLE
Add bounds check for postprocess_utils.py abbr_dispose()

### DIFF
--- a/funasr/utils/postprocess_utils.py
+++ b/funasr/utils/postprocess_utils.py
@@ -122,7 +122,7 @@ def abbr_dispose(words: List[Any], time_stamp: List[List] = None) -> List[Any]:
                         abbr_word += words[num].upper()
                 num += 1
             word_lists.append(abbr_word)
-            if time_stamp is not None:
+            if time_stamp is not None and ts_nums[num] < len(time_stamp):
                 end = time_stamp[ts_nums[num]][1]
                 ts_lists.append([begin, end])
         else:


### PR DESCRIPTION
Trying to run this example for `speech_timestamp_prediction-v1-16k-offline` [here](https://modelscope.cn/models/iic/speech_timestamp_prediction-v1-16k-offline/) for different audios. I see my English audio failed with this error.
Added this extra check locally and solved the issue.

```
"/Users/{USER}/.pyenv/versions/funasr_usage/lib/python3.12/site-packages/funasr/utils/postprocess_utils.py", line 127, in abbr_dispose
    end = time_stamp[ts_nums[num]][1]
          ~~~~~~~~~~^^^^^^^^^^^^^^
IndexError: list index out of range
```