### PR TITLE
docs: add GitHub Pages deployment matrix

### DIFF
--- a/deployment-matrix.html
+++ b/deployment-matrix.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Choose the right FunASR deployment path: Python API, OpenAI-compatible API, Docker Compose, WebSocket runtime, vLLM, MCP, subtitles, batch ASR, or Triton.">
+<meta property="og:title" content="FunASR Deployment Matrix">
+<meta property="og:description" content="A practical deployment decision table for FunASR products, demos, benchmarks, and internal workflows.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/deployment-matrix.html">
+<title>FunASR Deployment Matrix</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">Home</a><a href="tutorial.html">Tutorial</a><a href="training.html">Training</a><a href="model-registration.html">Develop</a><a href="api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">English</button><div class="lang-menu"><a href="deployment-matrix.html" class="current">English</a><a href="zh/deployment-matrix.html">中文</a><a href="ja/index.html">日本語</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>Deployment Matrix</h1>
+<p>Choose the shortest path for a product, demo, benchmark, or internal workflow. Start with the smallest surface that satisfies the job, then move to heavier runtimes only when throughput, latency, or integration requirements demand it.</p>
+<div class="toc-grid"><a href="#matrix">Decision table</a><a href="#choices">Common choices</a><a href="#checklist">Readiness checklist</a><a href="#help">Get help</a></div>
+<section id="matrix"><h2>Quick decision table</h2>
+<table><tr><th>Path</th><th>Best for</th><th>Start here</th><th>Operational notes</th></tr>
+<tr><td>Python API</td><td>Notebooks, offline jobs, first model evaluation</td><td><a href="tutorial.html">Tutorial</a></td><td>Lowest ceremony; caller owns batching, retries, and files.</td></tr>
+<tr><td>OpenAI-compatible API</td><td>Private speech API, agents, Dify/LangChain/AutoGen-style clients</td><td><a href="agent.html#server">OpenAI API</a></td><td>Easiest integration for apps that already support OpenAI audio APIs.</td></tr>
+<tr><td>Docker Compose API</td><td>Reproducible local smoke test or small internal service</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker docs</a></td><td>CPU by default; adapt the image before using CUDA in containers.</td></tr>
+<tr><td>Runtime WebSocket service</td><td>Live captions, meetings, call-center streams</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime docs</a></td><td>Use when partial results, endpointing, or long-lived audio streams matter.</td></tr>
+<tr><td>vLLM acceleration</td><td>Higher-throughput LLM-based ASR with Fun-ASR-Nano</td><td><a href="vllm.html">vLLM guide</a></td><td>Use for LLM decoder throughput; does not apply to non-autoregressive Paraformer.</td></tr>
+<tr><td>MCP server</td><td>Claude/Cursor/desktop agent speech tools</td><td><a href="agent.html#mcp">MCP example</a></td><td>Good when the ASR result should be exposed as a local tool.</td></tr>
+<tr><td>Subtitle generator</td><td>SRT/VTT from long audio or video</td><td><a href="agent.html#subtitle">Subtitle generator</a></td><td>Use verbose segments and speaker labels when readability matters.</td></tr>
+<tr><td>Batch ASR script</td><td>Archives, meetings, datasets, repeated offline runs</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">Batch example</a></td><td>Add queueing, manifests, and retry logs for production use.</td></tr>
+<tr><td>Triton runtime</td><td>Specialized high-performance serving</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime/triton_gpu">Triton runtime docs</a></td><td>Heavier setup; choose when your team already operates Triton/GPU serving.</td></tr></table>
+</section>
+<section id="choices"><h2>Common choices</h2>
+<div class="grid-2"><div class="card"><h3>Try FunASR in five minutes</h3><p>Use the Python API from the tutorial. It is the shortest route for validating installation, model download, device selection, and output shape.</p></div>
+<div class="card"><h3>Replace cloud transcription locally</h3><p>Use the OpenAI-compatible API. Start with <code>sensevoice</code>, run the smoke test, then connect existing SDK or HTTP clients using the client recipes.</p></div></div>
+<div class="grid-2"><div class="card"><h3>Run a repeatable container demo</h3><pre><code>cd examples/openai_api
+cp .env.example .env
+docker compose up --build</code></pre><p>Keep CPU mode until you have a CUDA-capable PyTorch/FunASR image.</p></div>
+<div class="card"><h3>Serve live audio</h3><p>Use the runtime WebSocket service. Validate chunk size, VAD, endpointing, punctuation, speaker diarization, reconnect behavior, and client backpressure with real audio.</p></div></div>
+</section>
+<section id="checklist"><h2>Readiness checklist</h2>
+<ul><li>Pick a model alias and pin it in deployment notes.</li><li>Record FunASR version, model version, device, CUDA/PyTorch version, Docker image tag, and command line.</li><li>Run a short public smoke sample and at least one realistic private sample.</li><li>Log audio duration, model, device, latency, response format, and error type for every request.</li><li>Add upload-size limits, authentication, TLS, and rate limits before exposing an API outside a trusted network.</li><li>For streaming, test silence, noise, overlapping speakers, long sessions, reconnects, and slow clients.</li></ul>
+</section>
+<section id="help"><h2>When to open an issue</h2>
+<p>Use <a href="https://github.com/modelscope/FunASR/issues/new?template=deployment_help.md">Deployment Help</a> for runtime, Docker, vLLM, Triton, Android, browser, or agent integration problems. Include your deployment path, exact command/config, logs, model, device, and audio characteristics.</p>
+</section>
+</div></div>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="deployment-matrix.html">Deployment</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -122,6 +122,11 @@ curl http://localhost:8000/v1/audio/transcriptions \
             <h2 class="section-title">Documentation</h2>
             <p class="section-subtitle">Start with examples, tune on your own data, extend the registry, or jump into source-linked API docs.</p>
             <div class="doc-grid">
