### PR TITLE
fix export_onnx when inputs num > 2

### DIFF
--- a/funasr/utils/export_utils.py
+++ b/funasr/utils/export_utils.py
@@ -67,7 +67,7 @@ def _onnx(
 
     device = kwargs.get("device", "cpu")
     dummy_input = model.export_dummy_inputs()
-    dummy_input = (dummy_input[0].to(device), dummy_input[1].to(device))
+    dummy_input = tuple(t.to(device) for t in dummy_input)
 
 
     verbose = kwargs.get("verbose", False)


### PR DESCRIPTION
for "iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-online" the decoder has more than 2 inputs