### PR TITLE
[codex] Link migration benchmark example on GitHub Pages

### DIFF
--- a/migration.html
+++ b/migration.html
@@ -23,7 +23,7 @@
 <ul><li>Private or self-hosted transcription where audio should stay inside your environment.</li><li>High-throughput long-form transcription for meetings, archives, media, or call recordings.</li><li>Speaker-aware transcripts with VAD, punctuation, timestamps, and diarization in one pipeline.</li><li>An OpenAI-compatible audio endpoint for agents, Dify, LangChain, AutoGen, or internal apps.</li><li>Streaming ASR or live captions with WebSocket/runtime service support.</li><li>CPU-viable smoke tests before moving to GPU deployment.</li></ul>
 <p>Stay on your current pipeline if you need a fully managed service, a vendor SLA, or a language/domain that your own benchmark shows FunASR does not handle well enough yet.</p></section>
 <section id="plan"><h2>Fast evaluation plan</h2>
-<ol><li>Pick 20-50 representative audio files, including short clips, long recordings, noisy samples, different speakers, and target languages or dialects.</li><li>Run your current Whisper or cloud ASR pipeline exactly as you use it in production. Save transcripts, latency, cost, and failure cases.</li><li>Run FunASR locally with the tutorial, then choose a deployment path from the <a href="deployment-matrix.html">deployment matrix</a>.</li><li>Compare output with human review or your normal WER/CER process. Do not compare only one clean demo file.</li><li>Run the OpenAI-compatible API smoke test if your application already uses OpenAI-style clients.</li><li>Record warmup time, model download time, device, GPU/CPU type, batch size, and audio duration separately from steady-state throughput.</li></ol></section>
+<ol><li>Pick 20-50 representative audio files, including short clips, long recordings, noisy samples, different speakers, and target languages or dialects.</li><li>Run your current Whisper or cloud ASR pipeline exactly as you use it in production. Save transcripts, latency, cost, and failure cases.</li><li>Run FunASR locally with the tutorial, then choose a deployment path from the <a href="deployment-matrix.html">deployment matrix</a>.</li><li>Compare output with human review or your normal WER/CER process. Do not compare only one clean demo file.</li><li>Run the <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">migration benchmark example</a> to write JSONL and Markdown summaries for your own audio folder.</li><li>Run the OpenAI-compatible API smoke test if your application already uses OpenAI-style clients.</li><li>Record warmup time, model download time, device, GPU/CPU type, batch size, and audio duration separately from steady-state throughput.</li></ol></section>
 <section id="mapping"><h2>Feature mapping</h2>
 <table><tr><th>Existing workflow</th><th>FunASR path</th><th>What to validate</th></tr>
 <tr><td>Whisper file transcription</td><td><a href="tutorial.html">Tutorial</a> with SenseVoice, Paraformer, or Fun-ASR-Nano</td><td>Transcript quality, timestamps, speed, model download, CPU/GPU behavior.</td></tr>
@@ -34,7 +34,7 @@
 <tr><td>Subtitle generation</td><td><a href="agent.html#subtitle">Subtitle generator</a></td><td>Segment readability, line length, speaker labels, SRT/VTT compatibility.</td></tr>
 <tr><td>Offline archive processing</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">Batch ASR example</a></td><td>Manifest handling, retries, progress logs, throughput, failed-file recovery.</td></tr></table></section>
 <section id="compare"><h2>Minimal local comparison</h2>
-<p>Install FunASR and run the same file you used for your baseline:</p>
+<p>Install FunASR and run the same file you used for your baseline. For a folder-level evaluation, use <a href="https://github.com/modelscope/FunASR/blob/main/examples/migration/benchmark_funasr.py">benchmark_funasr.py</a> to generate <code>results.jsonl</code> and <code>summary.md</code>.</p>
 <pre><code>pip install funasr</code></pre>
 <pre><code>from funasr import AutoModel
 
@@ -46,6 +46,14 @@ model = AutoModel(
 )
 result = model.generate(input="sample.wav")
 print(result)</code></pre>
