### PR TITLE
修复循环导入导致FunASRNano无法自动注册问题

### DIFF
--- a/funasr/models/fun_asr_nano/model.py
+++ b/funasr/models/fun_asr_nano/model.py
@@ -9,7 +9,6 @@ import traceback
 
 import torch
 import torch.nn as nn
-from funasr import AutoModel
 from funasr.metrics.compute_acc import compute_accuracy
 from funasr.register import tables
 from funasr.train_utils.device_funcs import force_gatherable, to_device
@@ -42,6 +41,7 @@ class FunASRNano(nn.Module):
             "activation_checkpoint", False
         )
         if hub == "ms":
+            from funasr import AutoModel
             model = AutoModel(model=audio_encoder, model_revision="master")
             audio_encoder_output_size = (
                 model.model.encoder_output_size


### PR DESCRIPTION
从funasr导入AutoModel时，其会自动导入注册的模块，但是此时fun_asr_nano 在模块级别又导入了AutoModel，形成循环导入，导致FunASRNano 模型注册失败，不能直接使用AutoModel加载。