### PR TITLE
[codex] Link Postman collection on website

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -54,7 +54,7 @@ print(verbose.segments)</code></pre>
   -F model=sensevoice \
   -F response_format=verbose_json</code></pre>
 </section>
-<section id="workflows"><h2>Dify, n8n, and workflow engines</h2><p>For low-code tools that call HTTP nodes or webhook workers, use the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">workflow recipes</a>. They cover multipart upload settings, Dify custom tools, n8n binary file fields, audio URL workers, timeouts, and production guardrails.</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Open workflow recipes</a></p></section>
+<section id="workflows"><h2>Dify, n8n, and workflow engines</h2><p>For low-code tools that call HTTP nodes or webhook workers, use the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">workflow recipes</a>. They cover multipart upload settings, Dify custom tools, n8n binary file fields, audio URL workers, timeouts, and production guardrails. For GUI smoke tests, import the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Postman collection</a>.</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Open workflow recipes</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Open Postman collection</a></p></section>
 <section id="mcp"><h2>MCP Server</h2>
 <p>The MCP server gives Claude Code, Claude Desktop, Cursor, Windsurf, and other MCP clients a local <code>transcribe_audio</code> tool.</p>
 <pre><code>pip install funasr

--- a/deployment-matrix.html
+++ b/deployment-matrix.html
@@ -27,7 +27,7 @@
 <section id="matrix"><h2>Quick decision table</h2>
 <table><tr><th>Path</th><th>Best for</th><th>Start here</th><th>Operational notes</th></tr>
 <tr><td>Python API</td><td>Notebooks, offline jobs, first model evaluation</td><td><a href="tutorial.html">Tutorial</a></td><td>Lowest ceremony; caller owns batching, retries, and files.</td></tr>
-<tr><td>OpenAI-compatible API</td><td>Private speech API, agents, Dify/LangChain/AutoGen/n8n-style clients</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Workflow recipes</a></td><td>Easiest integration for apps and workflow engines that already support OpenAI audio APIs or multipart HTTP nodes.</td></tr>
+<tr><td>OpenAI-compatible API</td><td>Private speech API, agents, Dify/LangChain/AutoGen/n8n-style clients</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">Workflow recipes</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Postman collection</a></td><td>Easiest integration for apps and workflow engines that already support OpenAI audio APIs or multipart HTTP nodes.</td></tr>
 <tr><td>Docker Compose API</td><td>Reproducible local smoke test or small internal service</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker docs</a></td><td>CPU by default; adapt the image before using CUDA in containers.</td></tr>
 <tr><td>Runtime WebSocket service</td><td>Live captions, meetings, call-center streams</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime docs</a></td><td>Use when partial results, endpointing, or long-lived audio streams matter.</td></tr>
 <tr><td>vLLM acceleration</td><td>Higher-throughput LLM-based ASR with Fun-ASR-Nano</td><td><a href="vllm.html">vLLM guide</a></td><td>Use for LLM decoder throughput; does not apply to non-autoregressive Paraformer.</td></tr>
@@ -38,7 +38,7 @@
 </section>
 <section id="choices"><h2>Common choices</h2>
 <div class="grid-2"><div class="card"><h3>Try FunASR in five minutes</h3><p>Use the Python API from the tutorial. It is the shortest route for validating installation, model download, device selection, and output shape.</p></div>
-<div class="card"><h3>Replace cloud transcription locally</h3><p>Use the OpenAI-compatible API. Start with <code>sensevoice</code>, run the smoke test, then connect existing SDK or HTTP clients using the client recipes. For Dify, n8n, or webhook workers, use the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">workflow recipes</a>.</p></div></div>
+<div class="card"><h3>Replace cloud transcription locally</h3><p>Use the OpenAI-compatible API. Start with <code>sensevoice</code>, run the smoke test, then connect existing SDK or HTTP clients using the client recipes. For Dify, n8n, or webhook workers, use the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS.md">workflow recipes</a>. For GUI API checks, import the <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Postman collection</a>.</p></div></div>
 <div class="grid-2"><div class="card"><h3>Run a repeatable container demo</h3><pre><code>cd examples/openai_api
 cp .env.example .env
 docker compose up --build</code></pre><p>Keep CPU mode until you have a CUDA-capable PyTorch/FunASR image.</p></div>

--- a/zh/agent.html
+++ b/zh/agent.html
@@ -54,7 +54,7 @@ print(verbose.segments)</code></pre>
   -F model=sensevoice \
   -F response_format=verbose_json</code></pre>
 </section>
