### PR TITLE
修复Fsmn_vad_online多线程调用报错

### DIFF
--- a/runtime/python/onnxruntime/funasr_onnx/utils/frontend.py
+++ b/runtime/python/onnxruntime/funasr_onnx/utils/frontend.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, NamedTuple, Set, Tuple, Union
 import copy
+from functools import lru_cache
 
 import numpy as np
 import kaldi_native_fbank as knf
@@ -45,7 +46,7 @@ class WavFrontend:
         self.cmvn_file = cmvn_file
 
         if self.cmvn_file:
-            self.cmvn = self.load_cmvn()
+            self.cmvn = load_cmvn(self.cmvn_file)
         self.fbank_fn = None
         self.fbank_beg_idx = 0
         self.reset_status()
@@ -122,33 +123,47 @@ class WavFrontend:
         inputs = (inputs + means) * vars
         return inputs
 
-    def load_cmvn(
-        self,
-    ) -> np.ndarray:
-        with open(self.cmvn_file, "r", encoding="utf-8") as f:
-            lines = f.readlines()
+@lru_cache()
+def load_cmvn(cmvn_file: Union[str, Path]) -> np.ndarray:
+    """load cmvn file to numpy array. 
 
-        means_list = []
-        vars_list = []
-        for i in range(len(lines)):
-            line_item = lines[i].split()
-            if line_item[0] == "<AddShift>":
-                line_item = lines[i + 1].split()
-                if line_item[0] == "<LearnRateCoef>":
-                    add_shift_line = line_item[3 : (len(line_item) - 1)]
-                    means_list = list(add_shift_line)
-                    continue
-            elif line_item[0] == "<Rescale>":
-                line_item = lines[i + 1].split()
-                if line_item[0] == "<LearnRateCoef>":
-                    rescale_line = line_item[3 : (len(line_item) - 1)]
-                    vars_list = list(rescale_line)
-                    continue
+    Args:
+        cmvn_file (Union[str, Path]): cmvn file path.
 
-        means = np.array(means_list).astype(np.float64)
-        vars = np.array(vars_list).astype(np.float64)
-        cmvn = np.array([means, vars])
-        return cmvn
+    Raises:
+        FileNotFoundError: cmvn file not exits.
+
+    Returns:
+        np.ndarray: cmvn array. shape is (2, dim).The first row is means, the second row is vars.
+    """
+
+    cmvn_file = Path(cmvn_file)
+    if not cmvn_file.exists():
+        raise FileNotFoundError("cmvn file not exits")
+    
+    with open(cmvn_file, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    means_list = []
+    vars_list = []
+    for i in range(len(lines)):
+        line_item = lines[i].split()
+        if line_item[0] == "<AddShift>":
+            line_item = lines[i + 1].split()
+            if line_item[0] == "<LearnRateCoef>":
+                add_shift_line = line_item[3 : (len(line_item) - 1)]
+                means_list = list(add_shift_line)
+                continue
+        elif line_item[0] == "<Rescale>":
+            line_item = lines[i + 1].split()
+            if line_item[0] == "<LearnRateCoef>":
+                rescale_line = line_item[3 : (len(line_item) - 1)]
+                vars_list = list(rescale_line)
+                continue
+
+    means = np.array(means_list).astype(np.float64)
+    vars = np.array(vars_list).astype(np.float64)
+    cmvn = np.array([means, vars])
+    return cmvn
 
 
 class WavFrontendOnline(WavFrontend):


### PR DESCRIPTION
与 #2519 一样的问题，Fsmn_vad_online在多线程调用时会出现数组越界的报错：
![image](https://github.com/user-attachments/assets/49d6a448-ddb8-4f8c-8ac5-7f51622f2028)

原因是共享了frontend和vad_scorer，通过在外部调用时单独保存实例的方式修复。

测试伪代码如下：
```
from funasr_onnx import Fsmn_vad_online
from joblib import Parallel, delayed

vad = Fsmn_vad_online("xxx")
audio = load_audio()
def test():
    segments = []
    chunks = audio.chunk(100)
    params = {}
    for chunk in chunks:
        params["is_final"] = chunk.is_last
        seg = vad(audio_in=chunk.waveform, param_dict=params)
        if seg:
            segments.append(seg)
    return segments

results = Parallel(n_jobs=2, backend="threading")(delayed(test)() for i in range(10))
```