### PR TITLE
[codex] Localize Colab quickstart for Japanese and Korean

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="#クイックスタート">クイックスタート</a> · <a href="#ベンチマーク">ベンチマーク</a> · <a href="./docs/migration_from_whisper.md">Migration guide</a> · <a href="./docs/use_case_showcase.md">Use cases</a> · <a href="./docs/deployment_matrix.md">Deployment matrix</a> · <a href="#モデル一覧">モデル一覧</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent連携</a> · <a href="https://modelscope.github.io/FunASR/">ドキュメント</a>
+  <a href="#クイックスタート">クイックスタート</a> · <a href="./examples/colab/README_ja.md">Colab</a> · <a href="#ベンチマーク">ベンチマーク</a> · <a href="./docs/migration_from_whisper.md">Migration guide</a> · <a href="./docs/use_case_showcase.md">Use cases</a> · <a href="./docs/deployment_matrix.md">Deployment matrix</a> · <a href="#モデル一覧">モデル一覧</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent連携</a> · <a href="https://modelscope.github.io/FunASR/">ドキュメント</a>
 </p>
 
 ---
@@ -132,7 +132,7 @@ funasr-server --device cuda
 docker pull registry.cn-hangzhou.aliyuncs.com/funasr_repo/funasr:funasr-runtime-sdk-online-cpu-0.1.12
 ```
 
-[Colab quickstart →](./examples/colab/) · [OpenAI API example →](./examples/openai_api/README_ja.md) · [Client recipes →](./examples/openai_api/CLIENTS.md) · [Workflow recipes →](./examples/openai_api/WORKFLOWS.md) · [Postman collection →](./examples/openai_api/POSTMAN.md) · [OpenAPI spec →](./examples/openai_api/OPENAPI.md) · [Security guide →](./examples/openai_api/SECURITY.md) · [Deployment matrix →](./docs/deployment_matrix.md) · [デプロイドキュメント →](./runtime/readme.md) · [Agent連携 →](https://modelscope.github.io/FunASR/agent.html)
+[Colab quickstart →](./examples/colab/README_ja.md) · [OpenAI API example →](./examples/openai_api/README_ja.md) · [Client recipes →](./examples/openai_api/CLIENTS.md) · [Workflow recipes →](./examples/openai_api/WORKFLOWS.md) · [Postman collection →](./examples/openai_api/POSTMAN.md) · [OpenAPI spec →](./examples/openai_api/OPENAPI.md) · [Security guide →](./examples/openai_api/SECURITY.md) · [Deployment matrix →](./docs/deployment_matrix.md) · [デプロイドキュメント →](./runtime/readme.md) · [Agent連携 →](https://modelscope.github.io/FunASR/agent.html)
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="#빠른-시작">빠른 시작</a> · <a href="#벤치마크">벤치마크</a> · <a href="./docs/migration_from_whisper.md">Migration guide</a> · <a href="./docs/use_case_showcase.md">Use cases</a> · <a href="./docs/deployment_matrix.md">Deployment matrix</a> · <a href="#모델-목록">모델 목록</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent 연동</a> · <a href="https://modelscope.github.io/FunASR/">문서</a>
+  <a href="#빠른-시작">빠른 시작</a> · <a href="./examples/colab/README_ko.md">Colab</a> · <a href="#벤치마크">벤치마크</a> · <a href="./docs/migration_from_whisper.md">Migration guide</a> · <a href="./docs/use_case_showcase.md">Use cases</a> · <a href="./docs/deployment_matrix.md">Deployment matrix</a> · <a href="#모델-목록">모델 목록</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent 연동</a> · <a href="https://modelscope.github.io/FunASR/">문서</a>
 </p>
 
 ---
@@ -132,7 +132,7 @@ funasr-server --device cuda
 docker pull registry.cn-hangzhou.aliyuncs.com/funasr_repo/funasr:funasr-runtime-sdk-online-cpu-0.1.12
 ```
 
