### PR TITLE
when mode is 2pass and test audio is vad_example.wav, we should give …

### DIFF
--- a/runtime/python/websocket/funasr_wss_client.py
+++ b/runtime/python/websocket/funasr_wss_client.py
@@ -242,6 +242,8 @@ async def record_from_scp(chunk_begin, chunk_size):
         while not offline_msg_done:
             await asyncio.sleep(1)
 
+    await asyncio.sleep(10)
+
     await websocket.close()
 
 


### PR DESCRIPTION
when mode is 2pass and test audio is vad_example.wav, we should give more time to websocket connection to recv message, or funasr_wss_client.py's websocket.recv() will cause exception occasionally because connection has been closed.