### PR TITLE
fix issue: https://github.com/modelscope/FunASR/issues/2237

### DIFF
--- a/runtime/onnxruntime/src/funasrruntime.cpp
+++ b/runtime/onnxruntime/src/funasrruntime.cpp
@@ -297,10 +297,12 @@
 			//timestamp
 			if(msg_vec.size() > 1){
 				std::vector<std::string> msg_stamp = funasr::split(msg_vec[1], ',');
-				for(int i=0; i<msg_stamp.size()-1; i+=2){
-					float begin = std::stof(msg_stamp[i])+msg_stimes[idx];
-					float end = std::stof(msg_stamp[i+1])+msg_stimes[idx];
-					cur_stamp += "["+std::to_string((int)(1000*begin))+","+std::to_string((int)(1000*end))+"],";
+				if(msg_stamp.size() > 0){
+                    for(int i=0; i<msg_stamp.size()-1; i+=2){
+                        float begin = std::stof(msg_stamp[i])+msg_stimes[idx];
+                        float end = std::stof(msg_stamp[i+1])+msg_stimes[idx];
+                        cur_stamp += "["+std::to_string((int)(1000*begin))+","+std::to_string((int)(1000*end))+"],";
+                    }
 				}
 			}
 		}


### PR DESCRIPTION
I am attempting to fix the issue described in: https://github.com/modelscope/FunASR/issues/2237.
When the language model (lm) is set to "none", certain Automatic Speech Recognition (ASR) tasks for.wav files are being processed abnormally. Upon debugging the code, it was found that the program crashed (core dumped) because the size of msg_stamp was equal to 0, leading to an access failure. Therefore, I have added a protection code to handle this situation more gracefully.