### PR TITLE
fix(load): clear FileNotFoundError for missing audio path

### DIFF
--- a/funasr/utils/load_utils.py
+++ b/funasr/utils/load_utils.py
@@ -97,6 +97,19 @@ def load_audio_text_image_video(
     ):  # download url to local file
         data_or_path_or_list = download_from_url(data_or_path_or_list)
 
+    # Fail fast with a clear error if an audio file path does not exist, instead of
+    # silently passing the string downstream (which later crashes with a cryptic
+    # "expected Tensor ... but got str" deep inside the model).
+    if (
+        isinstance(data_or_path_or_list, str)
+        and data_type in (None, "sound")
+        and not data_or_path_or_list.startswith(("http://", "https://"))
+        and not os.path.exists(data_or_path_or_list)
+    ):
+        raise FileNotFoundError(
+            f"Audio file not found: {data_or_path_or_list!r}. Pass a valid local file "
+            f"path, URL, numpy array, torch.Tensor, or bytes."
+        )
     if (isinstance(data_or_path_or_list, str) and os.path.exists(data_or_path_or_list)) or hasattr(data_or_path_or_list, 'read'):  # local file or bytes io
         if data_type is None or data_type == "sound":
             if hasattr(data_or_path_or_list, "read") and hasattr(data_or_path_or_list, "seek"):


### PR DESCRIPTION
## Problem (new-user UX)

Following the README quickstart with the placeholder path `input="meeting.wav"` (a file new users don't have) does **not** give a clear error. Instead it crashes deep inside the VAD with a cryptic:

```
TypeError: expected Tensor as element 1 in argument 0, but got str
  ... fsmn_vad_streaming/model.py: torch.cat((cache["prev_samples"], audio_sample_list[0]))
```

Root cause: in `load_audio_text_image_video`, audio is only loaded `if os.path.exists(path)`. A non-existent path string falls through the gate and is passed downstream as a raw `str`.

## Fix

Raise a clear `FileNotFoundError` naming the missing path, before the load gate. Scoped to `data_type="sound"` so text/PUNC inputs are unaffected.

## Tested (fresh venv, as a new user)

```
CASE 1 missing file -> FileNotFoundError: Audio file not found: 'meeting.wav'. Pass a valid local file path, URL, numpy array, torch.Tensor, or bytes.
CASE 2 valid file   -> unchanged, transcribes normally
```

Found by walking through the README quickstart as a first-time user.