### PR TITLE
Make Emotion2vec support onnx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ GPT-SoVITS*
 modelscope_models
 examples/aishell/llm_asr_nar/*
 *egg-info
+env/

--- a/export.py
+++ b/export.py
@@ -2,8 +2,9 @@
 from funasr import AutoModel
 
 model = AutoModel(
-    model="iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
+    model="iic/emotion2vec_base",
+    hub="ms"
 )
 
-res = model.export(type="onnx", quantize=False, opset_version=13, device='cuda')  # fp32 onnx-gpu
+res = model.export(type="onnx", quantize=False, opset_version=13, device='cpu')  # fp32 onnx-gpu
 # res = model.export(type="onnx_fp16", quantize=False, opset_version=13, device='cuda')  # fp16 onnx-gpu

--- a/funasr/models/emotion2vec/export_meta.py
+++ b/funasr/models/emotion2vec/export_meta.py
@@ -5,63 +5,69 @@
 
 import types
 import torch
+import torch.nn.functional as F
 
 
 def export_rebuild_model(model, **kwargs):
-    """Creates a wrapper model for ONNX export"""
+    model.device = kwargs.get("device")
 
-    class WrapperModule(torch.nn.Module):
-        def __init__(self, model):
-            super().__init__()
-            self.model = model
-            self.model.eval()
+    # store original forward since self.extract_features is calling it
+    model._original_forward = model.forward
 
-        def forward(self, x):
-            with torch.no_grad():
-                feats = self.model.extract_features(x, padding_mask=None)
-                return feats["x"]  # Return only the features tensor
+    model.forward = types.MethodType(export_forward, model)
+    model.export_dummy_inputs = types.MethodType(export_dummy_inputs, model)
+    model.export_input_names = types.MethodType(export_input_names, model)
+    model.export_output_names = types.MethodType(export_output_names, model)
+    model.export_dynamic_axes = types.MethodType(export_dynamic_axes, model)
+    model.export_name = types.MethodType(export_name, model)
 
-        def export_input_names(self):
-            return ["input"]
+    model.export_name = "emotion2vec"
+    return model
 
-        def export_output_names(self):
-            return ["output"]
 
-        def export_dynamic_axes(self):
-            return {
-                "input": {
-                    0: "batch_size",
-                    1: "sequence_length",
-                },
-                "output": {0: "batch_size", 1: "sequence_length"},
-            }
+def export_forward(
+    self, x: torch.Tensor
+):
+    with torch.no_grad():
+        # if self.cfg.normalize:
+        #     x = F.layer_norm(x, x.shape)
 
-        @property
-        def export_name(self):
-            return "emotion2vec"
+        # Call the original forward directly just like extract_features
+        # Cannot directly use self.extract_features since it is being replaced by export_forward
+        res = self._original_forward(
+            source=x,
+            padding_mask=None,
+            mask=False,
+            features_only=True,
+            remove_extra_tokens=True
+        )
         
-        def export_dummy_inputs(self):
-            return torch.randn(1, 16000)
+        x = res["x"]
 
-    wrapped_model = WrapperModule(model)
-    return wrapped_model
-
-# def export_dummy_inputs(self):
-#     return torch.randn(1, 16000)
-
-# def export_input_names(self):
-#     return ["input"]
+        return x
 
 
-# def export_output_names(self):
-#     return ["output"]
+def export_dummy_inputs(self):
+    return (torch.randn(1, 16000),)
 
 
-# def export_dynamic_axes(self):
-#     return {
-#         "input": {
-#             0: "batch_size",
-#             1: "sequence_length",
-#         },
-#         "output": {0: "batch_size", 1: "sequence_length"},
-#     }
+def export_input_names(self):
+    return ["input"]
+
+
+def export_output_names(self):
+    return ["output"]
+
+
+def export_dynamic_axes(self):
+    return {
+        "input": {
+            0: "batch_size",
+            1: "sequence_length",
+        },
+        "output": {0: "batch_size", 1: "sequence_length"},
+    }
+
+
+def export_name(self):
+    return "emotion2vec"

--- a/funasr/models/emotion2vec/export_meta.py
+++ b/funasr/models/emotion2vec/export_meta.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+# Copyright FunASR (https://github.com/alibaba-damo-academy/FunASR). All Rights Reserved.
+#  MIT License  (https://opensource.org/licenses/MIT)
+
+import types
+import torch
+
+
+def export_rebuild_model(model, **kwargs):
+    """Creates a wrapper model for ONNX export"""
+
+    class WrapperModule(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+            self.model.eval()
+
+        def forward(self, x):
+            with torch.no_grad():
+                feats = self.model.extract_features(x, padding_mask=None)
+                return feats["x"]  # Return only the features tensor
+
+        def export_input_names(self):
+            return ["input"]
+
+        def export_output_names(self):
+            return ["output"]
+
+        def export_dynamic_axes(self):
+            return {
+                "input": {
+                    0: "batch_size",
+                    1: "sequence_length",
+                },
+                "output": {0: "batch_size", 1: "sequence_length"},
+            }
+
+        @property
+        def export_name(self):
+            return "emotion2vec"
+        
+        def export_dummy_inputs(self):
+            return torch.randn(1, 16000)
+
+    wrapped_model = WrapperModule(model)
+    return wrapped_model
+
+# def export_dummy_inputs(self):
+#     return torch.randn(1, 16000)
+
+# def export_input_names(self):
+#     return ["input"]
+
+
+# def export_output_names(self):
+#     return ["output"]
+
+
+# def export_dynamic_axes(self):
+#     return {
+#         "input": {
+#             0: "batch_size",
+#             1: "sequence_length",
+#         },
+#         "output": {0: "batch_size", 1: "sequence_length"},
+#     }

--- a/funasr/models/emotion2vec/export_meta.py
+++ b/funasr/models/emotion2vec/export_meta.py
@@ -29,8 +29,11 @@ def export_forward(
     self, x: torch.Tensor
 ):
     with torch.no_grad():
-        # if self.cfg.normalize:
-        #     x = F.layer_norm(x, x.shape)
+        if self.cfg.normalize:
+            mean = torch.mean(x, dim=1, keepdim=True)
+            var = torch.var(x, dim=1, keepdim=True, unbiased=False)
+            x = (x - mean) / torch.sqrt(var + 1e-5)
+            x = x.view(x.shape[0], -1)
 
         # Call the original forward directly just like extract_features
         # Cannot directly use self.extract_features since it is being replaced by export_forward

--- a/funasr/models/emotion2vec/model.py
+++ b/funasr/models/emotion2vec/model.py
@@ -265,3 +265,9 @@ class Emotion2vec(torch.nn.Module):
             results.append(result_i)
 
         return results, meta_data
+
+    def export(self, **kwargs):
+        from .export_meta import export_rebuild_model
+
+        models = export_rebuild_model(model=self, **kwargs)
+        return models


### PR DESCRIPTION
From the following feature requests
- https://github.com/ddlBoJack/emotion2vec/issues/55
- https://github.com/modelscope/FunASR/issues/2291
- Amazing work did by https://github.com/thewh1teagle/FunASR/commit/586e81deb91daf0da1cbf31eb9b1af902857aaf0

- [x] Include LayerNorm to the Onnx model
~~I have made emotion2vec exportable to onnx with dynamic audio sequence length. Sadly, I cannot include LayerNorm to the `export_forward` it produces this error~~
<details>
  <summary>Error Log</summary>
  
  ```python
python export.py
funasr version: 1.2.2.
Check update of funasr, and it would cost few times. You may disable it by set `disable_update=True` in AutoModel
You are using the latest version of funasr-1.2.2
Downloading Model to directory: /Users/kridtaphadsae-khow/.cache/modelscope/hub/iic/emotion2vec_base
2025-01-10 15:31:59,726 - modelscope - WARNING - Using branch: master as version is unstable, use with caution
Traceback (most recent call last):
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/export.py", line 9, in <module>
    res = model.export(type="onnx", quantize=False, opset_version=13, device='cpu')  # fp32 onnx-gpu
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/funasr/auto/auto_model.py", line 664, in export
    export_dir = export_utils.export(model=model, data_in=data_list, **kwargs)
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/funasr/utils/export_utils.py", line 22, in export
    _onnx(
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/funasr/utils/export_utils.py", line 80, in _onnx
    torch.onnx.export(
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/__init__.py", line 375, in export
    export(
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/utils.py", line 502, in export
    _export(
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/utils.py", line 1564, in _export
    graph, params_dict, torch_out = _model_to_graph(
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/utils.py", line 1117, in _model_to_graph
    graph = _optimize_graph(
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/utils.py", line 639, in _optimize_graph
    graph = _C._jit_pass_onnx(graph, operator_export_type)
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/utils.py", line 1836, in _run_symbolic_function
    return symbolic_fn(graph_context, *inputs, **attrs)
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/symbolic_helper.py", line 369, in wrapper
    return fn(g, *args, **kwargs)
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/symbolic_helper.py", line 264, in wrapper
    args = [
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/symbolic_helper.py", line 265, in <listcomp>
    _parse_arg(arg, arg_desc, arg_name, fn_name)  # type: ignore[method-assign]
  File "/Users/kridtaphadsae-khow/Workspace/poc/FunASR/env/lib/python3.9/site-packages/torch/onnx/symbolic_helper.py", line 88, in _parse_arg
    raise errors.SymbolicValueError(
torch.onnx.errors.SymbolicValueError: Failed to export a node '%198 : Long(device=cpu) = onnx::Gather[axis=0](%195, %197), scope: funasr.models.emotion2vec.model.Emotion2vec:: # /Users/kridtaphadsae-khow/Workspace/poc/FunASR/funasr/models/emotion2vec/export_meta.py:33:0
' (in list node %204 : int[] = prim::ListConstruct(%198, %203), scope: funasr.models.emotion2vec.model.Emotion2vec::
) because it is not constant. Please try to make things (e.g. kernel sizes) static if possible.  [Caused by the value '204 defined in (%204 : int[] = prim::ListConstruct(%198, %203), scope: funasr.models.emotion2vec.model.Emotion2vec::
)' (type 'List[int]') in the TorchScript graph. The containing node has kind 'prim::ListConstruct'.] 

    Inputs:
        #0: 198 defined in (%198 : Long(device=cpu) = onnx::Gather[axis=0](%195, %197), scope: funasr.models.emotion2vec.model.Emotion2vec:: # /Users/kridtaphadsae-khow/Workspace/poc/FunASR/funasr/models/emotion2vec/export_meta.py:33:0
    )  (type 'Tensor')
        #1: 203 defined in (%203 : Long(device=cpu) = onnx::Gather[axis=0](%200, %202), scope: funasr.models.emotion2vec.model.Emotion2vec:: # /Users/kridtaphadsae-khow/Workspace/poc/FunASR/funasr/models/emotion2vec/export_meta.py:33:0
    )  (type 'Tensor')
    Outputs:
        #0: 204 defined in (%204 : int[] = prim::ListConstruct(%198, %203), scope: funasr.models.emotion2vec.model.Emotion2vec::
    )  (type 'List[int]')
  ```
</details>

## How to export
```python
from funasr import AutoModel
import onnxruntime as ort
import numpy as np

model = AutoModel(
    model="iic/emotion2vec_base",
    hub="ms"
)

export_dir = model.export(type="onnx", quantize=False, opset_version=13, device='cpu')
print(f"The onnx model is exported at {export_dir}")

session = ort.InferenceSession(f"{export_dir}/emotion2vec.onnx")
input_name = session.get_inputs()[0].name
output_name = session.get_outputs()[0].name


x = np.random.randn(1, 32000).astype(np.float32)
y = session.run([output_name], {input_name: x})

print(y)
```
Feel free to review the code and give feedbacks 😁