+<p>For a repeatable folder benchmark:</p>
+<pre><code>python examples/migration/benchmark_funasr.py \
+  --input /path/to/audio_samples \
+  --recursive \
+  --model iic/SenseVoiceSmall \
+  --device cuda \
+  --spk-model cam++ \
+  --output-dir outputs/funasr_migration_eval</code></pre>
 <p>For an API-style comparison:</p>
 <pre><code>pip install funasr fastapi uvicorn python-multipart
 funasr-server --model sensevoice --device cuda

--- a/use-cases.html
+++ b/use-cases.html
@@ -23,7 +23,7 @@
 <table><tr><th>Goal</th><th>Start here</th><th>Why it matters</th></tr>
 <tr><td>Transcribe one file locally</td><td><a href="tutorial.html">Tutorial</a></td><td>Verify install and model download in minutes.</td></tr>
 <tr><td>Compare accuracy and speed</td><td><a href="benchmark.html">Benchmark report</a></td><td>Review long-audio speed and CER before choosing a model.</td></tr>
-<tr><td>Migrate from Whisper/cloud ASR</td><td><a href="migration.html">Migration guide</a></td><td>Map existing pipelines to FunASR, benchmark representative audio, and plan a safe rollout.</td></tr>
+<tr><td>Migrate from Whisper/cloud ASR</td><td><a href="migration.html">Migration guide</a> · <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">Benchmark example</a></td><td>Map existing pipelines to FunASR, benchmark representative audio, and plan a safe rollout.</td></tr>
 <tr><td>Build a private speech API</td><td><a href="agent.html#server">OpenAI-compatible API</a></td><td>Reuse OpenAI-style clients without sending audio to a cloud ASR provider.</td></tr>
 <tr><td>Add speech input to agents</td><td><a href="agent.html#mcp">MCP server</a></td><td>Connect local ASR to Claude, Cursor, desktop tools, and internal assistants.</td></tr>
 <tr><td>Choose a deployment path</td><td><a href="deployment-matrix.html">Deployment matrix</a></td><td>Compare Python API, OpenAI API, Docker Compose, WebSocket, vLLM, MCP, subtitles, batch jobs, and Triton.</td></tr>

--- a/zh/migration.html
+++ b/zh/migration.html
@@ -23,7 +23,7 @@
 <ul><li>音频需要留在私有环境内，不能上传到外部云服务。</li><li>会议、归档、媒体、客服录音等长音频需要高吞吐转写。</li><li>希望一条流水线内完成 VAD、标点、时间戳和说话人分离。</li><li>需要 OpenAI 兼容音频接口，接入 Agent、Dify、LangChain、AutoGen 或内部应用。</li><li>需要 WebSocket/runtime 服务支撑流式识别或实时字幕。</li><li>希望先用 CPU 做可复现 smoke test，再迁移到 GPU 服务。</li></ul>
 <p>如果你更需要完全托管服务、厂商 SLA，或你的自有评测显示目标语言/领域还不够好，可以暂时保留现有方案。</p></section>
 <section id="plan"><h2>快速评估计划</h2>
-<ol><li>选择 20-50 条有代表性的音频，覆盖短音频、长录音、噪声、多说话人、目标语言和方言。</li><li>按生产方式运行当前 Whisper 或云端 ASR，保存转写结果、延迟、成本和失败样例。</li><li>用教程跑 FunASR，再根据 <a href="deployment-matrix.html">部署选型表</a> 选择服务路径。</li><li>用人工审阅或现有 WER/CER 流程比较结果，不要只看一个干净 demo 音频。</li><li>如果应用已经使用 OpenAI 风格客户端，运行 OpenAI 兼容 API smoke test。</li><li>分开记录 warmup、模型下载、设备、GPU/CPU 型号、batch size、音频时长和稳定吞吐。</li></ol></section>
+<ol><li>选择 20-50 条有代表性的音频，覆盖短音频、长录音、噪声、多说话人、目标语言和方言。</li><li>按生产方式运行当前 Whisper 或云端 ASR，保存转写结果、延迟、成本和失败样例。</li><li>用教程跑 FunASR，再根据 <a href="deployment-matrix.html">部署选型表</a> 选择服务路径。</li><li>用人工审阅或现有 WER/CER 流程比较结果，不要只看一个干净 demo 音频。</li><li>运行 <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">迁移评测示例</a>，为自己的音频目录生成 JSONL 和 Markdown 汇总。</li><li>如果应用已经使用 OpenAI 风格客户端，运行 OpenAI 兼容 API smoke test。</li><li>分开记录 warmup、模型下载、设备、GPU/CPU 型号、batch size、音频时长和稳定吞吐。</li></ol></section>
 <section id="mapping"><h2>功能映射</h2>
 <table><tr><th>现有流程</th><th>FunASR 路径</th><th>需要验证什么</th></tr>
 <tr><td>Whisper 文件转写</td><td>使用 SenseVoice、Paraformer 或 Fun-ASR-Nano 的 <a href="tutorial.html">教程</a></td><td>转写质量、时间戳、速度、模型下载、CPU/GPU 行为。</td></tr>
