### PR TITLE
FIX 'NoneType' object has no attribute 'isalpha'

### DIFF
--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -970,7 +970,7 @@ class SenseVoiceSmall(nn.Module):
             elif word.startswith("▁"):
                 word = word[1:]
                 timestamp_new.append([start, end])
-            elif prev_word.isalpha() and prev_word.isascii() and word.isalpha() and word.isascii():
+            elif prev_word is not None and prev_word.isalpha() and prev_word.isascii() and word.isalpha() and word.isascii():
                 prev_word += word
                 timestamp_new[-1][1] = end
             else:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/data2/workspace/egs_vocal_extractor/data/speech_det.py", line 156, in process_audio_task
    res = model.generate(
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/site-packages/funasr/auto/auto_model.py", line 306, in generate
    return self.inference_with_vad(input, input_len=input_len, **cfg)
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/site-packages/funasr/auto/auto_model.py", line 464, in inference_with_vad
    results = self.inference(
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/site-packages/funasr/auto/auto_model.py", line 345, in inference
    res = model.inference(**batch, **kwargs)
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/site-packages/funasr/models/sense_voice/model.py", line 950, in inference
    timestamp = self.post(timestamp)
  File "/root/miniconda3/envs/sensevoice/lib/python3.10/site-packages/funasr/models/sense_voice/model.py", line 973, in post
    elif prev_word.isalpha() and prev_word.isascii() and word.isalpha() and word.isascii():
AttributeError: 'NoneType' object has no attribute 'isalpha'