### PR TITLE
[codex] Add SEO metadata to documentation pages

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Run speech recognition as local infrastructure for agents, products, and desktop workflows: OpenAI-compatible API, MCP server, voice input, and subtitle generation.">
+<meta property="og:title" content="FunASR Agent Integration">
+<meta property="og:description" content="Run speech recognition as local infrastructure for agents, products, and desktop workflows: OpenAI-compatible API, MCP server, voice input, and subtitle generation.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/agent.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/agent.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Agent Integration">
+<meta name="twitter:description" content="Run speech recognition as local infrastructure for agents, products, and desktop workflows: OpenAI-compatible API, MCP server, voice input, and subtitle generation.">
 <title>FunASR Agent Integration</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/api.html
+++ b/api.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Browse the generated FunASR Python API reference with links to the latest GitHub source code for models, datasets, training, inference, and utilities.">
+<meta property="og:title" content="FunASR API">
+<meta property="og:description" content="Browse the generated FunASR Python API reference with links to the latest GitHub source code for models, datasets, training, inference, and utilities.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/api.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/api.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR API">
+<meta name="twitter:description" content="Browse the generated FunASR Python API reference with links to the latest GitHub source code for models, datasets, training, inference, and utilities.">
 <title>FunASR API</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/benchmark.html
+++ b/benchmark.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Speed and accuracy measurements for long-form ASR workloads. The headline result: FunASR CPU inference can be faster than Whisper GPU inference for production transcription...">
+<meta property="og:title" content="FunASR Benchmark">
+<meta property="og:description" content="Speed and accuracy measurements for long-form ASR workloads. The headline result: FunASR CPU inference can be faster than Whisper GPU inference for production transcription...">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/benchmark.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/benchmark.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Benchmark">
+<meta name="twitter:description" content="Speed and accuracy measurements for long-form ASR workloads. The headline result: FunASR CPU inference can be faster than Whisper GPU inference for production transcription...">
 <title>FunASR Benchmark</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/deployment-matrix.html
+++ b/deployment-matrix.html
@@ -5,6 +5,11 @@
 <meta property="og:description" content="A practical deployment decision table for FunASR products, demos, benchmarks, and internal workflows.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://modelscope.github.io/FunASR/deployment-matrix.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/deployment-matrix.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Deployment Matrix">
+<meta name="twitter:description" content="Choose the right FunASR deployment path: Python API, OpenAI-compatible API, Docker Compose, WebSocket runtime, vLLM, MCP, subtitles, batch ASR, or Triton.">
 <title>FunASR Deployment Matrix</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/ja/agent.html
+++ b/ja/agent.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="音声認識を Agent、プロダクト、デスクトップワークフローのローカル基盤として利用できます。OpenAI 互換 API、MCP server、音声入力、字幕生成に対応します。">
+<meta property="og:title" content="FunASR Agent 連携">
+<meta property="og:description" content="音声認識を Agent、プロダクト、デスクトップワークフローのローカル基盤として利用できます。OpenAI 互換 API、MCP server、音声入力、字幕生成に対応します。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/agent.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/agent.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Agent 連携">
+<meta name="twitter:description" content="音声認識を Agent、プロダクト、デスクトップワークフローのローカル基盤として利用できます。OpenAI 互換 API、MCP server、音声入力、字幕生成に対応します。">
 <title>FunASR Agent 連携</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/ja/api.html
+++ b/ja/api.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="FunASR の Python API リファレンスです。モデル、データセット、学習、推論、ユーティリティの最新 GitHub ソースコードに移動できます。">
+<meta property="og:title" content="FunASR API">
+<meta property="og:description" content="FunASR の Python API リファレンスです。モデル、データセット、学習、推論、ユーティリティの最新 GitHub ソースコードに移動できます。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/api.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/api.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR API">
+<meta name="twitter:description" content="FunASR の Python API リファレンスです。モデル、データセット、学習、推論、ユーティリティの最新 GitHub ソースコードに移動できます。">
 <title>FunASR API</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/ja/benchmark.html
+++ b/ja/benchmark.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="長時間 ASR ワークロードの速度と精度の測定結果です。実運用の書き起こしでは、FunASR の CPU 推論が Whisper の GPU 推論より速くなる場合があります。">
+<meta property="og:title" content="FunASR ベンチマーク">
+<meta property="og:description" content="長時間 ASR ワークロードの速度と精度の測定結果です。実運用の書き起こしでは、FunASR の CPU 推論が Whisper の GPU 推論より速くなる場合があります。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/benchmark.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/benchmark.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR ベンチマーク">
+<meta name="twitter:description" content="長時間 ASR ワークロードの速度と精度の測定結果です。実運用の書き起こしでは、FunASR の CPU 推論が Whisper の GPU 推論より速くなる場合があります。">
 <title>FunASR ベンチマーク</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/ja/model-registration.html