@@ -34,7 +34,7 @@
 <tr><td>字幕生成</td><td><a href="agent.html#subtitle">字幕生成器</a></td><td>分段可读性、行长、说话人标签、SRT/VTT 兼容性。</td></tr>
 <tr><td>离线归档处理</td><td><a href="https://github.com/modelscope/FunASR/blob/main/examples/batch_asr_improved.py">批处理示例</a></td><td>manifest、重试、进度日志、吞吐、失败文件恢复。</td></tr></table></section>
 <section id="compare"><h2>最小本地对比</h2>
-<p>安装 FunASR，并用你基线评测里的同一条音频运行：</p>
+<p>安装 FunASR，并用你基线评测里的同一条音频运行。若要评测整个目录，可以使用 <a href="https://github.com/modelscope/FunASR/blob/main/examples/migration/benchmark_funasr.py">benchmark_funasr.py</a> 生成 <code>results.jsonl</code> 和 <code>summary.md</code>。</p>
 <pre><code>pip install funasr</code></pre>
 <pre><code>from funasr import AutoModel
 
@@ -46,6 +46,14 @@ model = AutoModel(
 )
 result = model.generate(input="sample.wav")
 print(result)</code></pre>
+<p>若要做可复现的目录级评测：</p>
+<pre><code>python examples/migration/benchmark_funasr.py \
+  --input /path/to/audio_samples \
+  --recursive \
+  --model iic/SenseVoiceSmall \
+  --device cuda \
+  --spk-model cam++ \
+  --output-dir outputs/funasr_migration_eval</code></pre>
 <p>如果要按 API 服务方式对比：</p>
 <pre><code>pip install funasr fastapi uvicorn python-multipart
 funasr-server --model sensevoice --device cuda

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -23,7 +23,7 @@
 <table><tr><th>目标</th><th>从这里开始</th><th>为什么重要</th></tr>
 <tr><td>本地转写一个文件</td><td><a href="tutorial.html">使用教程</a></td><td>几分钟内验证安装、模型下载和首次推理。</td></tr>
 <tr><td>对比准确率和速度</td><td><a href="benchmark.html">性能评测报告</a></td><td>选型前查看长音频速度和 CER。</td></tr>
-<tr><td>从 Whisper/云端 ASR 迁移</td><td><a href="migration.html">迁移指南</a></td><td>将现有流水线映射到 FunASR，用代表性音频评测并规划安全上线。</td></tr>
+<tr><td>从 Whisper/云端 ASR 迁移</td><td><a href="migration.html">迁移指南</a> · <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">评测示例</a></td><td>将现有流水线映射到 FunASR，用代表性音频评测并规划安全上线。</td></tr>
 <tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a></td><td>复用 OpenAI 风格客户端，音频不出内网。</td></tr>
 <tr><td>给 Agent 增加语音输入</td><td><a href="agent.html#mcp">MCP 服务</a></td><td>将本地 ASR 接入 Claude、Cursor、桌面工具和内部助手。</td></tr>
 <tr><td>选择部署路径</td><td><a href="deployment-matrix.html">部署选型表</a></td><td>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、字幕、批处理和 Triton。</td></tr>


### PR DESCRIPTION
## Summary
- link the newly added migration benchmark example from English and Chinese migration pages
- add repeatable folder-level benchmark commands to the website migration pages
- add benchmark example links to English and Chinese use-case route tables

## Validation
- `git diff --check`
- HTML relative link check for changed pages
- checked command snippets remain multi-line and copyable
