### PR TITLE
[codex] Add migration guide pages to GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,11 @@ curl http://localhost:8000/v1/audio/transcriptions \
                     <h3>Deployment Matrix</h3>
                     <p>Choose between Python API, OpenAI API, Docker Compose, WebSocket runtime, vLLM, MCP, batch, subtitles, and Triton.</p>
                 </a>
+                <a class="doc-card" href="migration.html">
+                    <span class="doc-kicker">Compare</span>
+                    <h3>Migration Guide</h3>
+                    <p>Evaluate FunASR against Whisper or cloud ASR with feature mapping, representative benchmarks, and rollout checks.</p>
+                </a>
                 <a class="doc-card" href="use-cases.html">
                     <span class="doc-kicker">Choose</span>
                     <h3>Use Cases</h3>

--- a/migration.html
+++ b/migration.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Evaluate migration from Whisper or cloud ASR to FunASR with representative audio, feature mapping, OpenAI-compatible APIs, and rollout checklists.">
+<meta property="og:title" content="Migrate from Whisper or Cloud ASR to FunASR">
+<meta property="og:description" content="A practical benchmark and rollout guide for teams comparing Whisper, cloud ASR, and self-hosted FunASR.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/migration.html">
+<title>Migrate from Whisper or Cloud ASR to FunASR</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">Home</a><a href="tutorial.html">Tutorial</a><a href="training.html">Training</a><a href="model-registration.html">Develop</a><a href="api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">English</button><div class="lang-menu"><a href="migration.html" class="current">English</a><a href="zh/migration.html">中文</a><a href="ja/index.html">日本語</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>Migrate from Whisper or Cloud ASR to FunASR</h1>
+<p>Use this guide when you already have a Whisper, OpenAI or cloud ASR, or custom speech pipeline and want to decide whether FunASR is worth switching to. Compare quality, speed, cost, and deployment fit on audio that looks like your real workload.</p>
+<div class="toc-grid"><a href="#fit">When it fits</a><a href="#plan">Evaluation plan</a><a href="#mapping">Feature mapping</a><a href="#rollout">Rollout</a></div>
+<section id="fit"><h2>When FunASR is a good fit</h2>
+<ul><li>Private or self-hosted transcription where audio should stay inside your environment.</li><li>High-throughput long-form transcription for meetings, archives, media, or call recordings.</li><li>Speaker-aware transcripts with VAD, punctuation, timestamps, and diarization in one pipeline.</li><li>An OpenAI-compatible audio endpoint for agents, Dify, LangChain, AutoGen, or internal apps.</li><li>Streaming ASR or live captions with WebSocket/runtime service support.</li><li>CPU-viable smoke tests before moving to GPU deployment.</li></ul>
+<p>Stay on your current pipeline if you need a fully managed service, a vendor SLA, or a language/domain that your own benchmark shows FunASR does not handle well enough yet.</p></section>
+<section id="plan"><h2>Fast evaluation plan</h2>
+<ol><li>Pick 20-50 representative audio files, including short clips, long recordings, noisy samples, different speakers, and target languages or dialects.</li><li>Run your current Whisper or cloud ASR pipeline exactly as you use it in production. Save transcripts, latency, cost, and failure cases.</li><li>Run FunASR locally with the tutorial, then choose a deployment path from the <a href="deployment-matrix.html">deployment matrix</a>.</li><li>Compare output with human review or your normal WER/CER process. Do not compare only one clean demo file.</li><li>Run the OpenAI-compatible API smoke test if your application already uses OpenAI-style clients.</li><li>Record warmup time, model download time, device, GPU/CPU type, batch size, and audio duration separately from steady-state throughput.</li></ol></section>
+<section id="mapping"><h2>Feature mapping</h2>
+<table><tr><th>Existing workflow</th><th>FunASR path</th><th>What to validate</th></tr>
+<tr><td>Whisper file transcription</td><td><a href="tutorial.html">Tutorial</a> with SenseVoice, Paraformer, or Fun-ASR-Nano</td><td>Transcript quality, timestamps, speed, model download, CPU/GPU behavior.</td></tr>
+<tr><td>Whisper plus pyannote</td><td><code>spk_model="cam++"</code> with VAD and punctuation</td><td>Speaker labels, speaker changes, overlapping speech, long silences.</td></tr>
+<tr><td>OpenAI audio API or cloud batch ASR</td><td><a href="agent.html#server">OpenAI-compatible API</a></td><td><code>/v1/audio/transcriptions</code>, response format, client compatibility, upload limits.</td></tr>
+<tr><td>Dify/LangChain/AutoGen agent audio</td><td><a href="agent.html">Agent and API recipes</a> or MCP server</td><td>Tool latency, file handling, auth boundary, error reporting.</td></tr>
+<tr><td>Live captions or call-center streaming</td><td><a href="tutorial.html#real-time-speech-recognition">Realtime examples</a></td><td>Chunking, endpointing, reconnects, backpressure, partial/final result behavior.</td></tr>
+<tr><td>Subtitle generation</td><td><a href="agent.html#subtitle">Subtitle generator</a></td><td>Segment readability, line length, speaker labels, SRT/VTT compatibility.</td></tr>
+<tr><td>Offline archive processing</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">Batch ASR example</a></td><td>Manifest handling, retries, progress logs, throughput, failed-file recovery.</td></tr></table></section>
+<section id="compare"><h2>Minimal local comparison</h2>
+<p>Install FunASR and run the same file you used for your baseline:</p>
+<pre><code>pip install funasr</code></pre>
+<pre><code>from funasr import AutoModel
+
+model = AutoModel(
+    model="iic/SenseVoiceSmall",
+    vad_model="fsmn-vad",
+    spk_model="cam++",
+    device="cuda",  # use "cpu" for a portable smoke test
+)
+result = model.generate(input="sample.wav")
+print(result)</code></pre>
+<p>For an API-style comparison:</p>
+<pre><code>pip install funasr fastapi uvicorn python-multipart
+funasr-server --model sensevoice --device cuda
+
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@sample.wav \
+  -F model=sensevoice \
+  -F response_format=verbose_json</code></pre></section>
+<section id="quality"><h2>Quality and speed checklist</h2>
+<ul><li>Audio duration, language, domain, sample rate, channel count, and speaker count.</li><li>Model name, model version, FunASR version, Python/PyTorch/CUDA versions, and Docker image tag if used.</li><li>Hardware, device mode, batch size, streaming chunk size, and whether warmup/model download is excluded.</li><li>WER/CER or human review notes for names, numbers, punctuation, diarization, timestamps, and domain terms.</li><li>Latency, throughput, GPU/CPU memory, cost per hour of audio, and failed-file rate.</li><li>Operational requirements: authentication, upload limits, TLS, logs, monitoring, retries, and retention rules.</li></ul></section>
+<section id="rollout"><h2>Rollout checklist</h2>
+<ul><li>Keep the old pipeline available until FunASR passes your representative benchmark.</li><li>Start with an internal endpoint or batch job before exposing a public API.</li><li>Add request IDs and log audio duration, model, device, latency, and error type for every request.</li><li>Pin the model alias and deployment command in your runbook.</li><li>Test noisy audio, silence, overlapping speakers, long files, non-UTF-8 filenames, and network interruptions.</li><li>Open a <a href="https://github.com/modelscope/FunASR/issues/new?template=deployment_help.md">Deployment Help issue</a> with your command, logs, model, device, and sample characteristics if you hit a blocker.</li></ul></section>
+<section id="share"><h2>Share the result</h2><p>If FunASR replaces or complements your existing ASR stack, consider opening a <a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">showcase issue</a>. Migration reports with hardware, speed, quality notes, and deployment details help new users choose the right path faster.</p></section>
+</div></div>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="migration.html">Migration</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="deployment-matrix.html">Deployment</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,6 +13,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://modelscope.github.io/FunASR/migration.html</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://modelscope.github.io/FunASR/use-cases.html</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
@@ -152,6 +158,12 @@
   </url>
   <url>
     <loc>https://modelscope.github.io/FunASR/zh/tutorial.html</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://modelscope.github.io/FunASR/zh/migration.html</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/use-cases.html
