### PR TITLE
docs: link showcase template from website

### DIFF
--- a/use-cases.html
+++ b/use-cases.html
@@ -55,7 +55,7 @@ python examples/mcp_server/funasr_mcp.py
 </section>
 <section id="share"><h2>Share your result</h2>
 <p>If FunASR works well in your project, share the use case, model, device, processing speed, audio domain, and a public demo or benchmark summary when possible.</p>
-<p><a href="https://github.com/modelscope/FunASR/issues">Open an issue</a> or <a href="https://github.com/modelscope/FunASR/discussions">start a discussion</a>. Concrete usage reports help new users choose the right path and help maintainers prioritize docs and examples.</p>
+<p><a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">Share a showcase issue</a> or <a href="https://github.com/modelscope/FunASR/discussions">start a discussion</a>. Concrete usage reports help new users choose the right path and help maintainers prioritize docs and examples.</p>
 </section>
 </div></div>
 <footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -55,7 +55,7 @@ python examples/mcp_server/funasr_mcp.py
 </section>
 <section id="share"><h2>分享你的结果</h2>
 <p>如果 FunASR 在你的项目里效果不错，欢迎分享使用场景、模型、设备、处理速度、音频领域，以及可以公开的 demo 或 benchmark 摘要。</p>
-<p><a href="https://github.com/modelscope/FunASR/issues">提交 issue</a> 或 <a href="https://github.com/modelscope/FunASR/discussions">发起讨论</a>。具体使用反馈能帮助新用户更快选型，也能帮助维护者决定下一批文档和示例优先级。</p>
+<p><a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">提交 showcase issue</a> 或 <a href="https://github.com/modelscope/FunASR/discussions">发起讨论</a>。具体使用反馈能帮助新用户更快选型，也能帮助维护者决定下一批文档和示例优先级。</p>
 </section>
 </div></div>
 <footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>


### PR DESCRIPTION
## Summary
- Point the English and Chinese GitHub Pages use-case pages to the new showcase issue template.
- Keep Discussions as the secondary community feedback path.

## Validation
- Parsed relevant static HTML pages and checked local links.
- Verified the showcase issue-template URL appears in both use-case pages.
- Ran `git diff --check`.
