### PR TITLE
Fix #2806: NameError: name 'ClusterBackend' is not defined

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -40,11 +40,12 @@ def _resolve_ncpu(config, fallback=4):
         value = fallback
     return max(value, 1)
 
+sv_chunk = postprocess = distribute_spk = ClusterBackend = None
 try:
     from funasr.models.campplus.utils import sv_chunk, postprocess, distribute_spk
     from funasr.models.campplus.cluster_backend import ClusterBackend
-except:
-    pass
+except Exception as e:
+    logging.warning(f"Failed to import speaker-related modules: {e}. Speaker diarization will be unavailable.")
 
 
 def prepare_data_iterator(data_in, input_len=None, data_type=None, key=None):
@@ -169,6 +170,12 @@ class AutoModel:
             spk_kwargs["device"] = kwargs["device"]
             spk_kwargs.setdefault("ncpu", kwargs.get("ncpu", 4))
             spk_model, spk_kwargs = self.build_model(**spk_kwargs)
+            if ClusterBackend is None:
+                raise ImportError(
+                    "ClusterBackend is not available. This is likely because required dependencies "
+                    "(e.g. scikit-learn with HDBSCAN support, scipy) failed to import. "
+                    "Please ensure scikit-learn>=1.3.0 and scipy are properly installed."
+                )
             self.cb_model = ClusterBackend(**cb_kwargs).to(kwargs["device"])
             spk_mode = kwargs.get("spk_mode", "punc_segment")
             if spk_mode not in ["default", "vad_segment", "punc_segment"]:


### PR DESCRIPTION
Fixes #2806

## Summary
This PR addresses: NameError: name 'ClusterBackend' is not defined

## Changes
```
funasr/auto/auto_model.py | 11 +++++++++--
 1 file changed, 9 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*