### PR TITLE
docs: add Compose setup for OpenAI API example

### DIFF
--- a/examples/openai_api/.env.example
+++ b/examples/openai_api/.env.example
@@ -1,0 +1,8 @@
+# Host port exposed by Docker Compose.
+FUNASR_HOST_PORT=8000
+
+# The example Docker image defaults to CPU so the container can start on machines
+# without NVIDIA Container Toolkit. Keep CPU mode unless the image has CUDA-capable PyTorch.
+FUNASR_DEVICE=cpu
+# Set FUNASR_DEVICE=cuda only after using a CUDA-capable PyTorch image.
+FUNASR_MODEL=sensevoice

--- a/examples/openai_api/README.md
+++ b/examples/openai_api/README.md
@@ -111,6 +111,14 @@ Build the example image from this directory. The default image starts in CPU mod
 
 ```bash
 cd examples/openai_api
+cp .env.example .env
+
+docker compose up --build
+```
+
+Equivalent one-off `docker run` command:
+
+```bash
 docker build -t funasr-api .
 
 docker run --rm -p 8000:8000 \
@@ -119,7 +127,7 @@ docker run --rm -p 8000:8000 \
   funasr-api
 ```
 
-For GPU hosts, use NVIDIA Container Toolkit and a CUDA-capable PyTorch/FunASR environment, then run the same server with `FUNASR_DEVICE=cuda`:
+For GPU hosts, use NVIDIA Container Toolkit and a CUDA-capable PyTorch/FunASR image. After adapting the image dependencies for CUDA, run the same server with `FUNASR_DEVICE=cuda`:
 
 ```bash
 docker run --rm --gpus all -p 8000:8000 \

--- a/examples/openai_api/docker-compose.yml
+++ b/examples/openai_api/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  funasr-api:
+    build:
+      context: .
+    image: funasr-api:local
+    ports:
+      - "${FUNASR_HOST_PORT:-8000}:8000"
+    environment:
+      FUNASR_PORT: "8000"
+      FUNASR_DEVICE: "${FUNASR_DEVICE:-cpu}"
+      FUNASR_MODEL: "${FUNASR_MODEL:-sensevoice}"
+    volumes:
+      - funasr-cache:/root/.cache
+    shm_size: "2gb"
+
+volumes:
+  funasr-cache:


### PR DESCRIPTION
## Summary
- Add `.env.example` and `docker-compose.yml` for the OpenAI-compatible API example.
- Update README Docker instructions to prefer a CPU-mode `docker compose up --build` smoke-test path while keeping `docker run` and CUDA guidance.

## Validation
- Verified Compose/README markers and trailing newlines with Python checks.
- Ran `git diff --check` and `git diff --cached --check`.

Note: `docker compose` is not installed on the server, so I skipped `docker compose config`; no image build was attempted.
