### PR TITLE
[codex] Link Japanese model selection guide on website

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -105,6 +105,11 @@ print(res[0]["sentence_info"])</pre>
             <h2 class="section-title">ドキュメント</h2>
             <p class="section-subtitle">サンプルから始めて、自分のデータでチューニングし、レジストリを拡張するか、ソースリンク付き API ドキュメントへ。</p>
             <div class="doc-grid">
+                <a class="doc-card" href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ja.md">
+                    <span class="doc-kicker">選ぶ</span>
+                    <h3>モデル選択</h3>
+                    <p>SenseVoice、Paraformer、Fun-ASR-Nano、OpenAI API alias の最初の選び方を確認。</p>
+                </a>
                 <a class="doc-card" href="tutorial.html">
                     <span class="doc-kicker">学ぶ</span>
                     <h3>チュートリアル</h3>
@@ -235,7 +240,7 @@ print(res[0]["sentence_info"])</pre>
     <section>
         <div class="container narrow">
             <h2 class="section-title">クイックスタート</h2>
-            <p class="section-subtitle">ローカルにインストールするか、まず <a href="https://github.com/modelscope/FunASR/blob/main/examples/colab/README_ja.md">Colab クイックスタート</a> でブラウザからサンプル音声を文字起こしできます。</p>
+            <p class="section-subtitle">ローカルにインストールするか、まず <a href="https://github.com/modelscope/FunASR/blob/main/examples/colab/README_ja.md">Colab クイックスタート</a> でブラウザからサンプル音声を文字起こしできます。最初のモデル選びは <a href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ja.md">モデル選択ガイド</a> を参照してください。</p>
 <pre>pip install funasr
 # または最新版：pip install git+https://github.com/modelscope/FunASR.git</pre>
 <pre>from funasr import AutoModel


### PR DESCRIPTION
## Summary
- Link the Japanese homepage docs grid and quickstart copy to the localized model selection guide on `main`.

## Validation
- `git diff --check`
- HTML anchor parser confirms two Japanese model selection guide links
- GitHub model_selection_ja.md target returns HTTP 200
- Unicode NFC normalization check for `ja/index.html`
