### PR TITLE
[codex] Link Chinese Colab guide on website

### DIFF
--- a/zh/index.html
+++ b/zh/index.html
@@ -288,7 +288,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
     <section>
         <div class="container narrow">
             <h2 class="section-title">快速开始</h2>
-            <p class="section-subtitle">可以本地安装，也可以先运行 <a href="https://github.com/modelscope/FunASR/tree/main/examples/colab">Colab 快速体验</a>，在浏览器里转写样例音频。</p>
+            <p class="section-subtitle">可以本地安装，也可以先运行 <a href="https://github.com/modelscope/FunASR/blob/main/examples/colab/README_zh.md">Colab 快速体验</a>，在浏览器里转写样例音频。</p>
 <pre>pip install funasr
 # 或安装最新版：pip install git+https://github.com/modelscope/FunASR.git</pre>
 <pre>from funasr import AutoModel


### PR DESCRIPTION
## Summary
- Link the Chinese homepage Colab quickstart text to the localized Chinese guide on `main`.
- Keep the primary CTA buttons pointed directly at the Colab notebook.

## Validation
- `git diff --check`
- Parsed `zh/index.html` anchors and confirmed exactly one localized guide link
- Confirmed the GitHub README_zh.md target returns HTTP 200
