### PR TITLE
docs: add community showcase issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase.md
+++ b/.github/ISSUE_TEMPLATE/showcase.md
@@ -1,0 +1,56 @@
+---
+name: 🎤 Showcase / Production Story
+about: Share how you use FunASR in a demo, product, benchmark, research project, or internal workflow
+labels: 'showcase, needs triage'
+---
+
+Thanks for sharing your FunASR use case. Concrete usage reports help new users choose the right path and help maintainers prioritize docs, examples, models, and deployment work.
+
+If this is a support question, please use Bug Report or Deployment Help instead.
+
+## Summary
+
+<!-- What did you build or evaluate with FunASR? One or two sentences is enough. -->
+
+## Scenario
+
+- [ ] Local transcription demo
+- [ ] Private OpenAI-compatible speech API
+- [ ] Agent / MCP / voice-input workflow
+- [ ] Streaming ASR / live captions
+- [ ] Subtitle generation
+- [ ] Batch transcription / archive processing
+- [ ] Benchmark or migration from Whisper/cloud ASR
+- [ ] Research / education
+- [ ] Production deployment
+- [ ] Other:
+
+## Deployment details
+
+- FunASR version:
+- Model(s):
+- Device (`cuda`, `cpu`, `mps`):
+- GPU / CPU:
+- Runtime path (`Python API`, `funasr-server`, `WebSocket`, `Docker`, `vLLM`, `MCP`, other):
+- Audio language/domain:
+- Approximate audio duration or traffic:
+
+## Results
+
+<!-- Share speed, accuracy/CER/WER, latency, cost, CPU/GPU usage, or qualitative results if available. -->
+
+```text
+
+```
+
+## Links or screenshots
+
+<!-- Public demo, article, repo, benchmark report, screenshot, or architecture diagram. Do not include private audio, credentials, or customer data. -->
+
+## What was easy?
+
+<!-- Which docs, examples, or APIs helped most? -->
+
+## What should be improved?
+
+<!-- Missing docs, rough edges, model gaps, deployment friction, benchmark needs, etc. -->

--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -70,7 +70,7 @@ For each launch, prepare:
 ## Workstream 5: External proof
 
 - Publish reproducible benchmark scripts and raw configuration for the 184-file benchmark.
-- Encourage users to share production stories, dashboards, or public demos.
+- Encourage users to share production stories, dashboards, public demos, or benchmark notes through the showcase issue template.
 - Add third-party integrations and community projects to README when they are maintained and runnable.
 - Keep citations and paper links visible for researchers.
 

--- a/docs/use_case_showcase.md
+++ b/docs/use_case_showcase.md
@@ -75,7 +75,7 @@ Use this path when deciding whether FunASR is a good replacement for Whisper or 
 
 ## Share your result
 
-If FunASR works well in your project, consider opening a GitHub Discussion or issue with:
+If FunASR works well in your project, consider opening a [showcase issue](https://github.com/modelscope/FunASR/issues/new?template=showcase.md) or GitHub Discussion with:
 
 - Use case and deployment mode.
 - Model, device, and processing speed.

--- a/docs/use_case_showcase_zh.md
+++ b/docs/use_case_showcase_zh.md
@@ -75,7 +75,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
 
 ## 分享你的结果
 
-如果 FunASR 在你的项目里效果不错，欢迎在 GitHub Discussion 或 issue 里分享：
+如果 FunASR 在你的项目里效果不错，欢迎通过 [showcase issue](https://github.com/modelscope/FunASR/issues/new?template=showcase.md) 或 GitHub Discussion 分享：
 
 - 使用场景和部署方式。
 - 模型、设备和处理速度。


### PR DESCRIPTION
## Summary
- Add a Showcase / Production Story issue template for users to share demos, deployments, benchmarks, and migration notes.
- Link the showcase template from the English and Chinese use-case docs.
- Update the 20k growth plan to route external proof into the showcase template.

## Validation
- Checked Markdown links in touched files.
- Verified the issue-template front matter and required fields.
- Ran `git diff --check`.
