### PR TITLE
Fix #2782: SenseVoice output_timestamp=True,  # 必须显式打开再用vad模型报错

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -555,8 +555,8 @@ class AutoModel:
                         if k not in result:
                             result[k] = []
                         for t in restored_data[j][k]:
-                            t[0] += vadsegments[j][0]
-                            t[1] += vadsegments[j][0]
+                            t[0] = int(t[0]) + int(vadsegments[j][0])
+                            t[1] = int(t[1]) + int(vadsegments[j][0])
                         result[k].extend(restored_data[j][k])
                     elif k == "spk_embedding":
                         if k not in result:


### PR DESCRIPTION
Fixes #2782

## Summary
This PR addresses: SenseVoice output_timestamp=True,  # 必须显式打开再用vad模型报错

## Changes
```
funasr/auto/auto_model.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*