### PR TITLE
docs(readme): update onnx example import path and cache location

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,11 +315,16 @@ res = model.export(quantize=False)
 ### Test ONNX
 ```python
 # pip3 install -U funasr-onnx
-from funasr_onnx import Paraformer
+from pathlib import Path
+from runtime.python.onnxruntime.funasr_onnx.paraformer_bin import Paraformer
+
+
+home_dir = Path.home()
+
 model_dir = "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
 model = Paraformer(model_dir, batch_size=1, quantize=True)
 
-wav_path = ['~/.cache/modelscope/hub/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/example/asr_example.wav']
+wav_path = [f"{home_dir}/.cache/modelscope/hub/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/example/asr_example.wav"]
 
 result = model(wav_path)
 print(result)

--- a/README_zh.md
+++ b/README_zh.md
@@ -315,11 +315,16 @@ res = model.export(quantize=False)
 ### 测试ONNX
 ```python
 # pip3 install -U funasr-onnx
-from funasr_onnx import Paraformer
+from pathlib import Path
+from runtime.python.onnxruntime.funasr_onnx.paraformer_bin import Paraformer
+
+
+home_dir = Path.home()
+
 model_dir = "damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch"
 model = Paraformer(model_dir, batch_size=1, quantize=True)
 
-wav_path = ['~/.cache/modelscope/hub/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/example/asr_example.wav']
+wav_path = [f"{home_dir}/.cache/modelscope/hub/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/example/asr_example.wav"]
 
 result = model(wav_path)
 print(result)


### PR DESCRIPTION
The example code in README files was updated to use the correct import path for Paraformer from the runtime package instead of the top-level module. The wav path was also modified to use Path.home() for cross-platform compatibility and to include the missing 'models' directory in the cache path. These changes ensure the examples work correctly with the current package structure.

#2605