+++ b/use-cases.html
@@ -23,6 +23,7 @@
 <table><tr><th>Goal</th><th>Start here</th><th>Why it matters</th></tr>
 <tr><td>Transcribe one file locally</td><td><a href="tutorial.html">Tutorial</a></td><td>Verify install and model download in minutes.</td></tr>
 <tr><td>Compare accuracy and speed</td><td><a href="benchmark.html">Benchmark report</a></td><td>Review long-audio speed and CER before choosing a model.</td></tr>
+<tr><td>Migrate from Whisper/cloud ASR</td><td><a href="migration.html">Migration guide</a></td><td>Map existing pipelines to FunASR, benchmark representative audio, and plan a safe rollout.</td></tr>
 <tr><td>Build a private speech API</td><td><a href="agent.html#server">OpenAI-compatible API</a></td><td>Reuse OpenAI-style clients without sending audio to a cloud ASR provider.</td></tr>
 <tr><td>Add speech input to agents</td><td><a href="agent.html#mcp">MCP server</a></td><td>Connect local ASR to Claude, Cursor, desktop tools, and internal assistants.</td></tr>
 <tr><td>Choose a deployment path</td><td><a href="deployment-matrix.html">Deployment matrix</a></td><td>Compare Python API, OpenAI API, Docker Compose, WebSocket, vLLM, MCP, subtitles, batch jobs, and Triton.</td></tr>