+++ b/ja/model-registration.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="アーキテクチャの理解から自分のモデルの貢献まで——ステップバイステップの完全ガイド。">
+<meta property="og:title" content="FunASR 開発者ガイド">
+<meta property="og:description" content="アーキテクチャの理解から自分のモデルの貢献まで——ステップバイステップの完全ガイド。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/model-registration.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/model-registration.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 開発者ガイド">
+<meta name="twitter:description" content="アーキテクチャの理解から自分のモデルの貢献まで——ステップバイステップの完全ガイド。">
 <title>FunASR 開発者ガイド</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/ja/training.html
+++ b/ja/training.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="FunASR のトレーニングフレームワークを使用して、自分のデータで事前学習モデルをファインチューニングできます。">
+<meta property="og:title" content="FunASR トレーニング・ファインチューニング">
+<meta property="og:description" content="FunASR のトレーニングフレームワークを使用して、自分のデータで事前学習モデルをファインチューニングできます。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/training.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/training.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR トレーニング・ファインチューニング">
+<meta name="twitter:description" content="FunASR のトレーニングフレームワークを使用して、自分のデータで事前学習モデルをファインチューニングできます。">
 <title>FunASR トレーニング・ファインチューニング</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/ja/tutorial.html
+++ b/ja/tutorial.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="ゼロからプロダクションまで——10 分で FunASR を完全にマスター。">
+<meta property="og:title" content="FunASR チュートリアル">
+<meta property="og:description" content="ゼロからプロダクションまで——10 分で FunASR を完全にマスター。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/tutorial.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/tutorial.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR チュートリアル">
+<meta name="twitter:description" content="ゼロからプロダクションまで——10 分で FunASR を完全にマスター。">
 <title>FunASR チュートリアル</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/ja/vllm.html
+++ b/ja/vllm.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="vLLM を使って自己回帰型の LLM-based ASR モデルを高速化します。新しいエンジンは、オフライン一括書き起こし、SDK 形式のチャンクストリーミング、VAD・ホットワード・話者ラベル付きの本番向け WebSocket サービスを提供します。">
+<meta property="og:title" content="FunASR vLLM 推論エンジン">
+<meta property="og:description" content="vLLM を使って自己回帰型の LLM-based ASR モデルを高速化します。新しいエンジンは、オフライン一括書き起こし、SDK 形式のチャンクストリーミング、VAD・ホットワード・話者ラベル付きの本番向け WebSocket サービスを提供します。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/vllm.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/vllm.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR vLLM 推論エンジン">
+<meta name="twitter:description" content="vLLM を使って自己回帰型の LLM-based ASR モデルを高速化します。新しいエンジンは、オフライン一括書き起こし、SDK 形式のチャンクストリーミング、VAD・ホットワード・話者ラベル付きの本番向け WebSocket サービスを提供します。">
 <title>FunASR vLLM 推論エンジン</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/migration.html
+++ b/migration.html
@@ -5,6 +5,11 @@
 <meta property="og:description" content="A practical benchmark and rollout guide for teams comparing Whisper, cloud ASR, and self-hosted FunASR.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://modelscope.github.io/FunASR/migration.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/migration.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Migrate from Whisper or Cloud ASR to FunASR">
+<meta name="twitter:description" content="Evaluate migration from Whisper or cloud ASR to FunASR with representative audio, feature mapping, OpenAI-compatible APIs, and rollout checklists.">
 <title>Migrate from Whisper or Cloud ASR to FunASR</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/model-registration.html
+++ b/model-registration.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="From understanding the architecture to contributing your own model — a step-by-step guide.">
+<meta property="og:title" content="FunASR Developer Guide">
+<meta property="og:description" content="From understanding the architecture to contributing your own model — a step-by-step guide.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/model-registration.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/model-registration.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Developer Guide">
+<meta name="twitter:description" content="From understanding the architecture to contributing your own model — a step-by-step guide.">
 <title>FunASR Developer Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/training.html
+++ b/training.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Fine-tune pretrained models on your own data using FunASR&#x27;s training framework.">
+<meta property="og:title" content="FunASR Training Guide">
+<meta property="og:description" content="Fine-tune pretrained models on your own data using FunASR&#x27;s training framework.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/training.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/training.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Training Guide">
+<meta name="twitter:description" content="Fine-tune pretrained models on your own data using FunASR&#x27;s training framework.">
 <title>FunASR Training Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="From zero to production — learn FunASR in 10 minutes.">
