### PR TITLE
docs: add GitHub Pages use cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,11 @@ curl http://localhost:8000/v1/audio/transcriptions \
             <h2 class="section-title">Documentation</h2>
             <p class="section-subtitle">Start with examples, tune on your own data, extend the registry, or jump into source-linked API docs.</p>
             <div class="doc-grid">
+                <a class="doc-card" href="use-cases.html">
+                    <span class="doc-kicker">Choose</span>
+                    <h3>Use Cases</h3>
+                    <p>Find the fastest path for private APIs, agents, streaming, vLLM, subtitles, batch jobs, and benchmarks.</p>
+                </a>
                 <a class="doc-card" href="tutorial.html">
                     <span class="doc-kicker">Learn</span>
                     <h3>Tutorial</h3>
@@ -303,6 +308,7 @@ for sent in res[0]["sentence_info"]:
         <p>
             <a href="https://github.com/modelscope/FunASR">GitHub</a> &middot;
             <a href="training.html">Training</a> &middot;
+            <a href="use-cases.html">Use Cases</a> &middot;
             <a href="api.html">API</a> &middot;
             <a href="vllm.html">vLLM</a> &middot;
             <a href="agent.html">Agent</a> &middot;

--- a/use-cases.html
+++ b/use-cases.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Choose the right FunASR path for private speech APIs, agent voice input, streaming ASR, vLLM acceleration, subtitles, batch transcription, and benchmarks.">
+<meta property="og:title" content="FunASR Use Cases">
+<meta property="og:description" content="A practical route map for deploying FunASR in products, agents, streaming services, and benchmark-driven migrations.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/use-cases.html">
+<title>FunASR Use Cases</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">Home</a><a href="tutorial.html">Tutorial</a><a href="training.html">Training</a><a href="model-registration.html">Develop</a><a href="api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">English</button><div class="lang-menu"><a href="use-cases.html" class="current">English</a><a href="zh/use-cases.html">中文</a><a href="ja/index.html">日本語</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>Use Cases</h1>
+<p>Pick the shortest path from evaluation to production. FunASR covers local transcription, private OpenAI-compatible APIs, agent voice input, streaming services, vLLM acceleration, subtitles, and batch processing.</p>
+<div class="toc-grid"><a href="#paths">Choose a path</a><a href="#recipes">Production recipes</a><a href="#models">Model hints</a><a href="#share">Share results</a></div>
+<section id="paths"><h2>Choose the right path</h2>
+<table><tr><th>Goal</th><th>Start here</th><th>Why it matters</th></tr>
+<tr><td>Transcribe one file locally</td><td><a href="tutorial.html">Tutorial</a></td><td>Verify install and model download in minutes.</td></tr>
+<tr><td>Compare accuracy and speed</td><td><a href="benchmark.html">Benchmark report</a></td><td>Review long-audio speed and CER before choosing a model.</td></tr>
+<tr><td>Build a private speech API</td><td><a href="agent.html#server">OpenAI-compatible API</a></td><td>Reuse OpenAI-style clients without sending audio to a cloud ASR provider.</td></tr>
+<tr><td>Add speech input to agents</td><td><a href="agent.html#mcp">MCP server</a></td><td>Connect local ASR to Claude, Cursor, desktop tools, and internal assistants.</td></tr>
+<tr><td>Serve streaming ASR</td><td><a href="tutorial.html#real-time-speech-recognition">Realtime examples</a></td><td>Handle live captioning, meetings, and call-center style workloads.</td></tr>
+<tr><td>Accelerate LLM-based ASR</td><td><a href="vllm.html">vLLM guide</a></td><td>Use tensor parallel decoding and streaming service support for Fun-ASR-Nano.</td></tr>
+<tr><td>Generate subtitles</td><td><a href="agent.html#subtitle">Subtitle generator</a></td><td>Create SRT/VTT files from audio or video, with speaker labels when needed.</td></tr>
+<tr><td>Process many recordings</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">Batch ASR example</a></td><td>Build repeatable offline jobs for archives, meetings, and datasets.</td></tr></table>
+</section>
+<section id="recipes"><h2>Production recipes</h2>
+<div class="grid-2"><div class="card"><h3>Private transcription API</h3><p>Use this path when an application already speaks OpenAI-style APIs or when audio cannot leave your environment.</p><pre><code>pip install funasr fastapi uvicorn python-multipart
+funasr-server --model sensevoice --device cuda
+
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@sample.wav \
+  -F model=sensevoice \
+  -F response_format=verbose_json</code></pre></div>
+<div class="card"><h3>Agent speech input</h3><p>Start from the MCP server when you want to talk to coding agents, internal assistants, or workflow tools.</p><pre><code>pip install funasr
+python examples/mcp_server/funasr_mcp.py
+
+# Set FUNASR_DEVICE=cuda for GPU inference</code></pre></div></div>
+<div class="grid-2"><div class="card"><h3>Streaming workloads</h3><p>Pair ASR with VAD, punctuation, and speaker diarization when partial transcripts need to be readable by humans.</p><p>Validate with real audio: background noise, long silence, overlapping speakers, and different microphone quality.</p></div>
+<div class="card"><h3>Benchmark before migration</h3><p>Compare FunASR against Whisper or cloud ASR using your own sample set. Track throughput, CPU viability, download size, and deployment complexity together.</p><p><a href="benchmark.html">Open the public benchmark report</a></p></div></div>
+</section>
+<section id="models"><h2>Model selection hints</h2>
+<table><tr><th>Need</th><th>Good first choice</th><th>Notes</th></tr>
+<tr><td>Fast multilingual transcription</td><td>SenseVoice-Small</td><td>Strong default for local demos and private APIs.</td></tr>
+<tr><td>Mandarin production ASR</td><td>Paraformer-Large</td><td>Mature choice for Chinese speech recognition.</td></tr>
+<tr><td>LLM-based ASR experiments</td><td>Fun-ASR-Nano</td><td>Pair with <a href="vllm.html">vLLM</a> when throughput matters.</td></tr>
+<tr><td>Speaker-aware transcripts</td><td>SenseVoice or Paraformer with <code>spk_model="cam++"</code></td><td>Useful for meetings, interviews, and customer calls.</td></tr>
+<tr><td>Live audio</td><td>Runtime WebSocket service</td><td>Validate chunking, VAD, and endpointing with real traffic.</td></tr></table>
+</section>
+<section id="share"><h2>Share your result</h2>
+<p>If FunASR works well in your project, share the use case, model, device, processing speed, audio domain, and a public demo or benchmark summary when possible.</p>
+<p><a href="https://github.com/modelscope/FunASR/issues">Open an issue</a> or <a href="https://github.com/modelscope/FunASR/discussions">start a discussion</a>. Concrete usage reports help new users choose the right path and help maintainers prioritize docs and examples.</p>
+</section>
+</div></div>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -122,6 +122,11 @@ curl http://localhost:8000/v1/audio/transcriptions \
             <h2 class="section-title">文档中心</h2>
             <p class="section-subtitle">从示例开始，在自己的数据上微调，扩展模型注册表，或查阅带源码链接的 API 文档。</p>
             <div class="doc-grid">
