### PR TITLE
[codex] Link workflow recipes on GitHub Pages

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -13,7 +13,7 @@
 <div class="content"><div class="container narrow">
 <h1>Agent Integration</h1>
 <p>Run speech recognition as local infrastructure for agents, products, and desktop workflows: OpenAI-compatible API, MCP server, voice input, and subtitle generation.</p>
-<div class="toc-grid"><a href="#server">OpenAI API</a><a href="#sdk">SDK & curl</a><a href="#mcp">MCP Server</a><a href="#voice">Voice Input</a><a href="#subtitle">Subtitle Generator</a></div>
+<div class="toc-grid"><a href="#server">OpenAI API</a><a href="#sdk">SDK & curl</a><a href="#workflows">Workflows</a><a href="#mcp">MCP Server</a><a href="#voice">Voice Input</a><a href="#subtitle">Subtitle Generator</a></div>
 <section id="server"><h2>OpenAI-Compatible API Server</h2>
 <p><code>funasr-server</code> exposes <code>/v1/audio/transcriptions</code>, <code>/v1/models</code>, <code>/health</code>, and Swagger docs at <code>/docs</code>. It works with frameworks that already know the OpenAI audio API.</p>
 <pre><code>pip install funasr fastapi uvicorn python-multipart
@@ -44,6 +44,7 @@ print(verbose.segments)</code></pre>
   -F model=sensevoice \
   -F response_format=verbose_json</code></pre>
 </section>
+<section id="workflows"><h2>Dify, n8n, and workflow engines</h2><p>For low-code tools that call HTTP nodes or webhook workers, use the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">workflow recipes</a>. They cover multipart upload settings, Dify custom tools, n8n binary file fields, audio URL workers, timeouts, and production guardrails.</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Open workflow recipes</a></p></section>
 <section id="mcp"><h2>MCP Server</h2>
 <p>The MCP server gives Claude Code, Claude Desktop, Cursor, Windsurf, and other MCP clients a local <code>transcribe_audio</code> tool.</p>
 <pre><code>pip install funasr

--- a/deployment-matrix.html
+++ b/deployment-matrix.html
@@ -22,7 +22,7 @@
 <section id="matrix"><h2>Quick decision table</h2>
 <table><tr><th>Path</th><th>Best for</th><th>Start here</th><th>Operational notes</th></tr>
 <tr><td>Python API</td><td>Notebooks, offline jobs, first model evaluation</td><td><a href="tutorial.html">Tutorial</a></td><td>Lowest ceremony; caller owns batching, retries, and files.</td></tr>
-<tr><td>OpenAI-compatible API</td><td>Private speech API, agents, Dify/LangChain/AutoGen-style clients</td><td><a href="agent.html#server">OpenAI API</a></td><td>Easiest integration for apps that already support OpenAI audio APIs.</td></tr>
+<tr><td>OpenAI-compatible API</td><td>Private speech API, agents, Dify/LangChain/AutoGen/n8n-style clients</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Workflow recipes</a></td><td>Easiest integration for apps and workflow engines that already support OpenAI audio APIs or multipart HTTP nodes.</td></tr>
 <tr><td>Docker Compose API</td><td>Reproducible local smoke test or small internal service</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker docs</a></td><td>CPU by default; adapt the image before using CUDA in containers.</td></tr>
 <tr><td>Runtime WebSocket service</td><td>Live captions, meetings, call-center streams</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime docs</a></td><td>Use when partial results, endpointing, or long-lived audio streams matter.</td></tr>
 <tr><td>vLLM acceleration</td><td>Higher-throughput LLM-based ASR with Fun-ASR-Nano</td><td><a href="vllm.html">vLLM guide</a></td><td>Use for LLM decoder throughput; does not apply to non-autoregressive Paraformer.</td></tr>
@@ -33,7 +33,7 @@
 </section>
 <section id="choices"><h2>Common choices</h2>
 <div class="grid-2"><div class="card"><h3>Try FunASR in five minutes</h3><p>Use the Python API from the tutorial. It is the shortest route for validating installation, model download, device selection, and output shape.</p></div>
-<div class="card"><h3>Replace cloud transcription locally</h3><p>Use the OpenAI-compatible API. Start with <code>sensevoice</code>, run the smoke test, then connect existing SDK or HTTP clients using the client recipes.</p></div></div>
+<div class="card"><h3>Replace cloud transcription locally</h3><p>Use the OpenAI-compatible API. Start with <code>sensevoice</code>, run the smoke test, then connect existing SDK or HTTP clients using the client recipes. For Dify, n8n, or webhook workers, use the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">workflow recipes</a>.</p></div></div>
 <div class="grid-2"><div class="card"><h3>Run a repeatable container demo</h3><pre><code>cd examples/openai_api
 cp .env.example .env
 docker compose up --build</code></pre><p>Keep CPU mode until you have a CUDA-capable PyTorch/FunASR image.</p></div>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
             </div>
             <div class="section-cta">
                 <a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api" class="btn btn-primary">OpenAI API example</a>
