### PR TITLE
fix: check all speaker diarization imports to prevent silent failures

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -46,11 +46,19 @@ def _resolve_ncpu(config, fallback=4):
         value = fallback
     return max(value, 1)
 
+sv_chunk = None
+postprocess = None
+distribute_spk = None
+ClusterBackend = None
 try:
     from funasr.models.campplus.utils import sv_chunk, postprocess, distribute_spk
     from funasr.models.campplus.cluster_backend import ClusterBackend
-except:
-    pass
+except Exception as e:
+    import logging
+    logging.warning(
+        f"Speaker diarization modules could not be imported: {e}. "
+        "Speaker diarization functionality will be unavailable."
+    )
 
 
 def prepare_data_iterator(data_in, input_len=None, data_type=None, key=None):
@@ -175,6 +183,11 @@ class AutoModel:
             spk_kwargs["device"] = kwargs["device"]
             spk_kwargs.setdefault("ncpu", kwargs.get("ncpu", 4))
             spk_model, spk_kwargs = self.build_model(**spk_kwargs)
+            if any(x is None for x in (sv_chunk, postprocess, distribute_spk, ClusterBackend)):
+                raise ImportError(
+                    "Speaker diarization dependencies failed to import. "
+                    "Please ensure scikit-learn>=1.3.0 and scipy are properly installed."
+                )
             self.cb_model = ClusterBackend(**cb_kwargs).to(kwargs["device"])
             spk_mode = kwargs.get("spk_mode", "punc_segment")
             if spk_mode not in ["default", "vad_segment", "punc_segment"]:

--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -54,7 +54,6 @@ try:
     from funasr.models.campplus.utils import sv_chunk, postprocess, distribute_spk
     from funasr.models.campplus.cluster_backend import ClusterBackend
 except Exception as e:
-    import logging
     logging.warning(
         f"Speaker diarization modules could not be imported: {e}. "
         "Speaker diarization functionality will be unavailable."


### PR DESCRIPTION
## Summary

PR #2818 correctly fixes the NameError for ClusterBackend but as flagged 
in its Gemini code review, sv_chunk, postprocess and distribute_spk 
could also be None if imports fail — causing a cryptic TypeError later.

## Changes
- Initialize all 4 speaker diarization variables to None before try block
- Replace bare `except: pass` with `except Exception as e` + warning log
- Check all 4 variables together at usage site with a clear ImportError

## Related
Fixes #2806
Related to #2818