### PR TITLE
utils.install_model_requirements: support installing with uv

### DIFF
--- a/funasr/utils/install_model_requirements.py
+++ b/funasr/utils/install_model_requirements.py
@@ -1,15 +1,10 @@
+import shutil
 import subprocess
 
 
 def install_requirements(requirements_path):
     try:
-        result = subprocess.run(
-            ["pip", "install", "-r", requirements_path],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-
+        result = pip_install_r(requirements_path)
         # check status
         if result.returncode == 0:
             print("install model requirements successfully")
@@ -19,13 +14,7 @@ def install_requirements(requirements_path):
             print("error", result.stderr)
             return False
     except Exception as e:
-        result = subprocess.run(
-            ["pip", "install", "-r", requirements_path],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-
+        result = pip_install_r(requirements_path)
         # check status
         if result.returncode == 0:
             print("install model requirements successfully")
@@ -34,3 +23,20 @@ def install_requirements(requirements_path):
             print("fail to install model requirements! ")
             print("error", result.stderr)
             return False
+
+
+def pip_install_r(requirements_path):
+    cmd = []
+    if shutil.which("pip") is not None:
+        cmd = ["pip"]
+    elif shutil.which("uv") is not None:
+        cmd = ["uv", "pip"]
+    else:
+        raise RuntimeError("pip not found, failed to install model requirements")
+    cmd += ["install", "-r", requirements_path]
+    return subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )


### PR DESCRIPTION
[uv][1] is a new high performance pip replacement that's been quite popular recently.

I was able to install and use FunASR with uv, except one problem: `utils.install_model_requirements` executes `pip install` directly, which causes a `FileNotFoundError` when using uv. This PR runs [uv's pip-compatible interface][2] when `pip` is not found on `PATH` but `uv` is.

[1]: https://docs.astral.sh/uv/
[2]: https://docs.astral.sh/uv/pip/packages/
