### PR TITLE
Fix #2809: [Performance Regression] funasr 1.3.1 offline(vad+asr) laten

### DIFF
--- a/funasr/models/fsmn_vad_streaming/model.py
+++ b/funasr/models/fsmn_vad_streaming/model.py
@@ -348,7 +348,7 @@ class FsmnVADStreaming(nn.Module):
 
 
     def ComputeScores(self, feats: torch.Tensor, cache: dict = {}) -> None:
-        scores = self.encoder(feats, cache=cache["encoder"]).to("cpu")  # return B * T * D
+        scores = self.encoder(feats, cache=cache["encoder"])  # return B * T * D
         assert (
             scores.shape[1] == feats.shape[1]
         ), "The shape between feats and scores does not match"


### PR DESCRIPTION
Fixes #2809

## Summary
This PR addresses: [Performance Regression] funasr 1.3.1 offline(vad+asr) latency is ~10x slower than 1.3.0 on RTX 4080/4090

## Changes
```
funasr/models/fsmn_vad_streaming/model.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*