### PR TITLE
fix: correct the deepspeed_config path reference in the finetuning script

### DIFF
--- a/examples/industrial_data_pretraining/paraformer/finetune.sh
+++ b/examples/industrial_data_pretraining/paraformer/finetune.sh
@@ -41,7 +41,7 @@ scp2jsonl \
 output_dir="./outputs"
 log_file="${output_dir}/log.txt"
 
-deepspeed_config=${workspace}/../../ds_stage1.json
+deepspeed_config=${workspace}/../../deepspeed_conf/ds_stage1.json
 
 mkdir -p ${output_dir}
 echo "log_file: ${log_file}"


### PR DESCRIPTION
fix: correct deepspeed_config path reference error
Resolved incorrect path reference in DeepSpeed configuration
from:
- ${workspace}/../../ds_stage1.json
to:
+ ${workspace}/../../deepspeed_conf/ds_stage1.json