-<section id="workflows"><h2>Dify、n8n 与工作流引擎</h2><p>低代码工具如果通过 HTTP 节点或 webhook worker 调用语音 API，请参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a>。其中覆盖 multipart 上传配置、Dify custom tool、n8n binary file 字段、音频 URL worker、超时设置和生产防护。</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">打开工作流配方</a></p></section>
+<section id="workflows"><h2>Dify、n8n 与工作流引擎</h2><p>低代码工具如果通过 HTTP 节点或 webhook worker 调用语音 API，请参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a>。其中覆盖 multipart 上传配置、Dify custom tool、n8n binary file 字段、音频 URL worker、超时设置和生产防护。需要图形界面 smoke test 时，可导入 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Postman 集合</a>。</p><p><a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">打开工作流配方</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">打开 Postman 集合</a></p></section>
 <section id="mcp"><h2>MCP 服务</h2>
 <p>MCP 服务为 Claude Code、Claude Desktop、Cursor、Windsurf 和其他 MCP 客户端提供本地 <code>transcribe_audio</code> 工具。</p>
 <pre><code>pip install funasr

--- a/zh/deployment-matrix.html
+++ b/zh/deployment-matrix.html
@@ -27,7 +27,7 @@
 <section id="matrix"><h2>快速决策表</h2>
 <table><tr><th>路径</th><th>适合场景</th><th>从这里开始</th><th>运维提示</th></tr>
 <tr><td>Python API</td><td>Notebook、离线任务、首次模型评测</td><td><a href="tutorial.html">使用教程</a></td><td>最简单；调用方自己负责批处理、重试和文件管理。</td></tr>
-<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen/n8n 风格客户端</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a></td><td>已支持 OpenAI audio API 或 multipart HTTP 节点的应用和工作流引擎最容易接入。</td></tr>
+<tr><td>OpenAI 兼容 API</td><td>私有语音 API、Agent、Dify/LangChain/AutoGen/n8n 风格客户端</td><td><a href="agent.html#server">OpenAI API</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a> · <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Postman 集合</a></td><td>已支持 OpenAI audio API 或 multipart HTTP 节点的应用和工作流引擎最容易接入。</td></tr>
 <tr><td>Docker Compose API</td><td>可复现本地 smoke test 或小型内部服务</td><td><a href="https://github.com/modelscope/FunASR/tree/main/examples/openai_api#docker-deployment">OpenAI API Docker 文档</a></td><td>默认 CPU；容器里使用 CUDA 前需要先适配 CUDA-capable 镜像。</td></tr>
 <tr><td>Runtime WebSocket 服务</td><td>实时字幕、会议、客服流式音频</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime 文档</a></td><td>需要中间结果、断句或长连接音频流时选择。</td></tr>
 <tr><td>vLLM 加速</td><td>Fun-ASR-Nano 等 LLM-based ASR 高吞吐</td><td><a href="vllm.html">vLLM 指南</a></td><td>适合 LLM 解码吞吐；不适用于非自回归 Paraformer。</td></tr>
@@ -38,7 +38,7 @@
 </section>
 <section id="choices"><h2>常见选择</h2>
 <div class="grid-2"><div class="card"><h3>五分钟内试跑 FunASR</h3><p>使用教程里的 Python API。它是验证安装、模型下载、设备选择和基础输出格式的最短路径。</p></div>
-<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。Dify、n8n 或 webhook worker 可参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a>。</p></div></div>
+<div class="card"><h3>本地替代云端转写</h3><p>使用 OpenAI 兼容 API。先用 <code>sensevoice</code> 跑通 smoke test，再根据客户端配方接入 SDK 或 HTTP 客户端。Dify、n8n 或 webhook worker 可参考 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/WORKFLOWS_zh.md">工作流配方</a>；图形界面 API 检查可导入 <a href="https://github.com/modelscope/FunASR/blob/main/examples/openai_api/POSTMAN.md">Postman 集合</a>。</p></div></div>
 <div class="grid-2"><div class="card"><h3>可复现容器 demo</h3><pre><code>cd examples/openai_api
 cp .env.example .env
 docker compose up --build</code></pre><p>在没有 CUDA-capable PyTorch/FunASR 镜像前保持 CPU 模式。</p></div>


### PR DESCRIPTION
## Summary
- link the new OpenAI API Postman collection from English and Chinese Agent pages
- add Postman collection links to English and Chinese deployment matrix OpenAI API paths

## Validation
- git diff --check
- verified each updated website page includes the Postman collection link