### PR TITLE
fix: avoid IndexError by handling empty strings after event removal in rich transcription processing

### DIFF
--- a/funasr/utils/postprocess_utils.py
+++ b/funasr/utils/postprocess_utils.py
@@ -414,6 +414,8 @@ def rich_transcription_postprocess(s):
             continue
         if get_event(s_list[i]) == cur_ent_event and get_event(s_list[i]) != None:
             s_list[i] = s_list[i][1:]
+        if len(s_list[i]) == 0:
+            continue
         # else:
         cur_ent_event = get_event(s_list[i])
         if get_emo(s_list[i]) != None and get_emo(s_list[i]) == get_emo(new_s):


### PR DESCRIPTION
### Description:
Fix `IndexError` when processing empty strings after event removal in `rich_transcription_postprocess(s)`.

### Problem:
After removing the event character from `s_list[i]` when `get_event(s_list[i]) == cur_ent_event`, the string could become empty `''`. This empty string was then passed to `get_event(s)` function, which attempts to access `s[0]` causing an `IndexError: string index out of range.`

### Example:
When `rich_transcription_postprocess(s)` input:

> <|lang|><|EMO_UNKNOWN|><|Event_UNK|><|woitn|> <|lang|><|EMO_UNKNOWN|><|BGM|><|woitn|>语音内容1 <|lang|><|EMO_UNKNOWN|><|BGM|><|woitn|> <|lang|><|EMO_UNKNOWN|><|BGM|><|woitn|>语音内容2

When `for i in range(1, len(s_list))` meets `i==2`, `s_list[2]` is `'🎼'` (BGM event), after event removal: `s_list[2] = s_list[2][1:]`, s_list[2] becomes `''` and then is passed to `get_event(s[i])`, which causes `IndexError`.

### Solution:
Added string check after event removal.