### PR TITLE
[codex] Add Japanese and Korean model selection website pages

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -106,7 +106,7 @@ print(res[0]["sentence_info"])</pre>
             <h2 class="section-title">ドキュメント</h2>
             <p class="section-subtitle">サンプルから始めて、自分のデータでチューニングし、レジストリを拡張するか、ソースリンク付き API ドキュメントへ。</p>
             <div class="doc-grid">
-                <a class="doc-card" href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ja.md">
+                <a class="doc-card" href="model-selection.html">
                     <span class="doc-kicker">選ぶ</span>
                     <h3>モデル選択</h3>
                     <p>SenseVoice、Paraformer、Fun-ASR-Nano、OpenAI API alias の最初の選び方を確認。</p>
@@ -246,7 +246,7 @@ print(res[0]["sentence_info"])</pre>
     <section>
         <div class="container narrow">
             <h2 class="section-title">クイックスタート</h2>
-            <p class="section-subtitle">ローカルにインストールするか、まず <a href="https://github.com/modelscope/FunASR/blob/main/examples/colab/README_ja.md">Colab クイックスタート</a> でブラウザからサンプル音声を文字起こしできます。最初のモデル選びは <a href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ja.md">モデル選択ガイド</a> を参照してください。</p>
+            <p class="section-subtitle">ローカルにインストールするか、まず <a href="https://github.com/modelscope/FunASR/blob/main/examples/colab/README_ja.md">Colab クイックスタート</a> でブラウザからサンプル音声を文字起こしできます。最初のモデル選びは <a href="model-selection.html">モデル選択ガイド</a> を参照してください。</p>
 <pre>pip install funasr
 # または最新版：pip install git+https://github.com/modelscope/FunASR.git</pre>
 <pre>from funasr import AutoModel

