### PR TITLE
Fix #2787: model.generate时，传入的是音频字节流，会对采样率校验耗时200ms。

### DIFF
--- a/funasr/utils/load_utils.py
+++ b/funasr/utils/load_utils.py
@@ -166,6 +166,9 @@ def _is_audio_container(data: bytes) -> bool:
     # MP4 / M4A / AAC  – 'ftyp' box at offset 4
     if len(data) >= 8 and data[4:8] == b"ftyp":
         return True
+    # WebM / MKV
+    if data[:4] == b"\x1a\x45\xdf\xa3":
+        return True
     return False
 
 
@@ -177,7 +180,7 @@ def load_bytes(input):
     if _is_audio_container(input):
         try:
             input = validate_frame_rate(input)
-        except:
+        except Exception:
             pass
     middle_data = np.frombuffer(input, dtype=np.int16)
     middle_data = np.asarray(middle_data)


### PR DESCRIPTION
Fixes #2787

## Summary
This PR addresses: model.generate时，传入的是音频字节流，会对采样率校验耗时200ms。

## Changes
```
funasr/utils/load_utils.py | 40 +++++++++++++++++++++++++++++++++++-----
 1 file changed, 35 insertions(+), 5 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*