+<meta property="og:title" content="FunASR Tutorial">
+<meta property="og:description" content="From zero to production — learn FunASR in 10 minutes.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/tutorial.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/tutorial.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Tutorial">
+<meta name="twitter:description" content="From zero to production — learn FunASR in 10 minutes.">
 <title>FunASR Tutorial</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/use-cases.html
+++ b/use-cases.html
@@ -5,6 +5,11 @@
 <meta property="og:description" content="A practical route map for deploying FunASR in products, agents, streaming services, and benchmark-driven migrations.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://modelscope.github.io/FunASR/use-cases.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/use-cases.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Use Cases">
+<meta name="twitter:description" content="Choose the right FunASR path for private speech APIs, agent voice input, streaming ASR, vLLM acceleration, subtitles, batch transcription, and benchmarks.">
 <title>FunASR Use Cases</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/vllm.html
+++ b/vllm.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="Use vLLM to accelerate autoregressive, LLM-based ASR models. The new engine supports offline batch transcription, SDK-style chunked streaming, and a production WebSocket...">
+<meta property="og:title" content="FunASR vLLM Guide">
+<meta property="og:description" content="Use vLLM to accelerate autoregressive, LLM-based ASR models. The new engine supports offline batch transcription, SDK-style chunked streaming, and a production WebSocket...">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/vllm.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/vllm.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR vLLM Guide">
+<meta name="twitter:description" content="Use vLLM to accelerate autoregressive, LLM-based ASR models. The new engine supports offline batch transcription, SDK-style chunked streaming, and a production WebSocket...">
 <title>FunASR vLLM Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">

--- a/zh/agent.html
+++ b/zh/agent.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="把语音识别作为本地基础设施接入 Agent、产品和桌面工作流：OpenAI 兼容 API、MCP 服务、语音输入和字幕生成。">
+<meta property="og:title" content="FunASR Agent 集成">
+<meta property="og:description" content="把语音识别作为本地基础设施接入 Agent、产品和桌面工作流：OpenAI 兼容 API、MCP 服务、语音输入和字幕生成。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/agent.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/agent.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR Agent 集成">
+<meta name="twitter:description" content="把语音识别作为本地基础设施接入 Agent、产品和桌面工作流：OpenAI 兼容 API、MCP 服务、语音输入和字幕生成。">
 <title>FunASR Agent 集成</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/api.html
+++ b/zh/api.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="浏览 FunASR 自动生成的 Python API 文档，快速跳转到模型、数据集、训练、推理和工具模块的最新 GitHub 源码。">
+<meta property="og:title" content="FunASR API">
+<meta property="og:description" content="浏览 FunASR 自动生成的 Python API 文档，快速跳转到模型、数据集、训练、推理和工具模块的最新 GitHub 源码。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/api.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/api.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR API">
+<meta name="twitter:description" content="浏览 FunASR 自动生成的 Python API 文档，快速跳转到模型、数据集、训练、推理和工具模块的最新 GitHub 源码。">
 <title>FunASR API</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/benchmark.html
+++ b/zh/benchmark.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="长音频 ASR 的速度与准确率评测。核心结论：在生产转写场景中，FunASR 的 CPU 推理也可以快过 Whisper 的 GPU 推理。">
+<meta property="og:title" content="FunASR 性能评测">
+<meta property="og:description" content="长音频 ASR 的速度与准确率评测。核心结论：在生产转写场景中，FunASR 的 CPU 推理也可以快过 Whisper 的 GPU 推理。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/benchmark.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/benchmark.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 性能评测">
+<meta name="twitter:description" content="长音频 ASR 的速度与准确率评测。核心结论：在生产转写场景中，FunASR 的 CPU 推理也可以快过 Whisper 的 GPU 推理。">
 <title>FunASR 性能评测</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/deployment-matrix.html
+++ b/zh/deployment-matrix.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <meta name="description" content="FunASR 部署选型表：Python API、OpenAI 兼容 API、Docker Compose、WebSocket runtime、vLLM、MCP、字幕、批处理和 Triton。">
 <meta property="og:title" content="FunASR 部署选型表">
 <meta property="og:description" content="面向产品、demo、benchmark 和内部工作流的 FunASR 部署决策表。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://modelscope.github.io/FunASR/zh/deployment-matrix.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/deployment-matrix.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 部署选型表">
+<meta name="twitter:description" content="FunASR 部署选型表：Python API、OpenAI 兼容 API、Docker Compose、WebSocket runtime、vLLM、MCP、字幕、批处理和 Triton。">
 <title>FunASR 部署选型表</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/index.html
