### PR TITLE
Improve HuggingfaceTokenizer import error message

### DIFF
--- a/funasr/tokenizer/hf_tokenizer.py
+++ b/funasr/tokenizer/hf_tokenizer.py
@@ -5,9 +5,12 @@ from funasr.register import tables
 def HuggingfaceTokenizer(init_param_path, **kwargs):
     try:
         from transformers import AutoTokenizer
-    except:
-        # print("If you want to use hugging, please `pip install -U transformers`")
-        pass
+    except Exception as e:
+        raise ImportError(
+            "HuggingfaceTokenizer requires 'transformers'. "
+            "Please install it with: pip install -U transformers"
+        ) from e
+
     tokenizer = AutoTokenizer.from_pretrained(init_param_path)
 
     return tokenizer


### PR DESCRIPTION
**English: (I used gemini to translate. I hope there's no significant change in meaning.)**

## What
Improve the error message when `transformers` is missing in `HuggingfaceTokenizer` (tokenizer/hf_tokenizer.py).

## Why
This PR replaces a silent pass on import failures with a clear ImportError. This prevents users from having to check the source code to identify a missing transformers dependency and provides them with direct installation instructions.

## Changes
- Raise an `ImportError` with installation instructions instead of allowing a `NameError` to occur later when transformers is not installed.

---

**中文:**

## What
改善當 `HuggingfaceTokenizer` 找不到 `transformers` 時的錯誤訊息。 (tokenizer/hf_tokenizer.py)

## Why
原本當匯入失敗時，會被 pass，並且沒有任何其他的訊息，對於不熟悉的使用者可能需要再去查看源碼才能知道自己缺少 `transformers`。
這個 PR 可以讓他變為 raise 清晰的 ImportError，並告知使用者需下載 `transformers`。

## Changes
- 當transformers未安裝時，raise一個有 install instructions 的 ImportError，而非導致後面出錯時報出的NameError。