### PR TITLE
[codex] Link Chinese website to Chinese workflow recipes

### DIFF
--- a/zh/agent.html
+++ b/zh/agent.html
@@ -44,7 +44,7 @@ print(verbose.segments)</code></pre>
   -F model=sensevoice \
   -F response_format=verbose_json</code></pre>
 </section>
-<section id="workflows"><h2>Dify、n8n 与工作流引擎</h2><p>低代码工具如果通过 HTTP 节点或 webhook worker 调用语音 API，请参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a>。其中覆盖 multipart 上传配置、Dify custom tool、n8n binary file 字段、音频 URL worker、超时设置和生产防护。</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">打开工作流配方</a></p></section>
+<section id="workflows"><h2>Dify、n8n 与工作流引擎</h2><p>低代码工具如果通过 HTTP 节点或 webhook worker 调用语音 API，请参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a>。其中覆盖 multipart 上传配置、Dify custom tool、n8n binary file 字段、音频 URL worker、超时设置和生产防护。</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">打开工作流配方</a></p></section>
 <section id="mcp"><h2>MCP 服务</h2>
 <p>MCP 服务为 Claude Code、Claude Desktop、Cursor、Windsurf 和其他 MCP 客户端提供本地 <code>transcribe_audio</code> 工具。</p>
 <pre><code>pip install funasr

--- a/zh/deployment-matrix.html
+++ b/zh/deployment-matrix.html
@@ -22,7 +22,7 @@
 <section id="matrix"><h2>快速决策表</h2>
 <table><tr><th>路径</th><th>适合场景</th><th>从这里开始</th><th>运维提示</th></tr>
 <tr><td>Python API</td><td>Notebook、离线任务、首次模型评测</td><td><a href="tutorial.html">使用教程</a></td><td>最简单；调用方自己负责批处理、重试和文件管理。</td></tr>
-<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen/n8n 风格客户端</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a></td><td>已支持 OpenAI audio API 或 multipart HTTP 节点的应用和工作流引擎最容易接入。</td></tr>
+<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen/n8n 风格客户端</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a></td><td>已支持 OpenAI audio API 或 multipart HTTP 节点的应用和工作流引擎最容易接入。</td></tr>
 <tr><td>Docker Compose API</td><td>可复现本地 smoke test 或小型内部服务</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker 文档</a></td><td>默认 CPU；容器里使用 CUDA 前需要先适配 CUDA-capable 镜像。</td></tr>
 <tr><td>Runtime WebSocket 服务</td><td>实时字幕、会议、客服流式音频</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime 文档</a></td><td>需要中间结果、断句或长连接音频流时选择。</td></tr>
 <tr><td>vLLM 加速</td><td>Fun-ASR-Nano 等 LLM-based ASR 高吞吐</td><td><a href="vllm.html">vLLM 指南</a></td><td>适合 LLM 解码吞吐；不适用于非自回归 Paraformer。</td></tr>
@@ -33,7 +33,7 @@
 </section>
 <section id="choices"><h2>常见选择</h2>
 <div class="grid-2"><div class="card"><h3>五分钟内试跑 FunASR</h3><p>使用教程里的 Python API。它是验证安装、模型下载、设备选择和基础输出格式的最短路径。</p></div>
-<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。Dify、n8n 或 webhook worker 可参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a>。</p></div></div>
+<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。Dify、n8n 或 webhook worker 可参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a>。</p></div></div>
 <div class="grid-2"><div class="card"><h3>可复现容器 demo</h3><pre><code>cd examples/openai_api
 cp .env.example .env
 docker compose up --build</code></pre><p>在没有 CUDA-capable PyTorch/FunASR 镜像前保持 CPU 模式。</p></div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -111,7 +111,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
             </div>
             <div class="section-cta">
                 <a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api" class="btn btn-primary">OpenAI API 示例</a>
-                <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md" class="btn btn-primary">工作流配方</a>
+                <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md" class="btn btn-primary">工作流配方</a>
                 <a href="agent.html" class="btn btn-primary">Agent 集成</a>
             </div>
         </div>

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -24,7 +24,7 @@
 <tr><td>本地转写一个文件</td><td><a href="tutorial.html">使用教程</a></td><td>几分钟内验证安装、模型下载和首次推理。</td></tr>
 <tr><td>对比准确率和速度</td><td><a href="benchmark.html">性能评测报告</a></td><td>选型前查看长音频速度和 CER。</td></tr>
 <tr><td>从 Whisper/云端 ASR 迁移</td><td><a href="migration.html">迁移指南</a> · <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">评测示例</a></td><td>将现有流水线映射到 FunASR，用代表性音频评测并规划安全上线。</td></tr>
-<tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">工作流配方</a></td><td>复用 OpenAI 风格客户端、Dify、n8n 和 HTTP 工作流节点，音频不出内网。</td></tr>
+<tr><td>搭建私有语音 API</td><td><a href="agent.html#server">OpenAI 兼容 API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a></td><td>复用 OpenAI 风格客户端、Dify、n8n 和 HTTP 工作流节点，音频不出内网。</td></tr>
 <tr><td>给 Agent 增加语音输入</td><td><a href="agent.html#mcp">MCP 服务</a></td><td>将本地 ASR 接入 Claude、Cursor、桌面工具和内部助手。</td></tr>
 <tr><td>选择部署路径</td><td><a href="deployment-matrix.html">部署选型表</a></td><td>对比 Python API、OpenAI API、Docker Compose、WebSocket、vLLM、MCP、字幕、批处理和 Triton。</td></tr>
 <tr><td>部署流式 ASR</td><td><a href="tutorial.html#real-time-speech-recognition">实时示例</a></td><td>面向实时字幕、会议和客服类低延迟场景。</td></tr>


### PR DESCRIPTION
## Summary
- point Chinese GitHub Pages workflow links to WORKFLOWS_zh.md
- keep English website pages on the English workflow guide

## Validation
- git diff --check
- verified zh/*.html no longer links examples/openai_api/WORKFLOWS.md