@@ -44,7 +45,7 @@ python examples/mcp_server/funasr_mcp.py
 
 # Set FUNASR_DEVICE=cuda for GPU inference</code></pre></div></div>
 <div class="grid-2"><div class="card"><h3>Streaming workloads</h3><p>Pair ASR with VAD, punctuation, and speaker diarization when partial transcripts need to be readable by humans.</p><p>Validate with real audio: background noise, long silence, overlapping speakers, and different microphone quality.</p></div>
-<div class="card"><h3>Benchmark before migration</h3><p>Compare FunASR against Whisper or cloud ASR using your own sample set. Track throughput, CPU viability, download size, and deployment complexity together.</p><p><a href="benchmark.html">Open the public benchmark report</a></p></div></div>
+<div class="card"><h3>Benchmark before migration</h3><p>Compare FunASR against Whisper or cloud ASR using your own sample set. Track throughput, CPU viability, download size, and deployment complexity together.</p><p><a href="migration.html">Open the migration guide</a> · <a href="benchmark.html">Public benchmark</a></p></div></div>
 </section>
 <section id="models"><h2>Model selection hints</h2>
 <table><tr><th>Need</th><th>Good first choice</th><th>Notes</th></tr>
@@ -59,5 +60,5 @@ python examples/mcp_server/funasr_mcp.py
 <p><a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">Share a showcase issue</a> or <a href="https://github.com/modelscope/FunASR/discussions">start a discussion</a>. Concrete usage reports help new users choose the right path and help maintainers prioritize docs and examples.</p>
 </section>
 </div></div>
-<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="deployment-matrix.html">Deployment</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">Home</a> &middot; <a href="migration.html">Migration</a> &middot; <a href="use-cases.html">Use Cases</a> &middot; <a href="deployment-matrix.html">Deployment</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
 </body></html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -127,6 +127,11 @@ curl http://localhost:8000/v1/audio/transcriptions \
                     <h3>部署选型</h3>
                     <p>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、批处理、字幕和 Triton。</p>
                 </a>
+                <a class="doc-card" href="migration.html">
+                    <span class="doc-kicker">对比</span>
+                    <h3>迁移指南</h3>
+                    <p>用功能映射、代表性评测和上线检查，评估是否从 Whisper 或云端 ASR 切到 FunASR。</p>
+                </a>
                 <a class="doc-card" href="use-cases.html">
                     <span class="doc-kicker">选型</span>
                     <h3>场景速览</h3>

