### PR TITLE
[codex] Link Japanese deployment matrix on website

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -110,6 +110,11 @@ print(res[0]["sentence_info"])</pre>
                     <h3>モデル選択</h3>
                     <p>SenseVoice、Paraformer、Fun-ASR-Nano、OpenAI API alias の最初の選び方を確認。</p>
                 </a>
+                <a class="doc-card" href="https://github.com/modelscope/FunASR/blob/main/docs/deployment_matrix_ja.md">
+                    <span class="doc-kicker">運用</span>
+                    <h3>デプロイ選択</h3>
+                    <p>Colab、Python API、OpenAI 互換 API、Docker、Kubernetes、WebSocket、vLLM、MCP の選び方を確認。</p>
+                </a>
                 <a class="doc-card" href="tutorial.html">
                     <span class="doc-kicker">学ぶ</span>
                     <h3>チュートリアル</h3>


### PR DESCRIPTION
Summary:
- Add a Japanese website documentation card that links to the localized deployment matrix on main.
- Keep the change scoped to the Japanese homepage on gh-pages.

Validation:
- `git diff --check`
- NFC normalization, deployment-card count, and token-like string checker for `ja/index.html`