### PR TITLE
fix(fun_asr_nano): make bf16/fp16 inference work instead of crashing

### DIFF
--- a/funasr/models/fun_asr_nano/model.py
+++ b/funasr/models/fun_asr_nano/model.py
@@ -571,11 +571,11 @@ class FunASRNano(nn.Module):
                 encoder_out_lens = kwargs["audio_embedding_lens"]
             else:
                 speech_lengths = batch["speech_lengths"][:, 0]
-                # fp16
-                if kwargs.get("fp16", False):
-                    speech = speech.to(torch.float16)
-                elif kwargs.get("bf16", False):
-                    speech = speech.to(torch.bfloat16)
+                # NOTE: the audio encoder contains fp32-only ops, so casting its
+                # input to fp16/bf16 here raises a dtype mismatch. The encoder
+                # therefore always runs in fp32; low precision (fp16/bf16) is
+                # applied to the LLM decoder only. The audio embeddings are cast
+                # to the LLM dtype automatically when written into inputs_embeds.
                 # audio encoder
                 encoder_out, encoder_out_lens = self.encode(speech, speech_lengths)
 


### PR DESCRIPTION
## Problem
`AutoModel.generate(..., bf16=True)` (or `fp16=True`) on Fun-ASR-Nano crashes with `RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Float`. The inference path casts the audio encoder **input** to bf16/fp16 but leaves the encoder **weights** in fp32.

## Fix
The SenseVoice-style audio encoder has fp32-only ops and must stay fp32. Low precision is only needed for the LLM decoder; the audio embeddings are already cast to the LLM dtype when written into `inputs_embeds`. So this drops the encoder-input cast.

## Verified
Fun-ASR-Nano-2512 on a 184-file Chinese set (H100): `bf16=True` now runs end-to-end with **CER unchanged (10.38% vs 10.36% fp32)**.

Note: the inference path also defaults `llm_dtype` to `fp32`, which upcasts the bf16-loaded LLM back to fp32; passing `bf16=True` keeps it bf16. A follow-up could make the inference default respect the model's configured `llm_dtype`.