### PR TITLE
[feat] 说话人分离:可选返回每个说话人的声纹质心向量 (spk_embedding_center)

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -818,7 +818,16 @@ class AutoModel:
                     spk_embedding.cpu(), oracle_num=kwargs.get("preset_spk_num", None)
                 )
                 # del result['spk_embedding']
-                sv_output = postprocess(all_segments, None, labels, spk_embedding.cpu())
+                if kwargs.get("return_spk_center", False):
+                    sv_output, spk_center = postprocess(
+                        all_segments, None, labels, spk_embedding.cpu(), return_spk_center=True
+                    )
+                    # Per-speaker ERes2NetV2 centroids, indexed by the `spk` id in
+                    # sentence_info. Kept on the result for downstream voiceprint use
+                    # (the per-chunk spk_embedding below is still deleted to keep output small).
+                    result["spk_embedding_center"] = spk_center
+                else:
+                    sv_output = postprocess(all_segments, None, labels, spk_embedding.cpu())
                 if self.spk_mode == "punc_segment" and "timestamp" not in result and "timestamps" not in result:
                     logging.warning("No timestamps in ASR result (e.g. SenseVoice), falling back to vad_segment mode for speaker diarization.")
                     self.spk_mode = "vad_segment"

--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -818,16 +818,18 @@ class AutoModel:
                     spk_embedding.cpu(), oracle_num=kwargs.get("preset_spk_num", None)
                 )
                 # del result['spk_embedding']
+                # postprocess expects np.ndarray embeddings (per its type hint).
+                spk_embedding_np = spk_embedding.detach().cpu().numpy()
                 if kwargs.get("return_spk_center", False):
                     sv_output, spk_center = postprocess(
-                        all_segments, None, labels, spk_embedding.cpu(), return_spk_center=True
+                        all_segments, None, labels, spk_embedding_np, return_spk_center=True
                     )
                     # Per-speaker ERes2NetV2 centroids, indexed by the `spk` id in
                     # sentence_info. Kept on the result for downstream voiceprint use
                     # (the per-chunk spk_embedding below is still deleted to keep output small).
                     result["spk_embedding_center"] = spk_center
                 else:
-                    sv_output = postprocess(all_segments, None, labels, spk_embedding.cpu())
+                    sv_output = postprocess(all_segments, None, labels, spk_embedding_np)
                 if self.spk_mode == "punc_segment" and "timestamp" not in result and "timestamps" not in result:
                     logging.warning("No timestamps in ASR result (e.g. SenseVoice), falling back to vad_segment mode for speaker diarization.")
                     self.spk_mode = "vad_segment"

--- a/funasr/models/campplus/utils.py
+++ b/funasr/models/campplus/utils.py
@@ -143,7 +143,7 @@ def postprocess(
     labels: np.ndarray,
     embeddings: np.ndarray,
     return_spk_center: bool = False,
-) -> list:
+) -> Union[list, tuple]:
     """Postprocess.
     
         Args:
@@ -159,13 +159,6 @@ def postprocess(
         distribute_res.append([segments[i][0], segments[i][1], labels[i]])
     # merge the same speakers chronologically
     distribute_res = merge_seque(distribute_res)
-
-    # accquire speaker center
-    spk_embs = []
-    for i in range(labels.max() + 1):
-        spk_emb = embeddings[labels == i].mean(0)
-        spk_embs.append(spk_emb)
-    spk_embs = np.stack(spk_embs)
 
     def is_overlapped(t1, t2):
         """Is overlapped.
@@ -191,6 +184,10 @@ def postprocess(
     if return_spk_center:
         # spk_embs[i] is the centroid (mean of clustered chunk embeddings) for
         # corrected speaker label i, aligned with the `spk` ids in sentence_info.
+        # Computed lazily: only when the caller requests speaker centers.
+        spk_embs = np.stack(
+            [embeddings[labels == i].mean(0) for i in range(labels.max() + 1)]
+        )
         return distribute_res, spk_embs
     return distribute_res
 

--- a/funasr/models/campplus/utils.py
+++ b/funasr/models/campplus/utils.py
@@ -138,7 +138,11 @@ def extract_feature(audio):
 
 
 def postprocess(
-    segments: list, vad_segments: list, labels: np.ndarray, embeddings: np.ndarray
+    segments: list,
+    vad_segments: list,
+    labels: np.ndarray,
+    embeddings: np.ndarray,
+    return_spk_center: bool = False,
 ) -> list:
     """Postprocess.
     
@@ -184,6 +188,10 @@ def postprocess(
     # smooth the result
     distribute_res = smooth(distribute_res)
 
+    if return_spk_center:
+        # spk_embs[i] is the centroid (mean of clustered chunk embeddings) for
+        # corrected speaker label i, aligned with the `spk` ids in sentence_info.
+        return distribute_res, spk_embs
     return distribute_res
 
 


### PR DESCRIPTION
## 背景 / 动机
`AutoModel.generate` 做说话人分离时,`postprocess()` 内部其实已经算出了每个说话人的质心向量(同一聚类簇内各 chunk 嵌入的均值),但用完即丢、没有返回。下游若想做**说话人声纹 / 身份识别**,只能再额外跑一遍声纹模型重新抽取,白白浪费一次算力。

## 改动
新增可选参数 `return_spk_center`(默认 `False`):
- `funasr/models/campplus/utils.py::postprocess`:当 `return_spk_center=True` 时,额外返回 `spk_embs`(每个说话人的质心,按 `correct_labels` 修正后的说话人 id 对齐)。
- `funasr/auto/auto_model.py`:当 `generate(..., return_spk_center=True)` 时,在结果中加入 `spk_embedding_center`,形状 `[说话人数, 嵌入维度]`,其下标与 `sentence_info` 中的 `spk` 一一对应。逐 chunk 的 `spk_embedding` 仍按原逻辑删除,输出不膨胀。

## 兼容性
完全向后兼容:默认关闭;不传 `return_spk_center=True` 时 `postprocess()` 返回结构保持不变,现有调用方(`auto_model`、`auto_frontend`)均不受影响。

## 验证
本地用 `paraformer-zh` + `ERes2NetV2`(`spk_mode=punc_segment`)对一段双人音频测试:`spk_embedding_center` 形状为 `(2, 192)`,与 `sentence_info` 中的 2 个说话人对齐;两人质心 L2 归一化后余弦相似度约 0.34(可区分)。

## 用法
```python
res = model.generate(input=wav, return_spk_center=True)
centers = res[0]["spk_embedding_center"]  # np.ndarray, 形状 [说话人数, 维度]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