--- a/ja/model-selection.html
+++ b/ja/model-selection.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="FunASR モデル選択ガイド：SenseVoice、Paraformer、Fun-ASR-Nano、streaming runtime、OpenAI API alias、デプロイ経路を比較します。">
+<meta property="og:title" content="FunASR モデル選択ガイド">
+<meta property="og:description" content="デプロイ前に FunASR のモデル、API alias、runtime、benchmark 経路を選ぶための実用ガイド。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ja/model-selection.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ja/model-selection.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR モデル選択ガイド">
+<meta name="twitter:description" content="FunASR モデル選択ガイド：SenseVoice、Paraformer、Fun-ASR-Nano、streaming runtime、OpenAI API alias、デプロイ経路。">
+<title>FunASR モデル選択ガイド</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">ホーム</a><a href="tutorial.html">チュートリアル</a><a href="training.html">トレーニング</a><a href="model-registration.html">開発</a><a href="../api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">日本語</button><div class="lang-menu"><a href="../model-selection.html">English</a><a href="../zh/model-selection.html">中文</a><a href="model-selection.html" class="current">日本語</a><a href="../ko/model-selection.html">한국어</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>モデル選択ガイド</h1>
+<p>最初に使うモデルを選び、Whisper やクラウド ASR との比較を行い、OpenAI 互換 API で公開する model alias を決めます。</p>
+<div class="toc-grid"><a href="#default">最初の選択</a><a href="#decision">判断表</a><a href="#aliases">API alias</a><a href="#runtime">runtime</a><a href="#benchmark">benchmark</a></div>
+<section id="default"><h2>迷ったら SenseVoice-Small</h2>
+<p>まだ決めきれない場合は <strong>SenseVoice-Small</strong> から始めます。デモ、社内 API、多言語 transcription、話者情報付き会議録、agent voice input の強い初期値です。</p>
+<pre><code>from funasr import AutoModel
+
+model = AutoModel(
+    model="iic/SenseVoiceSmall",
+    vad_model="fsmn-vad",
+    spk_model="cam++",
+    device="cuda",  # portable smoke test では "cpu"
+)
+result = model.generate(input="meeting.wav")</code></pre>
+</section>
+<section id="decision"><h2>判断表</h2>
+<table><tr><th>目的</th><th>最初に試すもの</th><th>理由</th><th>次の文書</th></tr>
+<tr><td>高速な多言語 private transcription</td><td>SenseVoice-Small</td><td>ASR、emotion tag、audio event tag、CPU viability のバランスがよい。</td><td><a href="tutorial.html">チュートリアル</a></td></tr>
+<tr><td>中国語 production ASR</td><td>Paraformer-Large</td><td>VAD と punctuation を組み合わせやすい成熟した中国語 ASR 経路。</td><td><a href="tutorial.html">チュートリアル</a></td></tr>
+<tr><td>API example で英語 route を確認</td><td><code>paraformer-en</code></td><td>OpenAI 形式 client で軽量な英語 route を確認しやすい。</td><td><a href="agent.html#server">OpenAI API</a></td></tr>
+<tr><td>LLM-based ASR や 31 言語実験</td><td>Fun-ASR-Nano</td><td>LLM-based path。decoder throughput が重要なら vLLM を併用。</td><td><a href="vllm.html">vLLM guide</a></td></tr>
+<tr><td>ライブ字幕や call-center stream</td><td>Runtime WebSocket service</td><td>long-lived streaming session と partial result 向け。</td><td><a href="tutorial.html#streaming">Realtime examples</a></td></tr>
+<tr><td>Whisper/cloud ASR からの移行</td><td>まず SenseVoice-Small</td><td>個別 tuning の前に強い baseline を作れる。</td><td><a href="https://github.com/modelscope/FunASR/blob/main/docs/migration_from_whisper.md">Migration guide</a></td></tr></table>
+</section>
+<section id="aliases"><h2>OpenAI 互換 API alias</h2>
+<p><code>examples/openai_api</code> server は短い alias を提供します。application team は model repository ID を意識せずに接続できます。</p>
+<table><tr><th>Alias</th><th>実体</th><th>使う場面</th></tr>
+<tr><td><code>sensevoice</code></td><td><code>iic/SenseVoiceSmall</code></td><td>多言語 ASR、event tag、CPU/GPU behavior を含む default private speech API。</td></tr>
+<tr><td><code>paraformer</code></td><td><code>paraformer-zh</code></td><td>中国語 production route。</td></tr>
+<tr><td><code>paraformer-en</code></td><td><code>paraformer-en</code></td><td>OpenAI 形式 client の英語軽量 route。</td></tr>
+<tr><td><code>fun-asr-nano</code></td><td><code>FunAudioLLM/Fun-ASR-Nano-2512</code></td><td>LLM-based ASR、31 言語 coverage、vLLM acceleration の評価。</td></tr></table>
+<pre><code>curl http://localhost:8000/v1/models
+python examples/openai_api/smoke_test.py --base-url http://localhost:8000 --model sensevoice</code></pre>
+</section>
+<section id="runtime"><h2>workload 別 runtime</h2>
+<table><tr><th>workload</th><th>runtime path</th><th>メモ</th></tr>
+<tr><td>Notebook または一回限りの評価</td><td>Python <code>AutoModel</code></td><td>install、model download、output shape を確認する最短経路。</td></tr>
+<tr><td>社内 HTTP service</td><td>OpenAI 互換 API</td><td>OpenAI-style clients、Dify、n8n、LangChain、AutoGen、HTTP node を再利用。</td></tr>
+<tr><td>再現可能な local container demo</td><td>Docker Compose API</td><td>CPU-first smoke test。CUDA の前に image を調整。</td></tr>
+<tr><td>cluster 内 private service</td><td>Kubernetes API template</td><td>private ClusterIP、persistent model cache、health probes、port-forward smoke test。</td></tr>
+<tr><td>live audio</td><td>Runtime WebSocket service</td><td>実音声で chunking、VAD、endpointing、reconnect、client backpressure を検証。</td></tr>
+<tr><td>LLM-based ASR throughput</td><td>Fun-ASR-Nano の vLLM path</td><td>vLLM は autoregressive decoding を高速化し、non-autoregressive Paraformer には使いません。</td></tr></table>
+<p>runtime と deployment target を選ぶ場合は <a href="deployment-matrix.html">デプロイ選択表</a> も確認してください。</p>
+</section>
+<section id="benchmark"><h2>決める前に benchmark</h2>
+<ul><li>短い clip、長い会議、silence、noise、overlapping speakers、domain vocabulary、target languages を含む 20-50 件の代表音声を用意します。</li><li>model name、model revision、FunASR version、device、CPU/GPU type、CUDA/PyTorch version、runtime path、batch size、warmup/model download time を除外したかを記録します。</li><li>transcript の読みやすさだけではなく、通常の WER/CER または human review で品質を見ます。</li><li>latency、throughput、memory、failures、upload size limit を一緒に追跡します。</li><li>public smoke sample と realistic private sample を少なくとも 1 つずつ残します。</li></ul>
+<p>migration work では <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">migration benchmark example</a> と <a href="https://github.com/modelscope/FunASR/blob/main/docs/migration_from_whisper.md">migration guide</a> を使います。</p>
+</section>
+</div></div>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">ホーム</a> &middot; <a href="model-selection.html">モデル選択</a> &middot; <a href="deployment-matrix.html">デプロイ</a> &middot; <a href="agent.html">Agent</a> &middot; <a href="benchmark.html">Benchmark</a> &middot; <a href="vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/ko/index.html
+++ b/ko/index.html
@@ -32,7 +32,7 @@
             <div class="nav-links">
                 <a href="index.html" class="active">홈</a>
                 <a href="https://github.com/modelscope/FunASR/blob/main/README_ko.md">README</a>
