### PR TITLE
fix export error if using cpu device

### DIFF
--- a/export.py
+++ b/export.py
@@ -2,7 +2,7 @@
 from funasr import AutoModel
 
 model = AutoModel(
-    model="/raid/t3cv/wangch/WORK_SAPCE/ASR/models/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
+    model="iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
 )
 
 res = model.export(type="onnx", quantize=False, opset_version=13, device='cuda')  # fp32 onnx-gpu

--- a/funasr/utils/export_utils.py
+++ b/funasr/utils/export_utils.py
@@ -65,8 +65,9 @@ def _onnx(
     **kwargs,
 ):
 
+    device = kwargs.get("device", "cpu")
     dummy_input = model.export_dummy_inputs()
-    dummy_input = (dummy_input[0].to("cuda"), dummy_input[1].to("cuda"))
+    dummy_input = (dummy_input[0].to(device), dummy_input[1].to(device))
 
 
     verbose = kwargs.get("verbose", False)


### PR DESCRIPTION
If using device="cpu" to export onnx, there will be error like
```bash
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument weight in method wrapper_CUDA__native_layer_norm)
```