+++ b/zh/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/zh/migration.html
+++ b/zh/migration.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <meta name="description" content="从 Whisper 或云端 ASR 迁移到 FunASR 的评估指南：代表性音频、功能映射、OpenAI 兼容 API 和上线检查清单。">
 <meta property="og:title" content="从 Whisper 或云端 ASR 迁移到 FunASR">
 <meta property="og:description" content="面向正在比较 Whisper、云端 ASR 和私有化 FunASR 的团队，提供评测和上线路径。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://modelscope.github.io/FunASR/zh/migration.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/migration.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="从 Whisper 或云端 ASR 迁移到 FunASR">
+<meta name="twitter:description" content="从 Whisper 或云端 ASR 迁移到 FunASR 的评估指南：代表性音频、功能映射、OpenAI 兼容 API 和上线检查清单。">
 <title>从 Whisper 或云端 ASR 迁移到 FunASR</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/model-registration.html
+++ b/zh/model-registration.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="从理解框架架构到贡献你自己的模型——循序渐进的完整指南。">
+<meta property="og:title" content="FunASR 开发指南">
+<meta property="og:description" content="从理解框架架构到贡献你自己的模型——循序渐进的完整指南。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/model-registration.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/model-registration.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 开发指南">
+<meta name="twitter:description" content="从理解框架架构到贡献你自己的模型——循序渐进的完整指南。">
 <title>FunASR 开发指南</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/training.html
+++ b/zh/training.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="使用 FunASR 训练框架，在你自己的数据上微调预训练模型。">
+<meta property="og:title" content="FunASR 训练与微调">
+<meta property="og:description" content="使用 FunASR 训练框架，在你自己的数据上微调预训练模型。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/training.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/training.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 训练与微调">
+<meta name="twitter:description" content="使用 FunASR 训练框架，在你自己的数据上微调预训练模型。">
 <title>FunASR 训练与微调</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/tutorial.html
+++ b/zh/tutorial.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="从零开始，10 分钟掌握 FunASR 的完整使用方法。">
+<meta property="og:title" content="FunASR 使用教程">
+<meta property="og:description" content="从零开始，10 分钟掌握 FunASR 的完整使用方法。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/tutorial.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/tutorial.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 使用教程">
+<meta name="twitter:description" content="从零开始，10 分钟掌握 FunASR 的完整使用方法。">
 <title>FunASR 使用教程</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/use-cases.html
+++ b/zh/use-cases.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <meta name="description" content="FunASR 场景速览：私有语音 API、Agent 语音输入、流式 ASR、vLLM 加速、字幕、批处理和性能评测的快速入口。">
 <meta property="og:title" content="FunASR 场景速览">
 <meta property="og:description" content="面向评测、部署、Agent、流式服务和生产迁移的 FunASR 路径图。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://modelscope.github.io/FunASR/zh/use-cases.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/use-cases.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 场景速览">
+<meta name="twitter:description" content="FunASR 场景速览：私有语音 API、Agent 语音输入、流式 ASR、vLLM 加速、字幕、批处理和性能评测的快速入口。">
 <title>FunASR 场景速览</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">

--- a/zh/vllm.html
+++ b/zh/vllm.html
@@ -1,5 +1,15 @@
 <!DOCTYPE html>
 <html lang="zh-CN"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="使用 vLLM 加速自回归 LLM-based ASR 模型。新版引擎支持离线批量转写、SDK 级 chunk 流式推理，以及集成 VAD、热词和说话人标签的生产级 WebSocket 服务。">
+<meta property="og:title" content="FunASR vLLM 推理引擎">
+<meta property="og:description" content="使用 vLLM 加速自回归 LLM-based ASR 模型。新版引擎支持离线批量转写、SDK 级 chunk 流式推理，以及集成 VAD、热词和说话人标签的生产级 WebSocket 服务。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/zh/vllm.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/zh/vllm.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR vLLM 推理引擎">
+<meta name="twitter:description" content="使用 vLLM 加速自回归 LLM-based ASR 模型。新版引擎支持离线批量转写、SDK 级 chunk 流式推理，以及集成 VAD、热词和说话人标签的生产级 WebSocket 服务。">
 <title>FunASR vLLM 推理引擎</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../style.css">


### PR DESCRIPTION
## Summary
- add descriptions, canonical URLs, Open Graph tags, and Twitter summary tags across documentation pages
- complete metadata for Agent, API, benchmark, tutorial, training, vLLM, migration, deployment, and use-case pages
- correct zh/ja HTML lang attributes and NFC-normalize Japanese pages

## Validation
- git diff --check
- parsed all 30 HTML pages and verified one description, canonical, Open Graph, and Twitter metadata set per page
- verified zh/ja lang attributes and Japanese NFC normalization