-                <a href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ko.md">모델 선택</a>
+                <a href="model-selection.html">모델 선택</a>
                 <a href="deployment-matrix.html">배포</a>
                 <a href="../api.html">API</a>
                 <a href="../vllm.html">vLLM</a>
@@ -57,7 +57,7 @@
                 </div>
                 <div class="hero-actions">
                     <a href="https://github.com/modelscope/FunASR/blob/main/README_ko.md#빠른-시작" class="btn btn-white">시작하기</a>
-                    <a href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ko.md" class="btn btn-outline-white">모델 선택</a>
+                    <a href="model-selection.html" class="btn btn-outline-white">모델 선택</a>
                     <a href="deployment-matrix.html" class="btn btn-outline-white">배포 선택</a>
                 </div>
             </div>
@@ -108,7 +108,7 @@ print(res[0]["sentence_info"])</pre>
                     <h3>README</h3>
                     <p>주요 모델, 빠른 시작, 벤치마크, 배포 링크를 한국어로 확인합니다.</p>
                 </a>
-                <a class="doc-card" href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ko.md">
+                <a class="doc-card" href="model-selection.html">
                     <span class="doc-kicker">선택</span>
                     <h3>모델 선택</h3>
                     <p>SenseVoice, Paraformer, Fun-ASR-Nano, OpenAI API alias 중 첫 모델을 고릅니다.</p>
@@ -157,7 +157,7 @@ print(res[0]["sentence_info"])</pre>
         <p>
             <a href="https://github.com/modelscope/FunASR">GitHub</a> &middot;
             <a href="https://github.com/modelscope/FunASR/blob/main/README_ko.md">README</a> &middot;
-            <a href="https://github.com/modelscope/FunASR/blob/main/docs/model_selection_ko.md">모델 선택</a> &middot;
+            <a href="model-selection.html">모델 선택</a> &middot;
             <a href="deployment-matrix.html">배포</a> &middot;
             <a href="../api.html">API</a> &middot;
             <a href="https://pypi.org/project/funasr/">PyPI</a> &middot;

