### PR TITLE
fix(cli): use sentence_info "sentence" field for segment text

### DIFF
--- a/funasr/cli.py
+++ b/funasr/cli.py
@@ -145,7 +145,7 @@ def main():
         segments = []
         if "sentence_info" in result[0]:
             for seg in result[0]["sentence_info"]:
-                s = {"start": seg.get("start", 0), "end": seg.get("end", 0), "text": clean_text(seg.get("text", ""))}
+                s = {"start": seg.get("start", 0), "end": seg.get("end", 0), "text": clean_text(seg.get("sentence") or seg.get("text", ""))}
                 if args.spk and "spk" in seg:
                     s["speaker"] = seg["spk"]
                 segments.append(s)


### PR DESCRIPTION
Found dogfooding the CLI. `--spk -f srt`/`-f json` produced cues with correct timestamps but **empty text**, because the CLI read `seg.get("text")` while `sentence_info` elements use the key `sentence`. Now reads `sentence` (fallback `text`).

Tested: `--spk -f srt` now emits valid subtitles with text + per-sentence timestamps:
```
1
00:00:02,919 --> 00:00:08,169
日本首相啊男女首相
```