### PR TITLE
修复流式识别中prev_samples截取bug

### DIFF
--- a/funasr/models/fsmn_vad_streaming/model.py
+++ b/funasr/models/fsmn_vad_streaming/model.py
@@ -724,7 +724,7 @@ class FsmnVADStreaming(nn.Module):
             if len(segments_i) > 0:
                 segments.extend(*segments_i)
 
-        cache["prev_samples"] = audio_sample[:-m]
+        cache["prev_samples"] = audio_sample[-m:] if m > 0 else torch.empty(0)
         if _is_final:
             self.init_cache(cache)
 

--- a/funasr/models/paraformer_streaming/model.py
+++ b/funasr/models/paraformer_streaming/model.py
@@ -642,7 +642,7 @@ class ParaformerStreaming(Paraformer):
         result_i = {"key": key[0], "text": text_postprocessed}
         result = [result_i]
 
-        cache["prev_samples"] = audio_sample[:-m]
+        cache["prev_samples"] = audio_sample[-m:] if m > 0 else torch.empty(0)
         if _is_final:
             self.init_cache(cache, **kwargs)
 

--- a/funasr/models/scama/model.py
+++ b/funasr/models/scama/model.py
@@ -637,7 +637,7 @@ class SCAMA(nn.Module):
         cache["decoder"] = cache_decoder
         cache["frontend"] = {}
 
-        cache["prev_samples"] = torch.empty(0).to(device=device)
+        cache["prev_samples"] = torch.empty(0)
 
         return cache
 
@@ -726,7 +726,7 @@ class SCAMA(nn.Module):
         result_i = {"key": key[0], "text": text_postprocessed}
         result = [result_i]
 
-        cache["prev_samples"] = audio_sample[:-m]
+        cache["prev_samples"] = audio_sample[-m:] if m > 0 else torch.empty(0)
         if _is_final:
             self.init_cache(cache, **kwargs)
 


### PR DESCRIPTION
1、剩余的帧应该是audio_sample[-m:]或者torch.empty(0)
2、另外关于scama的init_cache部分代码，audio_sample_list = load_audio_text_image_video(...)返回的数据应该是在cpu上的tensor，如果cache["prev_samples"] 初始化的时候指定其他device，会导致torch.cat((cache["prev_samples"], audio_sample_list[0]))异常