+                <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md" class="btn btn-primary">Workflow recipes</a>
                 <a href="agent.html" class="btn btn-primary">Agent integration</a>
             </div>
         </div>
@@ -160,7 +161,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
                 <a class="doc-card" href="agent.html">
                     <span class="doc-kicker">Integrate</span>
                     <h3>Agent & API</h3>
-                    <p>Expose FunASR as an OpenAI-compatible endpoint, MCP tool, voice input, or subtitle generator.</p>
+                    <p>Expose FunASR as an OpenAI-compatible endpoint, low-code workflow node, MCP tool, voice input, or subtitle generator.</p>
                 </a>
                 <a class="doc-card" href="benchmark.html">
                     <span class="doc-kicker">Measure</span>

--- a/use-cases.html
+++ b/use-cases.html
@@ -24,7 +24,7 @@
 <tr><td>Transcribe one file locally</td><td><a href="tutorial.html">Tutorial</a></td><td>Verify install and model download in minutes.</td></tr>
 <tr><td>Compare accuracy and speed</td><td><a href="benchmark.html">Benchmark report</a></td><td>Review long-audio speed and CER before choosing a model.</td></tr>
 <tr><td>Migrate from Whisper/cloud ASR</td><td><a href="migration.html">Migration guide</a> · <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">Benchmark example</a></td><td>Map existing pipelines to FunASR, benchmark representative audio, and plan a safe rollout.</td></tr>
-<tr><td>Build a private speech API</td><td><a href="agent.html#server">OpenAI-compatible API</a></td><td>Reuse OpenAI-style clients without sending audio to a cloud ASR provider.</td></tr>
+<tr><td>Build a private speech API</td><td><a href="agent.html#server">OpenAI-compatible API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Workflow recipes</a></td><td>Reuse OpenAI-style clients, Dify, n8n, and HTTP workflow nodes without sending audio to a cloud ASR provider.</td></tr>
 <tr><td>Add speech input to agents</td><td><a href="agent.html#mcp">MCP server</a></td><td>Connect local ASR to Claude, Cursor, desktop tools, and internal assistants.</td></tr>
 <tr><td>Choose a deployment path</td><td><a href="deployment-matrix.html">Deployment matrix</a></td><td>Compare Python API, OpenAI API, Docker Compose, WebSocket, vLLM, MCP, subtitles, batch jobs, and Triton.</td></tr>
 <tr><td>Serve streaming ASR</td><td><a href="tutorial.html#real-time-speech-recognition">Realtime examples</a></td><td>Handle live captioning, meetings, and call-center style workloads.</td></tr>

--- a/zh/agent.html
+++ b/zh/agent.html
@@ -13,7 +13,7 @@
 <div class="content"><div class="container narrow">
 <h1>Agent 集成</h1>
 <p>把语音识别作为本地基础设施接入 Agent、产品和桌面工作流：OpenAI 兼容 API、MCP 服务、语音输入和字幕生成。</p>
-<div class="toc-grid"><a href="#server">OpenAI API</a><a href="#sdk">SDK 与 curl</a><a href="#mcp">MCP 服务</a><a href="#voice">语音输入</a><a href="#subtitle">字幕生成</a></div>
+<div class="toc-grid"><a href="#server">OpenAI API</a><a href="#sdk">SDK 与 curl</a><a href="#workflows">工作流</a><a href="#mcp">MCP 服务</a><a href="#voice">语音输入</a><a href="#subtitle">字幕生成</a></div>
 <section id="server"><h2>OpenAI 兼容 API 服务</h2>
 <p><code>funasr-server</code> 提供 <code>/v1/audio/transcriptions</code>、<code>/v1/models</code>、<code>/health</code>，并在 <code>/docs</code> 提供 Swagger 文档。任何支持 OpenAI audio API 的框架都可以接入。</p>
 <pre><code>pip install funasr fastapi uvicorn python-multipart
@@ -44,6 +44,7 @@ print(verbose.segments)</code></pre>
   -F model=sensevoice \
   -F response_format=verbose_json</code></pre>
 </section>
+<section id="workflows"><h2>Dify、n8n 与工作流引擎</h2><p>低代码工具如果通过 HTTP 节点或 webhook worker 调用语音 API，请参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a>。其中覆盖 multipart 上传配置、Dify custom tool、n8n binary file 字段、音频 URL worker、超时设置和生产防护。</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">打开工作流配方</a></p></section>
 <section id="mcp"><h2>MCP 服务</h2>
 <p>MCP 服务为 Claude Code、Claude Desktop、Cursor、Windsurf 和其他 MCP 客户端提供本地 <code>transcribe_audio</code> 工具。</p>
 <pre><code>pip install funasr