+                <a class="doc-card" href="use-cases.html">
+                    <span class="doc-kicker">选型</span>
+                    <h3>场景速览</h3>
+                    <p>快速找到私有 API、Agent、流式、vLLM、字幕、批处理和评测的最佳入口。</p>
+                </a>
                 <a class="doc-card" href="tutorial.html">
                     <span class="doc-kicker">学习</span>
                     <h3>使用教程</h3>
@@ -303,6 +308,7 @@ for sent in res[0]["sentence_info"]:
         <p>
             <a href="https://github.com/modelscope/FunASR">GitHub</a> &middot;
             <a href="training.html">训练</a> &middot;
+            <a href="use-cases.html">场景速览</a> &middot;
             <a href="../api.html">API</a> &middot;
             <a href="vllm.html">vLLM</a> &middot;
             <a href="agent.html">Agent</a> &middot;

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="FunASR 场景速览：私有语音 API、Agent 语音输入、流式 ASR、vLLM 加速、字幕、批处理和性能评测的快速入口。">
+<meta property="og:title" content="FunASR 场景速览">
+<meta property="og:description" content="面向评测、部署、Agent、流式服务和生产迁移的 FunASR 路径图。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/use-cases.html">
+<title>FunASR 场景速览</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">首页</a><a href="tutorial.html">教程</a><a href="training.html">训练</a><a href="model-registration.html">开发</a><a href="../api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">中文</button><div class="lang-menu"><a href="../use-cases.html">English</a><a href="use-cases.html" class="current">中文</a><a href="../ja/index.html">日本語</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>场景速览</h1>
+<p>从评测到生产，选择最短路径。FunASR 覆盖本地转写、私有 OpenAI 兼容 API、Agent 语音输入、流式服务、vLLM 加速、字幕生成和批处理。</p>
+<div class="toc-grid"><a href="#paths">选择路径</a><a href="#recipes">生产配方</a><a href="#models">模型建议</a><a href="#share">分享结果</a></div>
+<section id="paths"><h2>选择合适路径</h2>
+<table><tr><th>目标</th><th>从这里开始</th><th>为什么重要</th></tr>
+<tr><td>本地转写一个文件</td><td><a href="tutorial.html">使用教程</a></td><td>几分钟内验证安装、模型下载和首次推理。</td></tr>
+<tr><td>对比准确率和速度</td><td><a href="benchmark.html">性能评测报告</a></td><td>选型前查看长音频速度和 CER。</td></tr>
+<tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a></td><td>复用 OpenAI 风格客户端，音频不出内网。</td></tr>
+<tr><td>给 Agent 增加语音输入</td><td><a href="agent.html#mcp">MCP 服务</a></td><td>将本地 ASR 接入 Claude、Cursor、桌面工具和内部助手。</td></tr>
+<tr><td>部署流式 ASR</td><td><a href="tutorial.html#real-time-speech-recognition">实时示例</a></td><td>面向实时字幕、会议和客服类低延迟场景。</td></tr>
+<tr><td>加速 LLM-based ASR</td><td><a href="vllm.html">vLLM 指南</a></td><td>为 Fun-ASR-Nano 使用 tensor parallel 解码和流式服务能力。</td></tr>
+<tr><td>生成字幕</td><td><a href="agent.html#subtitle">字幕生成器</a></td><td>将音频或视频生成 SRT/VTT，需要时添加说话人标签。</td></tr>
+<tr><td>批量处理录音</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">批处理示例</a></td><td>为录音归档、会议纪要和数据集处理搭建可重复流水线。</td></tr></table>
+</section>
+<section id="recipes"><h2>面向生产的配方</h2>
+<div class="grid-2"><div class="card"><h3>私有转写 API</h3><p>当应用已经兼容 OpenAI 风格接口，或音频不能离开私有环境时，优先使用这个路径。</p><pre><code>pip install funasr fastapi uvicorn python-multipart
+funasr-server --model sensevoice --device cuda
+
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@sample.wav \
+  -F model=sensevoice \
+  -F response_format=verbose_json</code></pre></div>
+<div class="card"><h3>Agent 语音输入</h3><p>当你想把语音输入接到编码助手、内部助手或工作流工具时，可以从 MCP 服务开始。</p><pre><code>pip install funasr
+python examples/mcp_server/funasr_mcp.py
+
+# 设置 FUNASR_DEVICE=cuda 使用 GPU 推理</code></pre></div></div>
+<div class="grid-2"><div class="card"><h3>流式与客服场景</h3><p>需要给人阅读时，把 ASR 与 VAD、标点恢复、说话人分离一起使用。</p><p>用真实音频验证：背景噪声、长静音、多人重叠、不同麦克风质量。</p></div>
+<div class="card"><h3>迁移前先评测</h3><p>评估是否替代 Whisper 或云端 ASR 时，用自己的样本集同时记录吞吐、CPU 可用性、下载体积和部署复杂度。</p><p><a href="benchmark.html">打开公开评测报告</a></p></div></div>
+</section>
+<section id="models"><h2>模型选择建议</h2>
+<table><tr><th>需求</th><th>推荐先试</th><th>说明</th></tr>
+<tr><td>快速多语种转写</td><td>SenseVoice-Small</td><td>本地 demo 和私有 API 的稳妥默认选择。</td></tr>
+<tr><td>中文生产 ASR</td><td>Paraformer-Large</td><td>中文语音识别的成熟选择。</td></tr>
+<tr><td>LLM-based ASR 实验</td><td>Fun-ASR-Nano</td><td>吞吐敏感时配合 <a href="vllm.html">vLLM</a>。</td></tr>
+<tr><td>带说话人信息的转写</td><td>SenseVoice 或 Paraformer + <code>spk_model="cam++"</code></td><td>适合会议、访谈、客服录音。</td></tr>
+<tr><td>实时音频</td><td>Runtime WebSocket 服务</td><td>用真实流量验证分块、VAD 和断句。</td></tr></table>
+</section>
+<section id="share"><h2>分享你的结果</h2>
+<p>如果 FunASR 在你的项目里效果不错，欢迎分享使用场景、模型、设备、处理速度、音频领域，以及可以公开的 demo 或 benchmark 摘要。</p>
+<p><a href="https://github.com/modelscope/FunASR/issues">提交 issue</a> 或 <a href="https://github.com/modelscope/FunASR/discussions">发起讨论</a>。具体使用反馈能帮助新用户更快选型，也能帮助维护者决定下一批文档和示例优先级。</p>
+</section>
+</div></div>
+<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>


### PR DESCRIPTION
## Summary
- Add English and Chinese GitHub Pages use-case route maps for private API, agents, streaming, vLLM, subtitles, batch jobs, and benchmarks.
- Add homepage documentation cards and footer links to the new pages.

## Validation
- Parsed all static HTML files with Python html.parser.
- Checked local HTML/CSS links resolve inside the static site.
- Verified required markers on the new pages and homepage entries.
- Ran `git diff --check`.