--- a/zh/migration.html
+++ b/zh/migration.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="从 Whisper 或云端 ASR 迁移到 FunASR 的评估指南：代表性音频、功能映射、OpenAI 兼容 API 和上线检查清单。">
+<meta property="og:title" content="从 Whisper 或云端 ASR 迁移到 FunASR">
+<meta property="og:description" content="面向正在比较 Whisper、云端 ASR 和私有化 FunASR 的团队，提供评测和上线路径。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/migration.html">
+<title>从 Whisper 或云端 ASR 迁移到 FunASR</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">首页</a><a href="tutorial.html">教程</a><a href="training.html">训练</a><a href="model-registration.html">开发</a><a href="../api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">中文</button><div class="lang-menu"><a href="../migration.html">English</a><a href="migration.html" class="current">中文</a><a href="../ja/index.html">日本語</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>从 Whisper 或云端 ASR 迁移到 FunASR</h1>
+<p>当你已经有 Whisper、OpenAI/云端 ASR 或自研语音流水线，并想判断是否值得切到 FunASR 时，可以按这个指南评估。重点是在真实业务音频上比较质量、速度、成本和部署可行性。</p>
+<div class="toc-grid"><a href="#fit">适用场景</a><a href="#plan">评估计划</a><a href="#mapping">功能映射</a><a href="#rollout">上线检查</a></div>
+<section id="fit"><h2>什么时候值得评估 FunASR</h2>
+<ul><li>音频需要留在私有环境内，不能上传到外部云服务。</li><li>会议、归档、媒体、客服录音等长音频需要高吞吐转写。</li><li>希望一条流水线内完成 VAD、标点、时间戳和说话人分离。</li><li>需要 OpenAI 兼容音频接口，接入 Agent、Dify、LangChain、AutoGen 或内部应用。</li><li>需要 WebSocket/runtime 服务支撑流式识别或实时字幕。</li><li>希望先用 CPU 做可复现 smoke test，再迁移到 GPU 服务。</li></ul>
+<p>如果你更需要完全托管服务、厂商 SLA，或你的自有评测显示目标语言/领域还不够好，可以暂时保留现有方案。</p></section>
+<section id="plan"><h2>快速评估计划</h2>
+<ol><li>选择 20-50 条有代表性的音频，覆盖短音频、长录音、噪声、多说话人、目标语言和方言。</li><li>按生产方式运行当前 Whisper 或云端 ASR，保存转写结果、延迟、成本和失败样例。</li><li>用教程跑 FunASR，再根据 <a href="deployment-matrix.html">部署选型表</a> 选择服务路径。</li><li>用人工审阅或现有 WER/CER 流程比较结果，不要只看一个干净 demo 音频。</li><li>如果应用已经使用 OpenAI 风格客户端，运行 OpenAI 兼容 API smoke test。</li><li>分开记录 warmup、模型下载、设备、GPU/CPU 型号、batch size、音频时长和稳定吞吐。</li></ol></section>
+<section id="mapping"><h2>功能映射</h2>
+<table><tr><th>现有流程</th><th>FunASR 路径</th><th>需要验证什么</th></tr>
+<tr><td>Whisper 文件转写</td><td>使用 SenseVoice、Paraformer 或 Fun-ASR-Nano 的 <a href="tutorial.html">教程</a></td><td>转写质量、时间戳、速度、模型下载、CPU/GPU 行为。</td></tr>
+<tr><td>Whisper + pyannote</td><td>VAD、标点和 <code>spk_model="cam++"</code></td><td>说话人标签、换人位置、重叠说话、长静音。</td></tr>
+<tr><td>OpenAI 音频 API 或云端批量 ASR</td><td><a href="agent.html#server">OpenAI 兼容 API</a></td><td><code>/v1/audio/transcriptions</code>、响应格式、客户端兼容性、上传限制。</td></tr>
+<tr><td>Dify/LangChain/AutoGen Agent 音频</td><td><a href="agent.html">Agent 与 API 配方</a> 或 MCP 服务</td><td>工具延迟、文件处理、鉴权边界、错误返回。</td></tr>
+<tr><td>实时字幕或客服流式识别</td><td><a href="tutorial.html#real-time-speech-recognition">实时示例</a></td><td>分块、断句、重连、背压、中间/最终结果行为。</td></tr>
+<tr><td>字幕生成</td><td><a href="agent.html#subtitle">字幕生成器</a></td><td>分段可读性、行长、说话人标签、SRT/VTT 兼容性。</td></tr>
+<tr><td>离线归档处理</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">批处理示例</a></td><td>manifest、重试、进度日志、吞吐、失败文件恢复。</td></tr></table></section>
+<section id="compare"><h2>最小本地对比</h2>
+<p>安装 FunASR，并用你基线评测里的同一条音频运行：</p>
+<pre><code>pip install funasr</code></pre>
+<pre><code>from funasr import AutoModel
+
+model = AutoModel(
+    model="iic/SenseVoiceSmall",
+    vad_model="fsmn-vad",
+    spk_model="cam++",
+    device="cuda",  # 便携 smoke test 可改成 "cpu"
+)
+result = model.generate(input="sample.wav")
+print(result)</code></pre>
+<p>如果要按 API 服务方式对比：</p>
+<pre><code>pip install funasr fastapi uvicorn python-multipart
+funasr-server --model sensevoice --device cuda
+
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@sample.wav \
+  -F model=sensevoice \
+  -F response_format=verbose_json</code></pre></section>
+<section id="quality"><h2>质量与速度检查清单</h2>
+<ul><li>音频时长、语言、领域、采样率、声道数和说话人数。</li><li>模型名、模型版本、FunASR 版本、Python/PyTorch/CUDA 版本，以及 Docker 镜像 tag。</li><li>硬件、设备模式、batch size、流式 chunk size，以及是否排除 warmup/模型下载时间。</li><li>WER/CER 或人工审阅记录：姓名、数字、标点、说话人分离、时间戳、领域词。</li><li>延迟、吞吐、GPU/CPU 内存、每小时音频成本、失败文件比例。</li><li>运维要求：鉴权、上传限制、TLS、日志、监控、重试和数据留存规则。</li></ul></section>
+<section id="rollout"><h2>上线检查清单</h2>
+<ul><li>在代表性评测通过前，保留旧流水线作为回退。</li><li>先做内部 endpoint 或离线批处理，再对外暴露 API。</li><li>为每个请求记录 request id、音频时长、模型、设备、延迟和错误类型。</li><li>在 runbook 中固定模型别名和部署命令。</li><li>测试噪声、静音、多人重叠、长文件、非 UTF-8 文件名和网络中断。</li><li>遇到阻塞时，通过 <a href="https://github.com/modelscope/FunASR/issues/new?template=deployment_help.md">Deployment Help issue</a> 提交命令、日志、模型、设备和样本特征。</li></ul></section>
+<section id="share"><h2>分享迁移结果</h2><p>如果 FunASR 替代或补充了你的现有 ASR 栈，欢迎开一个 <a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">showcase issue</a>。包含硬件、速度、质量记录和部署细节的迁移报告，能帮助新用户更快选型。</p></section>
+</div></div>
+<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="migration.html">迁移指南</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="deployment-matrix.html">部署选型</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -23,6 +23,7 @@
 <table><tr><th>目标</th><th>从这里开始</th><th>为什么重要</th></tr>
 <tr><td>本地转写一个文件</td><td><a href="tutorial.html">使用教程</a></td><td>几分钟内验证安装、模型下载和首次推理。</td></tr>
 <tr><td>对比准确率和速度</td><td><a href="benchmark.html">性能评测报告</a></td><td>选型前查看长音频速度和 CER。</td></tr>
