### PR TITLE
Fix: prevent model graph and kwargs mutation in AutoModel.export() /修复 AutoModel 连续导出导致的计算图破坏与字典污染Fixes a critical destructive bug in `AutoModel.export()`.

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -715,8 +715,6 @@ class AutoModel:
         :return:
         """
 
-        import copy
-
         device = cfg.get("device", "cpu")
         
         # 对模型进行深拷贝，隔离 ONNX 算子替换（Monkey-patching）对原模型的破坏

--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -715,12 +715,26 @@ class AutoModel:
         :return:
         """
 
+        import copy
+
         device = cfg.get("device", "cpu")
-        model = self.model.to(device=device)
-        kwargs = self.kwargs
+        
+        # 对模型进行深拷贝，隔离 ONNX 算子替换（Monkey-patching）对原模型的破坏
+        # Implement deep copy of the model to isolate ONNX operator monkey-patching 
+        # and prevent corruption of the original model
+        model = copy.deepcopy(self.model).to(device=device)
+        
+        # 对配置参数进行深拷贝，隔离 deep_update 和 del 的引用污染
+        # Implement deep copy of configuration parameters to isolate reference pollution caused by deep_update and del.
+        kwargs = copy.deepcopy(self.kwargs)
+        
         deep_update(kwargs, cfg)
         kwargs["device"] = device
-        del kwargs["model"]
+        
+        # Safely delete keys that may cause issues during export
+        if "model" in kwargs:
+            del kwargs["model"]
+            
         model.eval()
 
         type = kwargs.get("type", "onnx")
@@ -730,6 +744,9 @@ class AutoModel:
         )
 
         with torch.no_grad():
+            # 这里的导出操作只会魔改 model 副本，原实例的 self.model 依然是纯洁的 PyTorch 图
+            # This export operation only mutates the model copy; 
+            # the original self.model instance remains an intact PyTorch graph.
             export_dir = export_utils.export(model=model, data_in=data_list, **kwargs)
 
         return export_dir


### PR DESCRIPTION
Fixes a critical destructive bug in `AutoModel.export()`. Previously, calling `export()` modified both `self.model` (by in-place replacing layers with ONNX-specific modules like `SANMEncoderExport`) and `self.kwargs`. This caused consecutive `export()` calls (e.g., exporting FP32 then Int8) to crash with either `KeyError: 'model'` or `AttributeError: 'SANMEncoderExport' object has no attribute 'encoders'`.
Implemented a dual deepcopy strategy:
1. `model = copy.deepcopy(self.model)`: Isolates the graph mutation, ensuring the original PyTorch model remains untouched.
2. `kwargs = copy.deepcopy(self.kwargs)`: Prevents parameter reference pollution.


修复了 `AutoModel.export()` 中破坏性的 Bug。原逻辑在导出时会就地（in-place）修改 `self.model` 的计算图（替换为 `SANMEncoderExport` 等 ONNX 算子）并污染 `self.kwargs`。这导致同一脚本连续调用 `export()` 时必定崩溃，抛出 `KeyError` 或 `AttributeError`。
 采用了双重深拷贝策略：
1. `model = copy.deepcopy(self.model)`：对模型进行深拷贝，隔离 ONNX 算子替换对原计算图的物理破坏。
2. `kwargs = copy.deepcopy(self.kwargs)`：深拷贝配置字典，防止引用污染。

Reproduction bug/ 复现bug

```python
from funasr import AutoModel
model = AutoModel(model="paraformer-zh", device="cpu")
model.export(quantize=False) # Mutates self.model and self.kwargs
model.export(quantize=True)  # Crashes without this PR
```