### PR TITLE
fix(qwen3): stop masking dependency ImportErrors during model init

### DIFF
--- a/funasr/models/qwen3_asr/model.py
+++ b/funasr/models/qwen3_asr/model.py
@@ -53,10 +53,13 @@ class Qwen3ASR(nn.Module):
 
         try:
             from qwen_asr import Qwen3ASRModel
-        except ImportError:
-            raise ImportError(
-                "qwen-asr package is required. Install with: pip install qwen-asr"
-            )
+        except ImportError as e:
+            # Only catch if the package itself is missing, not if its dependencies are broken
+            if "qwen_asr" in str(e):
+                raise ImportError(
+                    "qwen-asr package is required. Install with: pip install qwen-asr"
+                ) from e
+            raise e
 
         torch_dtype = self._dtype_map.get(dtype, torch.bfloat16)
         fa_kwargs = None


### PR DESCRIPTION
### Description
This PR fixes a critical usability issue where `FunASR` masks legitimate dependency conflicts (like the `transformers` vs `huggingface-hub` version deadlock) when initializing the Qwen3-ASR model.

### The Problem
The current implementation uses a generic `try...except ImportError` block:
```python
try:
    from qwen_asr import Qwen3ASRModel
except ImportError:
    raise ImportError("qwen-asr package is required...")
```
If `qwen-asr` is installed but one of its dependencies (like `transformers`) fails to import due to a version conflict, `FunASR` wrongly reports that the `qwen-asr` package itself is missing. This leads to a "dependency deadlock" where users are prompted to install a package they already have, while the real error (e.g., `ImportError: huggingface-hub>=0.34.0,<1.0 is required... but found 1.16.1`) is hidden.

### The Fix
The import block is updated to specifically check if `qwen_asr` is the missing module. If a different module caused the `ImportError`, the original exception is reraised, allowing for transparent debugging of environment issues.

### Verification
Verified by simulating a `transformers`/`huggingface-hub` mismatch. With this patch, the user correctly sees the underlying version conflict instead of a misleading "package required" message.