### PR TITLE
fix: crash when using online mode with uninitialized jieba

### DIFF
--- a/runtime/onnxruntime/src/ct-transformer-online.cpp
+++ b/runtime/onnxruntime/src/ct-transformer-online.cpp
@@ -29,6 +29,7 @@ void CTTransformerOnline::InitPunc(const std::string &punc_model, const std::str
     GetOutputNames(m_session.get(), m_strOutputNames, m_szOutputNames);
 
 	m_tokenizer.OpenYaml(punc_config.c_str(), token_file.c_str());
+	m_tokenizer.JiebaInit(punc_config);
 }
 
 CTTransformerOnline::~CTTransformerOnline()


### PR DESCRIPTION
Problem:
- Crash occurs with [punc_ct-transformer_cn-en-common-vocab471067-large-onnx](https://www.modelscope.cn/models/iic/punc_ct-transformer_cn-en-common-vocab471067-large-onnx) model
- Root cause: jieba is enabled but not properly initialized

Solution:
- Add jieba initialization before usage