### PR TITLE
[codex] Link Japanese Colab guide on website

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -235,7 +235,7 @@ print(res[0]["sentence_info"])</pre>
     <section>
         <div class="container narrow">
             <h2 class="section-title">クイックスタート</h2>
-            <p class="section-subtitle">パッケージをインストールし、パイプラインを構成、Python から認識を実行。</p>
+            <p class="section-subtitle">ローカルにインストールするか、まず <a href="https://github.com/modelscope/FunASR/blob/main/examples/colab/README_ja.md">Colab クイックスタート</a> でブラウザからサンプル音声を文字起こしできます。</p>
 <pre>pip install funasr
 # または最新版：pip install git+https://github.com/modelscope/FunASR.git</pre>
 <pre>from funasr import AutoModel


### PR DESCRIPTION
## Summary
- Link the Japanese homepage quickstart copy to the localized Colab guide on `main`.

## Validation
- `git diff --check`
- HTML anchor parser confirms exactly one Japanese Colab guide link
- GitHub README_ja.md target returns HTTP 200
- Unicode NFC normalization check for `ja/index.html`