--- a/ko/model-selection.html
+++ b/ko/model-selection.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ko"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta name="description" content="FunASR 모델 선택 가이드: SenseVoice, Paraformer, Fun-ASR-Nano, streaming runtime, OpenAI API alias, 배포 경로를 비교합니다.">
+<meta property="og:title" content="FunASR 모델 선택 가이드">
+<meta property="og:description" content="배포 전에 FunASR 모델, API alias, runtime, benchmark 경로를 고르는 실용 가이드입니다.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://modelscope.github.io/FunASR/ko/model-selection.html">
+<link rel="canonical" href="https://modelscope.github.io/FunASR/ko/model-selection.html">
+<meta property="og:site_name" content="FunASR">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="FunASR 모델 선택 가이드">
+<meta name="twitter:description" content="FunASR 모델 선택 가이드: SenseVoice, Paraformer, Fun-ASR-Nano, streaming runtime, OpenAI API alias, 배포 경로.">
+<title>FunASR 모델 선택 가이드</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../style.css">
+</head><body>
+<nav class="nav"><div class="container">
+<a href="index.html" class="nav-logo">FunASR</a>
+<div class="nav-links"><a href="index.html">홈</a><a href="https://github.com/modelscope/FunASR/blob/main/README_ko.md">README</a><a href="model-selection.html">모델 선택</a><a href="deployment-matrix.html">배포</a><a href="../api.html">API</a><a href="../vllm.html">vLLM</a><a href="../agent.html">Agent</a><a href="../benchmark.html">Benchmark</a></div>
+<div class="lang-dropdown"><button class="lang-btn">한국어</button><div class="lang-menu"><a href="../model-selection.html">English</a><a href="../zh/model-selection.html">中文</a><a href="../ja/model-selection.html">日本語</a><a href="model-selection.html" class="current">한국어</a></div></div>
+<a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
+</div></nav>
+<div class="content"><div class="container narrow">
+<h1>모델 선택 가이드</h1>
+<p>첫 모델을 고르고, Whisper 또는 cloud ASR와 비교하고, OpenAI 호환 API에서 노출할 model alias를 결정합니다.</p>
+<div class="toc-grid"><a href="#default">기본 선택</a><a href="#decision">결정표</a><a href="#aliases">API alias</a><a href="#runtime">runtime</a><a href="#benchmark">benchmark</a></div>
+<section id="default"><h2>망설이면 SenseVoice-Small</h2>
+<p>아직 확실하지 않다면 <strong>SenseVoice-Small</strong>부터 시작합니다. 데모, private API, 다국어 transcription, 화자 정보가 필요한 회의록, agent voice input에 좋은 기본값입니다.</p>
+<pre><code>from funasr import AutoModel
+
+model = AutoModel(
+    model="iic/SenseVoiceSmall",
+    vad_model="fsmn-vad",
+    spk_model="cam++",
+    device="cuda",  # portable smoke test에서는 "cpu"
+)
+result = model.generate(input="meeting.wav")</code></pre>
+</section>
+<section id="decision"><h2>결정표</h2>
+<table><tr><th>목적</th><th>먼저 시도</th><th>이유</th><th>다음 문서</th></tr>
+<tr><td>빠른 다국어 private transcription</td><td>SenseVoice-Small</td><td>ASR, emotion tag, audio event tag, CPU viability의 균형이 좋습니다.</td><td><a href="https://github.com/modelscope/FunASR/blob/main/README_ko.md#빠른-시작">README quickstart</a></td></tr>
+<tr><td>중국어 production ASR</td><td>Paraformer-Large</td><td>VAD와 punctuation을 조합하기 쉬운 성숙한 중국어 ASR 경로입니다.</td><td><a href="https://github.com/modelscope/FunASR/blob/main/README_ko.md#빠른-시작">README quickstart</a></td></tr>
+<tr><td>API example에서 영어 route 확인</td><td><code>paraformer-en</code></td><td>OpenAI 스타일 client에서 가벼운 영어 route를 확인하기 좋습니다.</td><td><a href="../agent.html#server">OpenAI API</a></td></tr>
+<tr><td>LLM-based ASR 또는 31개 언어 실험</td><td>Fun-ASR-Nano</td><td>LLM-based path입니다. decoder throughput이 중요하면 vLLM을 함께 씁니다.</td><td><a href="../vllm.html">vLLM guide</a></td></tr>
+<tr><td>실시간 자막 또는 call-center stream</td><td>Runtime WebSocket service</td><td>long-lived streaming session과 partial result에 맞습니다.</td><td><a href="https://github.com/modelscope/FunASR/tree/main/runtime">Runtime docs</a></td></tr>
+<tr><td>Whisper/cloud ASR에서 이전</td><td>먼저 SenseVoice-Small</td><td>모델별 tuning 전에 강한 baseline을 만들 수 있습니다.</td><td><a href="https://github.com/modelscope/FunASR/blob/main/docs/migration_from_whisper.md">Migration guide</a></td></tr></table>
+</section>
+<section id="aliases"><h2>OpenAI 호환 API alias</h2>
+<p><code>examples/openai_api</code> server는 짧은 alias를 제공합니다. application team은 model repository ID를 몰라도 연결할 수 있습니다.</p>
+<table><tr><th>Alias</th><th>실제 경로</th><th>사용 상황</th></tr>
+<tr><td><code>sensevoice</code></td><td><code>iic/SenseVoiceSmall</code></td><td>다국어 ASR, event tag, CPU/GPU behavior가 균형 잡힌 default private speech API.</td></tr>
+<tr><td><code>paraformer</code></td><td><code>paraformer-zh</code></td><td>중국어 production route.</td></tr>
+<tr><td><code>paraformer-en</code></td><td><code>paraformer-en</code></td><td>OpenAI 스타일 client의 가벼운 영어 route.</td></tr>
+<tr><td><code>fun-asr-nano</code></td><td><code>FunAudioLLM/Fun-ASR-Nano-2512</code></td><td>LLM-based ASR, 31개 언어 coverage, vLLM acceleration 평가.</td></tr></table>
+<pre><code>curl http://localhost:8000/v1/models
+python examples/openai_api/smoke_test.py --base-url http://localhost:8000 --model sensevoice</code></pre>
+</section>
+<section id="runtime"><h2>workload별 runtime</h2>
+<table><tr><th>workload</th><th>runtime path</th><th>메모</th></tr>
+<tr><td>Notebook 또는 일회성 평가</td><td>Python <code>AutoModel</code></td><td>install, model download, output shape를 확인하는 가장 짧은 경로입니다.</td></tr>
+<tr><td>사내 HTTP service</td><td>OpenAI 호환 API</td><td>OpenAI-style clients, Dify, n8n, LangChain, AutoGen, HTTP node를 재사용합니다.</td></tr>
+<tr><td>재현 가능한 local container demo</td><td>Docker Compose API</td><td>CPU-first smoke test입니다. CUDA 전에 image를 조정합니다.</td></tr>
+<tr><td>cluster 내부 private service</td><td>Kubernetes API template</td><td>private ClusterIP, persistent model cache, health probes, port-forward smoke test.</td></tr>
+<tr><td>live audio</td><td>Runtime WebSocket service</td><td>실제 오디오로 chunking, VAD, endpointing, reconnect, client backpressure를 검증합니다.</td></tr>
+<tr><td>LLM-based ASR throughput</td><td>Fun-ASR-Nano의 vLLM path</td><td>vLLM은 autoregressive decoding을 가속하며, non-autoregressive Paraformer에는 쓰지 않습니다.</td></tr></table>
+<p>runtime과 deployment target을 고를 때는 <a href="deployment-matrix.html">배포 선택표</a>도 확인하세요.</p>
+</section>
+<section id="benchmark"><h2>결정 전 benchmark</h2>
+<ul><li>짧은 clip, 긴 회의, silence, noise, overlapping speakers, domain vocabulary, target languages를 포함한 대표 오디오 20-50개를 준비합니다.</li><li>model name, model revision, FunASR version, device, CPU/GPU type, CUDA/PyTorch version, runtime path, batch size, warmup/model download time 제외 여부를 기록합니다.</li><li>transcript가 읽기 좋은지뿐 아니라 WER/CER 또는 human review로 품질을 확인합니다.</li><li>latency, throughput, memory, failures, upload size limit을 함께 추적합니다.</li><li>public smoke sample과 realistic private sample을 최소 1개씩 남깁니다.</li></ul>
+<p>migration work에서는 <a href="https://github.com/modelscope/FunASR/tree/main/examples/migration">migration benchmark example</a>과 <a href="https://github.com/modelscope/FunASR/blob/main/docs/migration_from_whisper.md">migration guide</a>를 사용합니다.</p>
+</section>
+</div></div>
+<footer><p>FunASR &middot; Tongyi Lab, Alibaba Group</p><p><a href="index.html">홈</a> &middot; <a href="model-selection.html">모델 선택</a> &middot; <a href="deployment-matrix.html">배포</a> &middot; <a href="../agent.html">Agent</a> &middot; <a href="../benchmark.html">Benchmark</a> &middot; <a href="../vllm.html">vLLM</a> &middot; <a href="https://github.com/modelscope/FunASR">GitHub</a></p></footer>
+</body></html>