+                <a class="doc-card" href="deployment-matrix.html">
+                    <span class="doc-kicker">Deploy</span>
+                    <h3>Deployment Matrix</h3>
+                    <p>Choose between Python API, OpenAI API, Docker Compose, WebSocket runtime, vLLM, MCP, batch, subtitles, and Triton.</p>
+                </a>
                 <a class="doc-card" href="use-cases.html">
                     <span class="doc-kicker">Choose</span>
                     <h3>Use Cases</h3>
@@ -309,6 +314,7 @@ for sent in res[0]["sentence_info"]:
             <a href="https://github.com/modelscope/FunASR">GitHub</a> &middot;
             <a href="training.html">Training</a> &middot;
             <a href="use-cases.html">Use Cases</a> &middot;
+            <a href="deployment-matrix.html">Deployment</a> &middot;
             <a href="api.html">API</a> &middot;
             <a href="vllm.html">vLLM</a> &middot;
             <a href="agent.html">Agent</a> &middot;

--- a/use-cases.html
+++ b/use-cases.html
@@ -25,6 +25,7 @@
 <tr><td>Compare accuracy and speed</td><td><a href="benchmark.html">Benchmark report</a></td><td>Review long-audio speed and CER before choosing a model.</td></tr>
 <tr><td>Build a private speech API</td><td><a href="agent.html#server">OpenAI-compatible API</a></td><td>Reuse OpenAI-style clients without sending audio to a cloud ASR provider.</td></tr>
 <tr><td>Add speech input to agents</td><td><a href="agent.html#mcp">MCP server</a></td><td>Connect local ASR to Claude, Cursor, desktop tools, and internal assistants.</td></tr>
+<tr><td>Choose a deployment path</td><td><a href="deployment-matrix.html">Deployment matrix</a></td><td>Compare Python API, OpenAI API, Docker Compose, WebSocket, vLLM, MCP, subtitles, batch jobs, and Triton.</td></tr>
 <tr><td>Serve streaming ASR</td><td><a href="tutorial.html#real-time-speech-recognition">Realtime examples</a></td><td>Handle live captioning, meetings, and call-center style workloads.</td></tr>
 <tr><td>Accelerate LLM-based ASR</td><td><a href="vllm.html">vLLM guide</a></td><td>Use tensor parallel decoding and streaming service support for Fun-ASR-Nano.</td></tr>
 <tr><td>Generate subtitles</td><td><a href="agent.html#subtitle">Subtitle generator</a></td><td>Create SRT/VTT files from audio or video, with speaker labels when needed.</td></tr>
@@ -58,5 +59,5 @@ python examples/mcp_server/funasr_mcp.py
 <p><a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">Share a showcase issue</a> or <a href="https://github.com/modelscope/FunASR/discussions">start a discussion</a>. Concrete usage reports help new users choose the right path and help maintainers prioritize docs and examples.</p>
 </section>
 </div></div>