-[Colab quickstart →](./examples/colab/) · [OpenAI API example →](./examples/openai_api/README_ko.md) · [Client recipes →](./examples/openai_api/CLIENTS.md) · [Workflow recipes →](./examples/openai_api/WORKFLOWS.md) · [Postman collection →](./examples/openai_api/POSTMAN.md) · [OpenAPI spec →](./examples/openai_api/OPENAPI.md) · [Security guide →](./examples/openai_api/SECURITY.md) · [Deployment matrix →](./docs/deployment_matrix.md) · [배포 문서 →](./runtime/readme.md) · [Agent 연동 →](https://modelscope.github.io/FunASR/agent.html)
+[Colab quickstart →](./examples/colab/README_ko.md) · [OpenAI API example →](./examples/openai_api/README_ko.md) · [Client recipes →](./examples/openai_api/CLIENTS.md) · [Workflow recipes →](./examples/openai_api/WORKFLOWS.md) · [Postman collection →](./examples/openai_api/POSTMAN.md) · [OpenAPI spec →](./examples/openai_api/OPENAPI.md) · [Security guide →](./examples/openai_api/SECURITY.md) · [Deployment matrix →](./docs/deployment_matrix.md) · [배포 문서 →](./runtime/readme.md) · [Agent 연동 →](https://modelscope.github.io/FunASR/agent.html)
 
 ---
 

--- a/examples/colab/README.md
+++ b/examples/colab/README.md
@@ -1,6 +1,6 @@
 # FunASR Colab Quickstart
 
-English | [简体中文](README_zh.md)
+English | [简体中文](README_zh.md) | [日本語](README_ja.md) | [한국어](README_ko.md)
 
 Run FunASR in a browser without preparing a local Python environment.
 

--- a/examples/colab/README_ja.md
+++ b/examples/colab/README_ja.md
@@ -1,0 +1,24 @@
+# FunASR Colab クイックスタート
+
+[English](README.md) | [简体中文](README_zh.md) | 日本語 | [한국어](README_ko.md)
+
+ローカルの Python 環境を準備せずに、ブラウザだけで FunASR を実行できます。
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/modelscope/FunASR/blob/main/examples/colab/funasr_quickstart.ipynb)
+
+## Notebook で試せること
+
+- Colab に FunASR と実行時依存関係をインストールします。
+- Colab の GPU が使える場合は自動で `cuda:0` を選び、なければ CPU を使います。
+- `paraformer-zh`、VAD、句読点モデルで公開サンプル音声を文字起こしします。
+- 自分の音声ファイルをアップロードし、同じモデルで文字起こしします。
+- transcript JSON を保存し、共有、比較、issue 報告に利用できます。
+
+## 利用メモ
+
+- 初回実行ではモデルファイルをダウンロードするため、数分かかる場合があります。
+- CPU runtime は短い smoke test に使えます。長い音声では GPU runtime の方が高速です。
+- 本番デプロイを評価する場合は、notebook が動いた後に [deployment matrix](../../docs/deployment_matrix.md) を確認してください。
+- OpenAI 互換 HTTP サービスを試す場合は [examples/openai_api](../openai_api/README_ja.md) を利用してください。
+
+Notebook source: [funasr_quickstart.ipynb](https://github.com/modelscope/FunASR/blob/main/examples/colab/funasr_quickstart.ipynb).

--- a/examples/colab/README_ko.md
+++ b/examples/colab/README_ko.md
@@ -1,0 +1,24 @@
+# FunASR Colab 빠른 시작
+
+[English](README.md) | [简体中文](README_zh.md) | [日本語](README_ja.md) | 한국어
+
+로컬 Python 환경을 준비하지 않고 브라우저에서 바로 FunASR을 실행할 수 있습니다.
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/modelscope/FunASR/blob/main/examples/colab/funasr_quickstart.ipynb)
+
+## Notebook에서 확인할 수 있는 것
+
+- Colab에 FunASR과 런타임 의존성을 설치합니다.
+- Colab GPU가 있으면 자동으로 `cuda:0`을 사용하고, 없으면 CPU를 사용합니다.
+- `paraformer-zh`, VAD, 문장부호 모델로 공개 샘플 오디오를 전사합니다.
+- 직접 업로드한 오디오 파일을 같은 모델로 전사합니다.
+- transcript JSON을 저장하여 공유, 비교, issue 보고에 활용할 수 있습니다.
+
+## 사용 메모
+
+- 첫 실행에서는 모델 파일을 다운로드하므로 몇 분이 걸릴 수 있습니다.
+- CPU runtime은 짧은 smoke test에 적합합니다. 긴 오디오에는 GPU runtime이 더 빠릅니다.
+- 프로덕션 배포를 검토하려면 notebook을 먼저 실행한 뒤 [deployment matrix](../../docs/deployment_matrix.md)를 확인하세요.
+- OpenAI 호환 HTTP 서비스를 테스트하려면 [examples/openai_api](../openai_api/README_ko.md)를 사용하세요.
+
+Notebook source: [funasr_quickstart.ipynb](https://github.com/modelscope/FunASR/blob/main/examples/colab/funasr_quickstart.ipynb).

--- a/examples/colab/README_zh.md
+++ b/examples/colab/README_zh.md
@@ -1,6 +1,6 @@
 # FunASR Colab 快速体验
 
-[English](README.md) | 简体中文
+[English](README.md) | 简体中文 | [日本語](README_ja.md) | [한국어](README_ko.md)
 
 无需提前配置本地 Python 环境，直接在浏览器里运行 FunASR。
 


### PR DESCRIPTION
## Summary
- Add Japanese and Korean localized Colab quickstart guides.
- Expand the Colab example language switch to English, Chinese, Japanese, and Korean.
- Point Japanese and Korean project README navigation/deployment links to the localized Colab guides.

## Validation
- `git diff --cached --check`
- `python3 -m json.tool examples/colab/funasr_quickstart.ipynb`
- Markdown relative link, code fence, Unicode NFC, and token-like string checker for touched docs
