### PR TITLE
Fix key extraction from JSON lines

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -60,7 +60,7 @@ def prepare_data_iterator(data_in, input_len=None, data_type=None, key=None):
                     if data_in.endswith(".jsonl"):  # file.jsonl: json.dumps({"source": data})
                         lines = json.loads(line.strip())
                         data = lines["source"]
-                        key = lines["key"] if "key" in lines else key
+                        key = lines.get("key", key)
                     else:  # filelist, wav.scp, text.txt: id \t data or data
                         lines = line.strip().split(maxsplit=1)
                         data = lines[1] if len(lines) > 1 else lines[0]


### PR DESCRIPTION
按照数据结构，key应当直接从lines中读取，而不是从data中读取，data仅仅是音频文件的路径