### PR TITLE
docs: add Dockerfile for OpenAI API example

### DIFF
--- a/examples/openai_api/.dockerignore
+++ b/examples/openai_api/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.wav
+*.mp3
+*.flac
+*.m4a
+*.ogg
+*.webm
+*.log
+.cache/
+.pytest_cache/

--- a/examples/openai_api/Dockerfile
+++ b/examples/openai_api/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    FUNASR_MODEL=sensevoice \
+    FUNASR_DEVICE=cpu \
+    FUNASR_PORT=8000
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        git \
+        libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip \
+    && pip install \
+        funasr \
+        fastapi \
+        "uvicorn[standard]" \
+        python-multipart
+
+COPY server.py /app/server.py
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen('http://127.0.0.1:%s/health' % os.getenv('FUNASR_PORT', '8000'), timeout=3).read()" || exit 1
+
+CMD ["sh", "-c", "python server.py --host 0.0.0.0 --port ${FUNASR_PORT:-8000} --device ${FUNASR_DEVICE:-cpu} --model ${FUNASR_MODEL:-sensevoice}"]

--- a/examples/openai_api/README.md
+++ b/examples/openai_api/README.md
@@ -107,12 +107,31 @@ def transcribe_for_agent(audio_path: str) -> str:
 
 ## Docker Deployment
 
+Build the example image from this directory. The default image starts in CPU mode so it can be used as a portable smoke test.
+
 ```bash
-# Build
+cd examples/openai_api
 docker build -t funasr-api .
 
-# Run with GPU
-docker run --gpus all -p 8000:8000 funasr-api
+docker run --rm -p 8000:8000 \
+  -e FUNASR_DEVICE=cpu \
+  -e FUNASR_MODEL=sensevoice \
+  funasr-api
+```
+
+For GPU hosts, use NVIDIA Container Toolkit and a CUDA-capable PyTorch/FunASR environment, then run the same server with `FUNASR_DEVICE=cuda`:
+
+```bash
+docker run --rm --gpus all -p 8000:8000 \
+  -e FUNASR_DEVICE=cuda \
+  -e FUNASR_MODEL=sensevoice \
+  funasr-api
+```
+
+Verify the container from another terminal:
+
+```bash
+BASE_URL=http://localhost:8000 bash smoke_test.sh
 ```
 
 ## Configuration
@@ -123,6 +142,14 @@ docker run --gpus all -p 8000:8000 funasr-api
 | `--port` | 8000 | Port |
 | `--device` | cuda | Device (cuda/cpu/mps) |
 | `--model` | sensevoice | Pre-load model at startup |
+
+Docker environment variables:
+
+| Env | Default | Description |
+|-----|---------|-------------|
+| `FUNASR_PORT` | 8000 | Container port passed to `server.py` |
+| `FUNASR_DEVICE` | cpu | Container device mode; set to `cuda` only when the image has CUDA-capable dependencies |
+| `FUNASR_MODEL` | sensevoice | Model alias loaded at container startup |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add a Dockerfile and .dockerignore for the OpenAI-compatible API example.
- Update the Docker instructions to build from the example directory, run a CPU smoke-test container by default, and document the GPU environment variables.

## Validation
- Ran `python3 -m py_compile examples/openai_api/server.py`.
- Verified Dockerfile and README markers with a Python check.
- Ran `git diff --check` and `git diff --cached --check`.

Note: I did not build the Docker image in this pass because it downloads full runtime dependencies and model assets; the Dockerfile is intended as a reproducible starting point for users and CI.
