### PR TITLE
fix(cli): valid SRT timestamps + clear json duration fields

### DIFF
--- a/funasr/cli.py
+++ b/funasr/cli.py
@@ -48,10 +48,24 @@ def _format_output(text, segments, timestamps, fmt, audio_path, model_name, lang
             obj["segments"] = segments
         if timestamps:
             obj["timestamps"] = timestamps
-        obj.update({"file": os.path.basename(audio_path), "model": model_name, "language": language or "auto", "duration_s": round(elapsed, 3)})
+        try:
+            import soundfile as sf
+            audio_dur = round(sf.info(audio_path).duration, 3)
+        except Exception:
+            audio_dur = None
+        obj.update({"file": os.path.basename(audio_path), "model": model_name, "language": language or "auto", "audio_duration_s": audio_dur, "processing_s": round(elapsed, 3)})
         return json.dumps(obj, ensure_ascii=False, indent=2)
     elif fmt == "srt":
-        return format_srt(segments) if segments else f"1\n00:00:00,000 --> 99:59:59,999\n{text}\n"
+        if segments:
+            return format_srt(segments)
+        # No per-sentence timestamps: emit one valid cue spanning the whole audio
+        # (instead of a bogus 99:59:59 end time).
+        try:
+            import soundfile as sf
+            dur_ms = int(sf.info(audio_path).duration * 1000)
+        except Exception:
+            dur_ms = 0
+        return f"1\n00:00:00,000 --> {_srt_time(dur_ms)}\n{text}\n"
     elif fmt == "tsv":
         return format_tsv(segments) if segments else f"start\tend\ttext\n0.000\t0.000\t{text}"
 


### PR DESCRIPTION
Found by smoke-testing the new `funasr` CLI as a first-time user.

**SRT bug:** `funasr audio.wav -f srt` produced an invalid cue when the model returns no per-sentence timestamps — a bogus `00:00:00,000 --> 99:59:59,999` end. Now spans the real audio duration.

**json bug:** `duration_s` was actually the *processing* time — a 60s file showed `"duration_s": 2.3`, misleading users into thinking the audio is 2.3s. Split into `audio_duration_s` (real length) + `processing_s` (elapsed). Safe rename (the new CLI is unreleased).

Tested:
```
-f srt  -> 00:00:00,000 --> 00:00:59,520  (real duration)
-f json -> "audio_duration_s": 59.52, "processing_s": 2.165
```