### PR TITLE
fix: support loading .pcm (16k 1c 16bit) audio files in load_utils.py…

### DIFF
--- a/funasr/utils/load_utils.py
+++ b/funasr/utils/load_utils.py
@@ -241,10 +241,19 @@ def _load_audio_ffmpeg(file: str, sr: int = 16000):
     # This launches a subprocess to decode audio while down-mixing
     # and resampling as necessary.  Requires the ffmpeg CLI in PATH.
     # fmt: off
+    pcm_params = []
+    if file.lower().endswith('.pcm'):
+        pcm_params = [
+            "-f", "s16le",
+            "-ar", str(sr),
+            "-ac", "1"
+        ]
+
     cmd = [
         "ffmpeg",
         "-nostdin",
         "-threads", "0",
+        *pcm_params,  # PCM files need input format specified before -i since PCM is raw data without headers
         "-i", file,
         "-f", "s16le",
         "-ac", "1",


### PR DESCRIPTION
… (#2667)

- Fix "Failed to load audio" error when recognizing .pcm audio files (16kHz, mono, 16bit)
- Ensure .pcm file support as described in issue #2667