+<tr><td>从 Whisper/云端 ASR 迁移</td><td><a href="migration.html">迁移指南</a></td><td>将现有流水线映射到 FunASR，用代表性音频评测并规划安全上线。</td></tr>
 <tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a></td><td>复用 OpenAI 风格客户端，音频不出内网。</td></tr>
 <tr><td>给 Agent 增加语音输入</td><td><a href="agent.html#mcp">MCP 服务</a></td><td>将本地 ASR 接入 Claude、Cursor、桌面工具和内部助手。</td></tr>
 <tr><td>选择部署路径</td><td><a href="deployment-matrix.html">部署选型表</a></td><td>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、字幕、批处理和 Triton。</td></tr>
@@ -44,7 +45,7 @@ python examples/mcp_server/funasr_mcp.py
 
 # 设置 FUNASR_DEVICE=cuda 使用 GPU 推理</code></pre></div></div>
 <div class="grid-2"><div class="card"><h3>流式与客服场景</h3><p>需要给人阅读时，把 ASR 与 VAD、标点恢复、说话人分离一起使用。</p><p>用真实音频验证：背景噪声、长静音、多人重叠、不同麦克风质量。</p></div>
-<div class="card"><h3>迁移前先评测</h3><p>评估是否替代 Whisper 或云端 ASR 时，用自己的样本集同时记录吞吐、CPU 可用性、下载体积和部署复杂度。</p><p><a href="benchmark.html">打开公开评测报告</a></p></div></div>
+<div class="card"><h3>迁移前先评测</h3><p>评估是否替代 Whisper 或云端 ASR 时，用自己的样本集同时记录吞吐、CPU 可用性、下载体积和部署复杂度。</p><p><a href="migration.html">打开迁移指南</a> · <a href="benchmark.html">公开评测</a></p></div></div>
 </section>
 <section id="models"><h2>模型选择建议</h2>
 <table><tr><th>需求</th><th>推荐先试</th><th>说明</th></tr>
@@ -59,5 +60,5 @@ python examples/mcp_server/funasr_mcp.py
 <p><a href="https://github.com/modelscope/FunASR/issues/new?template=showcase.md">提交 showcase issue</a> 或 <a href="https://github.com/modelscope/FunASR/discussions">发起讨论</a>。具体使用反馈能帮助新用户更快选型，也能帮助维护者决定下一批文档和示例优先级。</p>
 </section>
 </div></div>
-<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="deployment-matrix.html">部署选型</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+<footer><p>FunASR &middot; 通义实验室，阿里巴巴集团</p><p><a href="index.html">首页</a> &middot; <a href="migration.html">迁移指南</a> &middot; <a href="use-cases.html">场景速览</a> &middot; <a href="deployment-matrix.html">部署选型</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
 </body></html>


### PR DESCRIPTION
## Summary
- add English and Chinese GitHub Pages migration guides for teams comparing Whisper/cloud ASR with FunASR
- link the migration pages from the homepage documentation cards and use-case pages
- add both migration pages to the sitemap

## Validation
- `git diff --check`
- HTML relative link check for changed pages
- `sitemap.xml` parses as XML and includes the new URLs
