### PR TITLE
允许 model.generate 使用bytes io, 以便不写入文件，节省io时间

### DIFF
--- a/funasr/utils/load_utils.py
+++ b/funasr/utils/load_utils.py
@@ -86,8 +86,10 @@ def load_audio_text_image_video(
     ):  # download url to local file
         data_or_path_or_list = download_from_url(data_or_path_or_list)
 
-    if isinstance(data_or_path_or_list, str) and os.path.exists(data_or_path_or_list):  # local file
+    if (isinstance(data_or_path_or_list, str) and os.path.exists(data_or_path_or_list)) or hasattr(data_or_path_or_list, 'read'):  # local file or bytes io
         if data_type is None or data_type == "sound":
+            if hasattr(data_or_path_or_list, "read") and hasattr(data_or_path_or_list, "seek"):
+                data_or_path_or_list.seek(0)
             # if use_ffmpeg:
             #     data_or_path_or_list = _load_audio_ffmpeg(data_or_path_or_list, sr=fs)
             #     data_or_path_or_list = torch.from_numpy(data_or_path_or_list).squeeze()  # [n_samples,]


### PR DESCRIPTION
直接将用户上传的语音文件传入torchaudio,它支持bytes io, 以避免服务端的文件写入， 直接传入wav bytes不能正常工作。
model = AutoModel(model="paraformer-zh",  vad_model="fsmn-vad",  punc_model="ct-punc", 
                  # spk_model="cam++", 
                  disable_update=True)
model.generate(input=wav,
                        batch_size_s=300）