--- a/zh/deployment-matrix.html
+++ b/zh/deployment-matrix.html
@@ -22,7 +22,7 @@
 <section id="matrix"><h2>快速决策表</h2>
 <table><tr><th>路径</th><th>适合场景</th><th>从这里开始</th><th>运维提示</th></tr>
 <tr><td>Python API</td><td>Notebook、离线任务、首次模型评测</td><td><a href="tutorial.html">使用教程</a></td><td>最简单；调用方自己负责批处理、重试和文件管理。</td></tr>
-<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen 风格客户端</td><td><a href="agent.html#server">OpenAI API</a></td><td>已支持 OpenAI audio API 的应用最容易接入。</td></tr>
+<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen/n8n 风格客户端</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a></td><td>已支持 OpenAI audio API 或 multipart HTTP 节点的应用和工作流引擎最容易接入。</td></tr>
 <tr><td>Docker Compose API</td><td>可复现本地 smoke test 或小型内部服务</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker 文档</a></td><td>默认 CPU；容器里使用 CUDA 前需要先适配 CUDA-capable 镜像。</td></tr>
 <tr><td>Runtime WebSocket 服务</td><td>实时字幕、会议、客服流式音频</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime 文档</a></td><td>需要中间结果、断句或长连接音频流时选择。</td></tr>
 <tr><td>vLLM 加速</td><td>Fun-ASR-Nano 等 LLM-based ASR 高吞吐</td><td><a href="vllm.html">vLLM 指南</a></td><td>适合 LLM 解码吞吐；不适用于非自回归 Paraformer。</td></tr>
@@ -33,7 +33,7 @@
 </section>
 <section id="choices"><h2>常见选择</h2>
 <div class="grid-2"><div class="card"><h3>五分钟内试跑 FunASR</h3><p>使用教程里的 Python API。它是验证安装、模型下载、设备选择和基础输出格式的最短路径。</p></div>
-<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。</p></div></div>
+<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。Dify、n8n 或 webhook worker 可参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a>。</p></div></div>
 <div class="grid-2"><div class="card"><h3>可复现容器 demo</h3><pre><code>cd examples/openai_api
 cp .env.example .env
 docker compose up --build</code></pre><p>在没有 CUDA-capable PyTorch/FunASR 镜像前保持 CPU 模式。</p></div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -111,6 +111,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
             </div>
             <div class="section-cta">
                 <a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api" class="btn btn-primary">OpenAI API 示例</a>
+                <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md" class="btn btn-primary">工作流配方</a>
                 <a href="agent.html" class="btn btn-primary">Agent 集成</a>
             </div>
         </div>
@@ -160,7 +161,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
                 <a class="doc-card" href="agent.html">
                     <span class="doc-kicker">集成</span>
                     <h3>Agent 与 API</h3>
-                    <p>将 FunASR 暴露为 OpenAI 兼容接口、MCP 工具、语音输入法或字幕生成器。</p>
+                    <p>将 FunASR 暴露为 OpenAI 兼容接口、低代码工作流节点、MCP 工具、语音输入法或字幕生成器。</p>
                 </a>
                 <a class="doc-card" href="benchmark.html">
                     <span class="doc-kicker">评测</span>

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -24,7 +24,7 @@
 <tr><td>本地转写一个文件</td><td><a href="tutorial.html">使用教程</a></td><td>几分钟内验证安装、模型下载和首次推理。</td></tr>
 <tr><td>对比准确率和速度</td><td><a href="benchmark.html">性能评测报告</a></td><td>选型前查看长音频速度和 CER。</td></tr>
 <tr><td>从 Whisper/云端 ASR 迁移</td><td><a href="migration.html">迁移指南</a> · <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">评测示例</a></td><td>将现有流水线映射到 FunASR，用代表性音频评测并规划安全上线。</td></tr>
-<tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a></td><td>复用 OpenAI 风格客户端，音频不出内网。</td></tr>
+<tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a></td><td>复用 OpenAI 风格客户端、Dify、n8n 和 HTTP 工作流节点，音频不出内网。</td></tr>
 <tr><td>给 Agent 增加语音输入</td><td><a href="agent.html#mcp">MCP 服务</a></td><td>将本地 ASR 接入 Claude、Cursor、桌面工具和内部助手。</td></tr>
 <tr><td>选择部署路径</td><td><a href="deployment-matrix.html">部署选型表</a></td><td>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、字幕、批处理和 Triton。</td></tr>
 <tr><td>部署流式 ASR</td><td><a href="tutorial.html#real-time-speech-recognition">实时示例</a></td><td>面向实时字幕、会议和客服类低延迟场景。</td></tr>


### PR DESCRIPTION
## Summary
- link the new OpenAI API workflow recipes from the English and Chinese homepage API sections
- add Dify/n8n workflow links to Agent, Use Cases, and Deployment Matrix pages
- keep the website pointing to the canonical `examples/openai_api/WORKFLOWS.md` in main

## Validation
- `git diff --check`
- HTML relative link and local anchor check for changed pages
- verified changed pages contain `WORKFLOWS.md` links
