### PR TITLE
fix: resolve unexpected 'out of memory' issue in multi-GPU setup

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -366,7 +366,8 @@ class AutoModel:
         if pbar:
             # pbar.update(1)
             pbar.set_description(f"rtf_avg: {time_escape_total/time_speech_total:0.3f}")
-        torch.cuda.empty_cache()
+        with torch.cuda.device(next(model.parameters()).device):
+            torch.cuda.empty_cache()
         return asr_result_list
 
     def inference_with_vad(self, input, input_len=None, **cfg):

--- a/funasr/bin/train.py
+++ b/funasr/bin/train.py
@@ -221,7 +221,8 @@ def main(**kwargs):
             )
             trainer.start_step = 0
 
-            torch.cuda.empty_cache()
+            with torch.cuda.device(kwargs["device"]):
+                torch.cuda.empty_cache()
 
             time_escaped = (time.perf_counter() - time_slice_i) / 3600.0
             logging.info(

--- a/funasr/bin/train_ds.py
+++ b/funasr/bin/train_ds.py
@@ -184,7 +184,8 @@ def main(**kwargs):
             )
             trainer.start_step = 0
 
-            torch.cuda.empty_cache()
+            with torch.cuda.device(kwargs["device"]):
+                torch.cuda.empty_cache()
 
             time_escaped = (time.perf_counter() - time_slice_i) / 3600.0
             logging.info(

--- a/funasr/models/language_model/rnn/decoders.py
+++ b/funasr/models/language_model/rnn/decoders.py
@@ -873,7 +873,8 @@ class Decoder(torch.nn.Module, ScorerInterface):
                         ctc_state[idx], accum_best_ids
                     )
 
-        torch.cuda.empty_cache()
+        with torch.cuda.device(vscores.device):
+            torch.cuda.empty_cache()
 
         dummy_hyps = [{"yseq": [self.sos, self.eos], "score": np.array([-float("inf")])}]
         ended_hyps = [


### PR DESCRIPTION
Fixed a bug where calling `torch.cuda.empty_cache()` caused extra memory usage on 'cuda:0', leading to unexpected 'out of memory' errors in multi-GPU environments.

To reproduce the issue: 
1. On a multi-GPU machine, run a model on `cuda:0` until its memory usage reaches 100%.
2. Run `paraformer-zh` on another GPU, causing the out-of-memory error.

The issue may be the bug described in [#1145](https://github.com/modelscope/FunASR/issues/1145).

Reference:
- https://github.com/pytorch/pytorch/issues/25752
- https://github.com/pytorch/pytorch/issues/144025