-<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="deployment-matrix.html">Deployment</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
 </body></html>

--- a/zh/deployment-matrix.html
+++ b/zh/deployment-matrix.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="FunASR 部署选型表：Python API、OpenAI 兼容 API、Docker Compose、WebSocket runtime、vLLM、MCP、字幕、批处理和 Triton。">
+<meta property="og:title" content="FunASR 部署选型表">
+<meta property="og:description" content="面向产品、demo、benchmark 和内部工作流的 FunASR 部署决策表。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/deployment-matrix.html">
+<title>FunASR 部署选型表</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">首页</a><a href="tutorial.html">教程</a><a href="training.html">训练</a><a href="model-registration.html">开发</a><a href="../api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">中文</button><div class="lang-menu"><a href="../deployment-matrix.html">English</a><a href="deployment-matrix.html" class="current">中文</a><a href="../ja/index.html">日本語</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>部署选型表</h1>
+<p>为产品、demo、benchmark 或内部工作流选择最短部署路径。先选择能满足目标的最小方案，只有在吞吐、延迟或集成方式有明确要求时，再切换到更重的运行时。</p>
+<div class="toc-grid"><a href="#matrix">决策表</a><a href="#choices">常见选择</a><a href="#checklist">上线检查</a><a href="#help">获取帮助</a></div>
+<section id="matrix"><h2>快速决策表</h2>
+<table><tr><th>路径</th><th>适合场景</th><th>从这里开始</th><th>运维提示</th></tr>
+<tr><td>Python API</td><td>Notebook、离线任务、首次模型评测</td><td><a href="tutorial.html">使用教程</a></td><td>最简单；调用方自己负责批处理、重试和文件管理。</td></tr>
+<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen 风格客户端</td><td><a href="agent.html#server">OpenAI API</a></td><td>已支持 OpenAI audio API 的应用最容易接入。</td></tr>
+<tr><td>Docker Compose API</td><td>可复现本地 smoke test 或小型内部服务</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker 文档</a></td><td>默认 CPU；容器里使用 CUDA 前需要先适配 CUDA-capable 镜像。</td></tr>
+<tr><td>Runtime WebSocket 服务</td><td>实时字幕、会议、客服流式音频</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime 文档</a></td><td>需要中间结果、断句或长连接音频流时选择。</td></tr>
+<tr><td>vLLM 加速</td><td>Fun-ASR-Nano 等 LLM-based ASR 高吞吐</td><td><a href="vllm.html">vLLM 指南</a></td><td>适合 LLM 解码吞吐；不适用于非自回归 Paraformer。</td></tr>
+<tr><td>MCP 服务</td><td>Claude/Cursor/桌面 Agent 语音工具</td><td><a href="agent.html#mcp">MCP 示例</a></td><td>适合把 ASR 结果暴露成一个本地工具。</td></tr>
+<tr><td>字幕生成</td><td>从长音频或视频生成 SRT/VTT</td><td><a href="agent.html#subtitle">字幕生成器</a></td><td>需要可读性时使用 verbose segments 和说话人标签。</td></tr>
+<tr><td>批处理脚本</td><td>录音归档、会议纪要、数据集处理</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">批处理示例</a></td><td>生产使用时建议增加队列、manifest 和重试日志。</td></tr>
+<tr><td>Triton Runtime</td><td>专门的高性能推理服务</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime/triton_gpu">Triton 文档</a></td><td>配置更重；适合已经在运维 Triton/GPU serving 的团队。</td></tr></table>
+</section>
+<section id="choices"><h2>常见选择</h2>
+<div class="grid-2"><div class="card"><h3>五分钟内试跑 FunASR</h3><p>使用教程里的 Python API。它是验证安装、模型下载、设备选择和基础输出格式的最短路径。</p></div>
+<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。</p></div></div>
+<div class="grid-2"><div class="card"><h3>可复现容器 demo</h3><pre><code>cd examples/openai_api
+cp .env.example .env
+docker compose up --build</code></pre><p>在没有 CUDA-capable PyTorch/FunASR 镜像前保持 CPU 模式。</p></div>
+<div class="card"><h3>实时音频服务</h3><p>使用 Runtime WebSocket 服务。上线前请用真实音频验证 chunk size、VAD、断句、标点、说话人分离、重连行为和客户端背压。</p></div></div>
+</section>
+<section id="checklist"><h2>上线检查清单</h2>
+<ul><li>选择模型 alias，并写入部署说明。</li><li>记录 FunASR 版本、模型版本、设备、CUDA/PyTorch 版本、Docker 镜像 tag 和启动命令。</li><li>跑一个公开短音频 smoke sample，再跑至少一个真实私有样本。</li><li>每次请求记录音频时长、模型、设备、延迟、响应格式和错误类型。</li><li>API 暴露到可信网络外之前，增加上传大小限制、鉴权、TLS 和限流。</li><li>流式场景需要测试静音、噪声、多人重叠、长连接、重连和慢客户端。</li></ul>
+</section>
+<section id="help"><h2>什么时候开 issue</h2>
+<p>Runtime、Docker、vLLM、Triton、Android、浏览器或 Agent 集成问题，请使用 <a href="https://github.com/modelscope/FunASR/issues/new?template=deployment_help.md">Deployment Help</a>。请附上部署路径、完整命令/config、日志、模型、设备和音频特征。</p>
+</section>
+</div></div>
+<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="deployment-matrix.html">部署选型</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -122,6 +122,11 @@ curl http://localhost:8000/v1/audio/transcriptions \
             <h2 class="section-title">文档中心</h2>
             <p class="section-subtitle">从示例开始，在自己的数据上微调，扩展模型注册表，或查阅带源码链接的 API 文档。</p>
             <div class="doc-grid">
