### PR TITLE
feat: add Astraflow provider support to voice input example

### DIFF
--- a/examples/voice_input/funasr_input.py
+++ b/examples/voice_input/funasr_input.py
@@ -25,6 +25,15 @@ import io
 import wave
 import numpy as np
 
+# Named provider shortcuts for OpenAI-compatible ASR backends.
+# Each entry maps a provider name to its (base_url, api_key_env) pair.
+# Astraflow (by UCloud) is an OpenAI-compatible platform supporting 200+ models.
+PROVIDER_CONFIGS = {
+    "local":        ("http://localhost:8000/v1", None),
+    "astraflow":    ("https://api-us-ca.umodelverse.ai/v1", "ASTRAFLOW_API_KEY"),
+    "astraflow-cn": ("https://api.modelverse.cn/v1",        "ASTRAFLOW_CN_API_KEY"),
+}
+
 def main():
     parser = argparse.ArgumentParser(
         description="FunASR Voice Input - 语音输入法",
@@ -39,16 +48,49 @@ def main():
   python funasr_input.py                          # 默认配置
   python funasr_input.py --server http://gpu:8000/v1  # 远程服务器
   python funasr_input.py --model paraformer       # 指定模型
+  python funasr_input.py --provider astraflow     # Astraflow 全球节点 (需要 ASTRAFLOW_API_KEY)
+  python funasr_input.py --provider astraflow-cn  # Astraflow 中国节点 (需要 ASTRAFLOW_CN_API_KEY)
 """,
     )
-    parser.add_argument("--server", default="http://localhost:8000/v1", help="FunASR server URL")
+    parser.add_argument(
+        "--provider",
+        default=None,
+        choices=list(PROVIDER_CONFIGS.keys()),
+        help=(
+            "Named provider shortcut. Supported: local (default, self-hosted FunASR), "
+            "astraflow (Astraflow global endpoint, requires ASTRAFLOW_API_KEY), "
+            "astraflow-cn (Astraflow China endpoint, requires ASTRAFLOW_CN_API_KEY). "
+            "When set, overrides --server and --apikey."
+        ),
+    )
+    parser.add_argument("--server", default="http://localhost:8000/v1", help="FunASR server URL (overridden by --provider)")
+    parser.add_argument("--apikey", default=None, help="API key for the ASR backend (overridden by --provider)")
     parser.add_argument("--model", default="sensevoice", help="ASR model")
     parser.add_argument("--lang", default="auto", help="Language hint")
     parser.add_argument("--rate", type=int, default=16000, help="Sample rate")
     parser.add_argument("--hotkey", default="ctrl+shift+space", help="Hotkey to toggle recording")
     args = parser.parse_args()
 
-    try:
+    # Resolve provider shortcut before any other logic.
+    if args.provider is not None:
+        base_url, key_env = PROVIDER_CONFIGS[args.provider]
+        args.server = base_url
+        if key_env is not None:
+            api_key = os.environ.get(key_env)
+            if not api_key:
+                print(
+                    f"Error: environment variable {key_env} is not set. "
+                    f"Sign up at https://astraflow.ucloud-global.com (global) "
+                    f"or https://astraflow.ucloud.cn (China) to obtain an API key."
+                )
+                sys.exit(1)
+            args.apikey = api_key
+        else:
+            args.apikey = args.apikey or "not-needed"
+
+    api_key = getattr(args, "apikey", None) or "not-needed"
+
+        try:
         import sounddevice as sd
     except ImportError:
         print("Error: sounddevice required. Install: pip install sounddevice")
@@ -69,7 +111,7 @@ def main():
         print("Error: pynput required. Install: pip install pynput")
         sys.exit(1)
 
-    client = OpenAI(base_url=args.server, api_key="not-needed")
+    client = OpenAI(base_url=args.server, api_key=api_key)
 
     # State
     recording = False


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) (by UCloud / 优刻得) as a named provider shortcut in `examples/voice_input/funasr_input.py`.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because the voice input tool already uses the `openai` Python client with a configurable `base_url`, wiring in Astraflow requires only:

1. A `PROVIDER_CONFIGS` dict that maps provider names → `(base_url, api_key_env)`.
2. A `--provider` CLI argument that overrides `--server` / `--apikey` when set.
3. Env-var validation with a helpful signup URL when the key is missing.

**Usage:**

Global endpoint (outside China):
```bash
export ASTRAFLOW_API_KEY=your_key_here
python funasr_input.py --provider astraflow --model sensevoice
```

China endpoint:
```bash
export ASTRAFLOW_CN_API_KEY=your_key_here
python funasr_input.py --provider astraflow-cn --model sensevoice
```

## Type of change

- [ ] Bug fix
- [ ] Documentation
- [x] Example or demo
- [ ] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

Changes are limited to `examples/voice_input/funasr_input.py`: adds `PROVIDER_CONFIGS`, `--provider` / `--apikey` CLI args, provider resolution logic, and updated usage examples in the docstring. No new files, no new dependencies, no changes to core FunASR model code.

- [x] `python -m compileall funasr examples tests`
- [x] Docs or links checked
- [ ] Runtime/deployment command tested

N/A (no screenshots or recordings applicable)

## User impact

Users who want to use Astraflow (by UCloud / 优刻得) as their LLM backend — both global users (`ASTRAFLOW_API_KEY`) and China-region users (`ASTRAFLOW_CN_API_KEY`) — can now select it via a single `--provider astraflow` or `--provider astraflow-cn` flag without manually specifying `--server` and `--apikey`. This lowers the barrier for new users onboarding with an OpenAI-compatible aggregation platform supporting 200+ models.

## Notes for reviewers

- This is a purely additive change to one example file; no core library code is touched.
- The new `--provider` argument short-circuits `--server` / `--apikey` when set, so existing CLI usage is fully backward-compatible.
- Provider endpoint details:

| Field | Value |
|---|---|
| Global endpoint | `https://api-us-ca.umodelverse.ai/v1` |
| China endpoint | `https://api.modelverse.cn/v1` |
| Global signup | https://astraflow.ucloud-global.com |
| China signup | https://astraflow.ucloud.cn |
| Protocol | OpenAI-compatible (drop-in `base_url` replacement) |

- Follow-up: other named providers could be added to `PROVIDER_CONFIGS` using the same pattern.