### PR TITLE
Fix: Spelling causes hotwords to not take effect

### DIFF
--- a/runtime/python/websocket/funasr_wss_server.py
+++ b/runtime/python/websocket/funasr_wss_server.py
@@ -179,7 +179,7 @@ async def ws_serve(websocket, path):
                     websocket.status_dict_asr_online["decoder_chunk_look_back"] = messagejson[
                         "decoder_chunk_look_back"
                     ]
-                if "hotword" in messagejson:
+                if "hotwords" in messagejson:
                     websocket.status_dict_asr["hotword"] = messagejson["hotwords"]
                 if "mode" in messagejson:
                     websocket.mode = messagejson["mode"]


### PR DESCRIPTION
The hotword passed by the client cannot take effect because of a spelling error.