+                <a class="doc-card" href="deployment-matrix.html">
+                    <span class="doc-kicker">部署</span>
+                    <h3>部署选型</h3>
+                    <p>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、批处理、字幕和 Triton。</p>
+                </a>
                 <a class="doc-card" href="use-cases.html">
                     <span class="doc-kicker">选型</span>
                     <h3>场景速览</h3>
@@ -309,6 +314,7 @@ for sent in res[0]["sentence_info"]:
             <a href="https://github.com/modelscope/FunASR">GitHub</a> &middot;
             <a href="training.html">训练</a> &middot;
             <a href="use-cases.html">场景速览</a> &middot;
+            <a href="deployment-matrix.html">部署选型</a> &middot;
             <a href="../api.html">API</a> &middot;
             <a href="vllm.html">vLLM</a> &middot;
             <a href="agent.html">Agent</a> &middot;

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -25,6 +25,7 @@
 <tr><td>对比准确率和速度</td><td><a href="benchmark.html">性能评测报告</a></td><td>选型前查看长音频速度和 CER。</td></tr>
 <tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a></td><td>复用 OpenAI 风格客户端，音频不出内网。</td></tr>
 <tr><td>给 Agent 增加语音输入</td><td><a href="agent.html#mcp">MCP 服务</a></td><td>将本地 ASR 接入 Claude、Cursor、桌面工具和内部助手。</td></tr>
+<tr><td>选择部署路径</td><td><a href="deployment-matrix.html">部署选型表</a></td><td>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、字幕、批处理和 Triton。</td></tr>
 <tr><td>部署流式 ASR</td><td><a href="tutorial.html#real-time-speech-recognition">实时示例</a></td><td>面向实时字幕、会议和客服类低延迟场景。</td></tr>
 <tr><td>加速 LLM-based ASR</td><td><a href="vllm.html">vLLM 指南</a></td><td>为 Fun-ASR-Nano 使用 tensor parallel 解码和流式服务能力。</td></tr>
 <tr><td>生成字幕</td><td><a href="agent.html#subtitle">字幕生成器</a></td><td>将音频或视频生成 SRT/VTT，需要时添加说话人标签。</td></tr>
@@ -58,5 +59,5 @@ python examples/mcp_server/funasr_mcp.py
 <p><a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">提交 showcase issue</a> 或 <a href="https://github.com/modelscope/FunASR/discussions">发起讨论</a>。具体使用反馈能帮助新用户更快选型，也能帮助维护者决定下一批文档和示例优先级。</p>
 </section>
 </div></div>
-<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="deployment-matrix.html">部署选型</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
 </body></html>


### PR DESCRIPTION
## Summary
- Add English and Chinese GitHub Pages deployment matrix pages.
- Link the new deployment pages from the homepage documentation cards, use-case pages, and footers.

## Validation
- Parsed all static HTML files with Python html.parser.
- Checked local HTML/CSS links resolve inside the static site.
- Verified deployment matrix markers on the new pages and entry points.
- Ran `git diff --check` and `git diff --cached --check`.
