### PR TITLE
fix(fun_asr_nano): warn when vLLM dtype=fp16 (degraded output)

### DIFF
--- a/funasr/models/fun_asr_nano/inference_vllm.py
+++ b/funasr/models/fun_asr_nano/inference_vllm.py
@@ -175,6 +175,13 @@ class FunASRNanoVLLM:
         self.device = device
         self.dtype = dtype
         self.torch_dtype = dtype_map.get(dtype, torch.bfloat16)
+        if self.torch_dtype == torch.float16:
+            logger.warning(
+                "dtype='fp16' can produce degraded or garbage transcription for "
+                "Fun-ASR-Nano (numerical overflow in the audio embedding path). "
+                "Use dtype='bf16' (recommended) or dtype='fp32'. On GPUs without "
+                "bfloat16 support (e.g. NVIDIA V100), use 'fp32'."
+            )
         self.model_dir = model_dir
 
         # Step 1: Prepare LLM weights for vLLM (extract from model.pt if needed)


### PR DESCRIPTION
## Problem

Fun-ASR-Nano vLLM inference (`AutoModelVLLM`) produces **degraded/garbage transcription in fp16** — reproduced on GPU as degenerate repeated tokens (e.g. `stud stud stud...`); users on V100 see it as empty output. This is a numerical-overflow issue in the audio embedding path; **bf16 and fp32 both produce correct output**.

This fails **silently** (no error, just wrong text), which is hard to diagnose — see #2976, where a user spent significant effort isolating it on a V100 (which lacks bf16 support, forcing fp16).

## Change

Add a clear warning when `dtype='fp16'` is used, recommending `bf16` (or `fp32` on GPUs without bf16 support like the V100). Minimal, non-breaking (7-line warning).

## Verified

On an H100, `AutoModelVLLM(..., dtype=...)` on `Fun-ASR-Nano-2512`:
- `fp16` → garbage (`stud stud...`)
- `fp32` → correct (`日本首相啊，女首相啊…`)
- `bf16` → correct

Refs #2976.