### PR TITLE
fix: use converted token_ids for alignment for sensevoice model with timestamp output

### DIFF
--- a/funasr/utils/timestamp_tools.py
+++ b/funasr/utils/timestamp_tools.py
@@ -160,7 +160,7 @@ def timestamp_sentence(
         punc_id = int(punc_id) if punc_id is not None else 1
         sentence_end = timestamp[1] if timestamp is not None else sentence_end
         sentence_text_seg = (
-            sentence_text_seg[:-1] if sentence_text_seg[-1] == " " else sentence_text_seg
+            sentence_text_seg[:-1] if sentence_text_seg and sentence_text_seg[-1] == " " else sentence_text_seg
         )
         if punc_id > 1:
             sentence_text += punc_list[punc_id - 2]


### PR DESCRIPTION
BPE doesn't guarantee converted ids (subwords) are revertible. which means `tokens` converted back is not always the same as `token_int`. A easy fix is to directly use the converted ids for alignment. Since they are from the same text, it shouldn't matter. 

在使用sensevoice模型中，我遇到这样的报错：
```
  File "d:\miniconda3\lib\site-packages\funasr\auto\auto_model.py", line 343, in inference
    res = model.inference(**batch, **kwargs)
  File "d:\miniconda3\lib\site-packages\funasr\models\sense_voice\model.py", line 941, in inference
    timestamp.append([tokens[token_id], ts_left, ts_right])
IndexError: list index out of range
```
这是由于 `tokens` 和 `token_int` 长度不同。在我这次运行中，是因为模型推理结果有两个连续的空格，但是在转回来时变成了一个空格。但是，在简单修改后，发现还会有其他的情况。因为**BPE不保证可以互相转换**。我发现了另一个问题：模型推理为一个token `its` 但是从文本转回时变成了 `['it', 's']`。所以我撤回了之前的PR。

本次修改，直接使用 文本转回的 id 去做 align，这样保证两个列表一定是同样长度的。这两个列表在大部分情况下还是相同的。既然他们对应的是同样的声音片段和文本，用转回的id来对齐时间更合理。否则无法把subwords拼回去。
