### PR TITLE
fix(kws): fix off-by-one error in is_sublist boundary

### DIFF
--- a/funasr/utils/kws_utils.py
+++ b/funasr/utils/kws_utils.py
@@ -224,7 +224,7 @@ class KwsCtcPrefixDecoder():
         if len(main_list) == len(check_list):
             return 0 if main_list == check_list else -1
 
-        for i in range(len(main_list) - len(check_list)):
+        for i in range(len(main_list) - len(check_list) + 1):
             if main_list[i] == check_list[0]:
                 for j in range(len(check_list)):
                     if main_list[i + j] != check_list[j]:


### PR DESCRIPTION
在 Python 中，range(n) 不包含 n。
如果 len(main_list) - len(check_list) = k，循环只检查到索引 k-1，从而跳过了最后一个可能的起始位置 k。
Example:
prefix_ids: (353, 353, 1722) (len=3)
lab: (353, 1722) (len=2)
range(3 - 2) -> range(1) -> only checks i=0.
It misses the match at i=1.