### PR TITLE
Fix prefix concatenation in timestamp post-processing for sensevoice

### DIFF
--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -980,6 +980,7 @@ class SenseVoiceSmall(nn.Module):
                 words_new.append(word)
             elif prev_word is not None and prev_word.isalpha() and prev_word.isascii() and word.isalpha() and word.isascii():
                 prev_word += word
+                word = prev_word
                 timestamp_new[-1][1] = end
                 words_new[-1] = prev_word
             else:

--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -979,10 +979,9 @@ class SenseVoiceSmall(nn.Module):
                 timestamp_new.append([start, end])
                 words_new.append(word)
             elif prev_word is not None and prev_word.isalpha() and prev_word.isascii() and word.isalpha() and word.isascii():
-                prev_word += word
-                word = prev_word
+                word = prev_word + word
                 timestamp_new[-1][1] = end
-                words_new[-1] = prev_word
+                words_new[-1] = word
             else:
                 # timestamp_new[-1][0] += word
                 timestamp_new.append([start, end])


### PR DESCRIPTION
When there are more than two tokens in a word, there will be token splicing errors in the previous timestamp post-processing.

1. The sensevoice example test passed.
2. The audio test also passes for words consisting of three tokens, such as "language".