### PR TITLE
优化seaco_paraformer，加快百分之20以上推理速度

### DIFF
--- a/funasr/models/seaco_paraformer/model.py
+++ b/funasr/models/seaco_paraformer/model.py
@@ -16,6 +16,7 @@ import numpy as np
 from typing import Dict, Tuple
 from contextlib import contextmanager
 from distutils.version import LooseVersion
+from functools import lru_cache
 
 from funasr.register import tables
 from funasr.utils import postprocess_utils
@@ -510,17 +511,6 @@ class SeacoParaformer(BiCifParaformer, Paraformer):
         return results, meta_data
 
     def generate_hotwords_list(self, hotword_list_or_file, tokenizer=None, frontend=None):
-        def load_seg_dict(seg_dict_file):
-            seg_dict = {}
-            assert isinstance(seg_dict_file, str)
-            with open(seg_dict_file, "r", encoding="utf8") as f:
-                lines = f.readlines()
-                for line in lines:
-                    s = line.strip().split()
-                    key = s[0]
-                    value = s[1:]
-                    seg_dict[key] = " ".join(value)
-            return seg_dict
 
         def seg_tokenize(txt, seg_dict):
             pattern = re.compile(r"^[\u4E00-\u9FA50-9]+$")
@@ -626,3 +616,17 @@ class SeacoParaformer(BiCifParaformer, Paraformer):
 
         models = export_rebuild_model(model=self, **kwargs)
         return models
+    
+
+@lru_cache(maxsize=1)
+def load_seg_dict(seg_dict_file):
+    seg_dict = {}
+    assert isinstance(seg_dict_file, str)
+    with open(seg_dict_file, "r", encoding="utf8") as f:
+        lines = f.readlines()
+        for line in lines:
+            s = line.strip().split()
+            key = s[0]
+            value = s[1:]
+            seg_dict[key] = " ".join(value)
+    return seg_dict


### PR DESCRIPTION
最近使用热词模型sea_paraformer时，发现推理速度明显慢于paraformer，在rtx6000gpu机器上，大概慢百分30，使用性能分析工具py-spy分析发现耗时很大一部分来自load_seg_dict函数。

运行命令：
`sudo py-spy record -0 output.svg -- python test.py
`
test.py代码如下：
`from funasr import AutoModel
import time

model = AutoModel(model=xxx)
audio = load_audio(xxx)

start = time.perf_counter()
for i in range(100):
    result = model.generate(audio, hotword="你好啊 哈哈")
    # print(result)
end = time.perf_counter()
print(f"time: {end - start}")
`

火焰图：
![image](https://github.com/user-attachments/assets/bc6c99a2-d21c-41a9-9268-b64edbc2ed11)

解决方案：
可能最好的方案是在模型初始化的时候加载，但考虑到加载条件依赖frontend，故仅采用缓存方案避免后续每次都会加载seg_dict


