### PR TITLE
fix: convert tokens from ids instead of from text

### DIFF
--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -918,7 +918,7 @@ class SenseVoiceSmall(nn.Module):
                 from itertools import groupby
 
                 timestamp = []
-                tokens = tokenizer.text2tokens(text)[4:]
+                tokens = tokenizer.ids2tokens([[tok_int] for tok_int in token_int])[4:]
                 logits_speech = self.ctc.softmax(encoder_out)[i, 4 : encoder_out_lens[i].item(), :]
                 pred = logits_speech.argmax(-1).cpu()
                 logits_speech[pred == self.blank_id, self.blank_id] = 0


### PR DESCRIPTION
If you use text, consecutive empty spaces '' are merged into one, causing a mismatch in timestamp calculation.

```python
from funasr import AutoModel
from funasr.utils.postprocess_utils import rich_transcription_postprocess


model = AutoModel(
    model="iic/SenseVoiceSmall",
    trust_remote_code=True,
    remote_code="./model.py",
    vad_model="fsmn-vad",
    vad_kwargs={"max_single_segment_time": 30000},
)

res = model.generate(
    input="av114076797632738.wav",
    cache={},
    language="auto",  # "zn", "en", "yue", "ja", "ko", "nospeech"
    use_itn=True,
    batch_size_s=60,
    merge_vad=True,  #
    merge_length_s=15,
    output_timestamp=True
)
text = rich_transcription_postprocess(res[0]["text"])
print(text)
```

Error: 
```
  File "d:\miniconda3\lib\site-packages\funasr\auto\auto_model.py", line 343, in inference
    res = model.inference(**batch, **kwargs)
  File "d:\miniconda3\lib\site-packages\funasr\models\sense_voice\model.py", line 941, in inference
    timestamp.append([tokens[token_id], ts_left, ts_right])
IndexError: list index out of range
```

dig into the cause: 
```python
>>> len(tokenizer.text2tokens(text)) # old way
46
>>> len(tokenizer.ids2tokens([[tok_int] for tok_int in token_int])) # fixed 
47
>>> list(zip(tokenizer.text2tokens(text), tokenizer.ids2tokens([[tok_int] for tok_int in token_int])))
[('<|en|>', '<|en|>'),
 ('<|EMO_UNKNOWN|>', '<|EMO_UNKNOWN|>'),
 ('<|Speech|>', '<|Speech|>'),
 ('<|withitn|>', '<|withitn|>'),
 ('Pro', 'Pro'),
 ('b', 'b'),
 ('ably', 'ably'),
 ('▁do', 'do'),
 ('▁you', 'you'),
 ("'", "'"),
 ('re', 're'),
 ('▁getting', 'getting'),
 ('▁like', 'like'),
 ('▁', ''),
 ('1', '1'),
 ('1', '1'),
 ('0', '0'),
 ('▁average', 'average'),
 ('▁y', 'y'),
 ('▁and', 'and'),
 ('▁it', 'it'),
 ("'", "'"),
 ('s', 's'),
 ('▁like', 'like'), 
 ('▁', ''), ### <- 
 ('9', ''), ### <- the empty space that is absorbed
 ('1', '9'),
 ('%', '1'),
 ('▁low', '%'),
 ('s', 'low'),
 ('▁so', 's'),
 ('▁you', 'so'),
 ('▁are', 'you'),
 ('▁getting', 'are'),
 ('▁native', 'getting'),
 ('▁performance', 'native'),
 ('▁where', 'performance'),
 ('▁you', 'where'),
 ('▁used', 'you'),
 ('▁to', 'used'),
 ('▁need', 'to'),
 ('▁D', 'need'),
 ('L', 'D'),
 ('S', 'L'),
 ('S', 'S'),
 ('.', 'S')]
```
