### PR TITLE
# 增强说话人分离功能的时间戳支持

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -549,8 +549,41 @@ class AutoModel:
 
             # speaker embedding cluster after resorted
             if self.spk_model is not None and kwargs.get("return_spk_res", True):
-                if raw_text is None:
-                    logging.error("Missing punc_model, which is required by spk_model.")
+                # 1. 先检查时间戳
+                has_timestamp = (
+                    hasattr(self.model, "internal_punc") or
+                    self.punc_model is not None or
+                    "timestamp" in result
+                )
+                
+                if not has_timestamp:
+                    logging.error("Need timestamp support...")
+                    return results_ret_list
+
+                # 2. 初始化 punc_res
+                punc_res = None
+                
+                # 3. 根据不同情况设置 punc_res
+                if hasattr(self.model, "internal_punc"):
+                    punc_res = [{
+                        "text": result["text"],
+                        "punc_array": result.get("punc_array", []),
+                        "timestamp": result.get("timestamp", [])
+                    }]
+                elif self.punc_model is not None:
+                    punc_res = self.inference(
+                        result["text"], 
+                        model=self.punc_model, 
+                        kwargs=self.punc_kwargs, 
+                        **cfg
+                    )
+                else:
+                    # 如果只有时间戳，创建一个基本的 punc_res
+                    punc_res = [{
+                        "text": result["text"],
+                        "punc_array": [],  # 空的标点数组
+                        "timestamp": result["timestamp"]
+                    }]
                 all_segments = sorted(all_segments, key=lambda x: x[0])
                 spk_embedding = result["spk_embedding"]
                 labels = self.cb_model(


### PR DESCRIPTION
# 增强说话人分离功能的时间戳支持
## 主要改动
1. 重构了说话人分离的依赖检查逻辑
   - 原本：仅检查标点模型是否存在
   - 现在：扩展为全面的时间戳支持检查

2. 增加了更灵活的时间戳处理机制：
   - 支持内部标点模型的时间戳
   - 支持外部标点模型的时间戳
   - 支持纯时间戳情况

3. 优化了错误处理和返回逻辑：
   - 替换了原有的单一错误提示
   - 增加了更具体的时间戳支持检查
   - 添加了不同情况下的结果格式化处理

## 功能说明
这次更新主要是为了适配 SenseVoice 的说话人分离功能，提供更灵活的时间戳支持：
- 支持说话人分离（Speaker Separation）
- 支持时间戳标注（Timestamp）
- 支持 VAD 语音活动检测切分（Voice Activity Detection）

## 改进效果
1. 更灵活的时间戳支持：
   - 不再强制要求标点模型
   - 支持多种时间戳来源
   - 统一的结果格式

2. 更好的错误处理：
   - 清晰的错误提示
   - 优雅的失败处理
   - 一致的返回格式