### PR TITLE
fix #2331: solve problems in sensevoice_bin.py related to argmax and unique operations.

### DIFF
--- a/runtime/python/onnxruntime/funasr_onnx/sensevoice_bin.py
+++ b/runtime/python/onnxruntime/funasr_onnx/sensevoice_bin.py
@@ -183,8 +183,10 @@ class SenseVoiceSmall:
                 #     ctc_logits = torch.from_numpy(ctc_logits).float()
                 # support batch_size=1 only currently
                 x = ctc_logits[b, : encoder_out_lens[b].item(), :]
-                yseq = x.argmax(dim=-1)
-                yseq = np.unique(yseq)
+                yseq = np.argmax(x, axis=-1)
+                # Use np.diff and np.where instead of torch.unique_consecutive.
+                mask = np.concatenate(([True], np.diff(yseq) != 0))
+                yseq = yseq[mask]
 
                 mask = yseq != self.blank_id
                 token_int = yseq[mask].tolist()


### PR DESCRIPTION
如issue #2331 提及，修复两个问题：
1. yseq = x.argmax(dim=-1) 改为 yseq = np.argmax(x, axis=-1)：

    - 由于 np.argmax 没有 dim 参数，原代码会导致 TypeError。改为 np.argmax(x, axis=-1) 以正确计算最大值的索引。    

3. 原来yseq = np.unique(yseq) 跟torch.unique_consecutive不一致（torch.unique_consecutive返回的结果是正确的），查了下：torch.unique_consecutive 只去除连续重复的元素，而np.unique：去除所有重复的元素，并返回排序后的唯一值数组。所以需要改为：

> mask = np.concatenate(([True], np.diff(yseq) != 0))
yseq = yseq[mask]

说明如下：
- np.diff(yseq) 计算数组中相邻元素的差值。
- np.diff(yseq) != 0 生成一个布尔数组，表示哪些位置的元素与前一个元素不同。
- np.concatenate(([True], ...)) 在布尔数组前添加一个 True，以保留第一个元素。
- yseq[mask] 使用布尔掩码提取去重后的数组。

经过测试后，结果符合预期。