### PR TITLE
Fix: 修复c++后端服务因为空数组的异常退出，以及c++的http服务在收到Ctrl+C信号后无法正常退出

### DIFF
--- a/runtime/http/bin/funasr-http-main.cpp
+++ b/runtime/http/bin/funasr-http-main.cpp
@@ -510,6 +510,7 @@ int main(int argc, char *argv[]) {
 
     s.run();
     LOG(INFO) << "http model loop " << s_port;
+    conn_guard.reset();
     // wait for theads
     for (auto &t : decoder_threads) {
       t.join();

--- a/runtime/onnxruntime/src/funasrruntime.cpp
+++ b/runtime/onnxruntime/src/funasrruntime.cpp
@@ -297,10 +297,12 @@
 			//timestamp
 			if(msg_vec.size() > 1){
 				std::vector<std::string> msg_stamp = funasr::split(msg_vec[1], ',');
-				for(int i=0; i<(int)msg_stamp.size()-1; i+=2){
-					float begin = std::stof(msg_stamp[i])+msg_stimes[idx];
-					float end = std::stof(msg_stamp[i+1])+msg_stimes[idx];
-					cur_stamp += "["+std::to_string((int)(1000*begin))+","+std::to_string((int)(1000*end))+"],";
+				if (msg_stamp.size() > 1) {
+					for(int i=0; i<msg_stamp.size()-1; i+=2){
+						float begin = std::stof(msg_stamp[i])+msg_stimes[idx];
+						float end = std::stof(msg_stamp[i+1])+msg_stimes[idx];
+						cur_stamp += "["+std::to_string((int)(1000*begin))+","+std::to_string((int)(1000*end))+"],";
+					}
 				}
 			}
 		}


### PR DESCRIPTION
1、添加msg_stamp是否为空的判断，在某些特定请求中，msg_stamp可能为空。避免msg_stamp为空时，直接对其进行取值操作，否则将引发segmentation fault，导致服务挂掉。
2、c++的http服务，在Ctrl+C让程序主动退出时，添加工作守卫的移除，确保在捕获Ctrl+C信号后，程序能正退退出。