### PR TITLE
[codex] Add homepage SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,18 @@
     <meta property="og:description" content="170x realtime, 50+ languages, speaker diarization, vLLM acceleration, and an OpenAI-compatible local speech API.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://modelscope.github.io/FunASR/">
+    <link rel="canonical" href="https://modelscope.github.io/FunASR/">
+    <link rel="alternate" hreflang="en" href="https://modelscope.github.io/FunASR/">
+    <link rel="alternate" hreflang="zh" href="https://modelscope.github.io/FunASR/zh/">
+    <link rel="alternate" hreflang="ja" href="https://modelscope.github.io/FunASR/ja/">
+    <link rel="alternate" hreflang="x-default" href="https://modelscope.github.io/FunASR/">
+    <meta property="og:site_name" content="FunASR">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="FunASR - Open-source speech understanding toolkit">
+    <meta name="twitter:description" content="170x realtime, 50+ languages, speaker diarization, vLLM acceleration, and an OpenAI-compatible local speech API.">
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"FunASR","description":"FunASR is an open-source speech recognition and speech understanding toolkit with ASR, VAD, punctuation, speaker diarization, emotion detection, vLLM acceleration, and OpenAI-compatible API examples.","url":"https://modelscope.github.io/FunASR/","codeRepository":"https://github.com/modelscope/FunASR","programmingLanguage":"Python","license":"https://github.com/modelscope/FunASR/blob/main/LICENSE","applicationCategory":"Speech recognition toolkit","operatingSystem":["Linux","macOS","Windows"]}
+    </script>
     <title>FunASR - End-to-End Speech Recognition Toolkit</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">

--- a/ja/index.html
+++ b/ja/index.html
@@ -3,6 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="FunASR は産業グレードのオープンソース音声認識ツールキットで、GPU 170x リアルタイム、50以上の言語、話者分離、感情検出、OpenAI互換API、vLLM高速化、Agent連携をサポートします。">
+    <meta property="og:title" content="FunASR - オープンソース音声理解ツールキット">
+    <meta property="og:description" content="GPU 170x リアルタイム、50以上の言語、話者分離、vLLM高速化、ローカルOpenAI互換音声API。">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://modelscope.github.io/FunASR/ja/">
+    <link rel="canonical" href="https://modelscope.github.io/FunASR/ja/">
+    <link rel="alternate" hreflang="en" href="https://modelscope.github.io/FunASR/">
+    <link rel="alternate" hreflang="zh" href="https://modelscope.github.io/FunASR/zh/">
+    <link rel="alternate" hreflang="ja" href="https://modelscope.github.io/FunASR/ja/">
+    <link rel="alternate" hreflang="x-default" href="https://modelscope.github.io/FunASR/">
+    <meta property="og:site_name" content="FunASR">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="FunASR - オープンソース音声理解ツールキット">
+    <meta name="twitter:description" content="GPU 170x リアルタイム、50以上の言語、話者分離、vLLM高速化、ローカルOpenAI互換音声APIを備えた音声認識ツールキット。">
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"FunASR","description":"FunASRは、ASR、VAD、句読点復元、話者分離、感情検出、vLLM高速化、OpenAI互換API例を備えたオープンソース音声認識・音声理解ツールキットです。","url":"https://modelscope.github.io/FunASR/ja/","codeRepository":"https://github.com/modelscope/FunASR","programmingLanguage":"Python","license":"https://github.com/modelscope/FunASR/blob/main/LICENSE","applicationCategory":"Speech recognition toolkit","operatingSystem":["Linux","macOS","Windows"]}
+    </script>
     <title>FunASR - エンドツーエンド音声認識ツールキット</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">

--- a/zh/index.html
+++ b/zh/index.html
@@ -8,6 +8,18 @@
     <meta property="og:description" content="GPU 170x 实时、50+ 语言、说话人分离、vLLM 加速和本地 OpenAI 兼容语音 API。">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://modelscope.github.io/FunASR/zh/">
+    <link rel="canonical" href="https://modelscope.github.io/FunASR/zh/">
+    <link rel="alternate" hreflang="en" href="https://modelscope.github.io/FunASR/">
+    <link rel="alternate" hreflang="zh" href="https://modelscope.github.io/FunASR/zh/">
+    <link rel="alternate" hreflang="ja" href="https://modelscope.github.io/FunASR/ja/">
+    <link rel="alternate" hreflang="x-default" href="https://modelscope.github.io/FunASR/">
+    <meta property="og:site_name" content="FunASR">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="FunASR - 开源语音理解工具包">
+    <meta name="twitter:description" content="GPU 170x 实时、50+ 语言、说话人分离、vLLM 加速和本地 OpenAI 兼容语音 API。">
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"FunASR","description":"FunASR 是开源语音识别与语音理解工具包，支持 ASR、VAD、标点恢复、说话人分离、情感检测、vLLM 加速和 OpenAI 兼容 API 示例。","url":"https://modelscope.github.io/FunASR/zh/","codeRepository":"https://github.com/modelscope/FunASR","programmingLanguage":"Python","license":"https://github.com/modelscope/FunASR/blob/main/LICENSE","applicationCategory":"Speech recognition toolkit","operatingSystem":["Linux","macOS","Windows"]}
+    </script>
     <title>FunASR - 端到端语音识别工具包</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">


### PR DESCRIPTION
## Summary
- add canonical and hreflang alternate links to English, Chinese, and Japanese homepages
- add Twitter summary cards and og:site_name metadata
- add SoftwareSourceCode JSON-LD for homepage discovery

## Validation
- git diff --check
- parsed all three homepage heads and verified canonical, alternate, Twitter, og:site_name, and JSON-LD tags
- NFC-normalized Japanese SEO copy