### PR TITLE
docs: update Trendshift badge in localized READMEs

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/3839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/3839" alt="Trendshift" width="250" height="55"/></a>
+<a href="https://trendshift.io/repositories/10479" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10479" alt="modelscope%2FFunASR | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
 <p align="center">

--- a/README_ko.md
+++ b/README_ko.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/3839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/3839" alt="Trendshift" width="250" height="55"/></a>
+<a href="https://trendshift.io/repositories/10479" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10479" alt="modelscope%2FFunASR | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/3839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/3839" alt="Trendshift" width="250" height="55"/></a>
+<a href="https://trendshift.io/repositories/10479" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10479" alt="modelscope%2FFunASR | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Update the Trendshift badge in README_zh, README_ja, and README_ko to use repository id 10479.
- Match the badge URL, image URL, alt text, style, width, and height used in the English README.

## Validation
- Confirmed all README language files point to Trendshift repository 10479.
- Confirmed no README language file still references repository 3839.
- Ran `git diff --check`.