--- a/model-selection.html
+++ b/model-selection.html
@@ -17,7 +17,7 @@
 <nav class="nav"><div class="container">
 <a href="index.html" class="nav-logo">FunASR</a>
 <div class="nav-links"><a href="index.html">Home</a><a href="tutorial.html">Tutorial</a><a href="training.html">Training</a><a href="model-registration.html">Develop</a><a href="api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">Benchmark</a></div>
-<div class="lang-dropdown"><button class="lang-btn">English</button><div class="lang-menu"><a href="model-selection.html" class="current">English</a><a href="zh/model-selection.html">中文</a><a href="ja/index.html">日本語</a></div></div>
+<div class="lang-dropdown"><button class="lang-btn">English</button><div class="lang-menu"><a href="model-selection.html" class="current">English</a><a href="zh/model-selection.html">中文</a><a href="ja/model-selection.html">日本語</a><a href="ko/model-selection.html">한국어</a></div></div>
 <a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
 </div></nav>
 <div class="content"><div class="container narrow">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -73,6 +73,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://modelscope.github.io/FunASR/ko/model-selection.html</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://modelscope.github.io/FunASR/ko/deployment-matrix.html</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>weekly</changefreq>
@@ -83,6 +89,12 @@
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://modelscope.github.io/FunASR/ja/model-selection.html</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://modelscope.github.io/FunASR/api.html</loc>

--- a/zh/model-selection.html
+++ b/zh/model-selection.html
@@ -17,7 +17,7 @@
 <nav class="nav"><div class="container">
 <a href="index.html" class="nav-logo">FunASR</a>
 <div class="nav-links"><a href="index.html">首页</a><a href="tutorial.html">教程</a><a href="training.html">训练</a><a href="model-registration.html">开发</a><a href="api.html">API</a><a href="vllm.html">vLLM</a><a href="agent.html">Agent</a><a href="benchmark.html">评测</a></div>
-<div class="lang-dropdown"><button class="lang-btn">中文</button><div class="lang-menu"><a href="../model-selection.html">English</a><a href="model-selection.html" class="current">中文</a><a href="../ja/index.html">日本語</a></div></div>
+<div class="lang-dropdown"><button class="lang-btn">中文</button><div class="lang-menu"><a href="../model-selection.html">English</a><a href="model-selection.html" class="current">中文</a><a href="../ja/model-selection.html">日本語</a><a href="../ko/model-selection.html">한국어</a></div></div>
 <a href="https://github.com/modelscope/FunASR" class="nav-github">GitHub</a>
 </div></nav>
 <div class="content"><div class="container narrow">


### PR DESCRIPTION
Summary:
- Add localized Japanese and Korean model selection pages on GitHub Pages.
- Route English and Chinese model-selection language switchers to the new pages.
- Point Japanese and Korean homepage model-selection links to local site pages and add both pages to the sitemap.

Validation:
- `git diff --check`
- HTML document count, relative link and anchor existence, four-language model-selection switcher, sitemap XML parse, Unicode NFC, and token-like string checker for touched website files