### PR TITLE
fix(cli): correct fun-asr-nano model id (Fun-ASR-Nano-2512)

### DIFF
--- a/funasr/cli.py
+++ b/funasr/cli.py
@@ -11,7 +11,7 @@ MODEL_CONFIGS = {
     "sensevoice": {"model": "iic/SenseVoiceSmall", "vad_model": "fsmn-vad", "vad_kwargs": {"max_single_segment_time": 30000}},
     "paraformer": {"model": "paraformer-zh", "vad_model": "fsmn-vad", "punc_model": "ct-punc"},
     "paraformer-en": {"model": "paraformer-en", "vad_model": "fsmn-vad"},
-    "fun-asr-nano": {"model": "FunAudioLLM/Fun-ASR-Nano"},
+    "fun-asr-nano": {"model": "FunAudioLLM/Fun-ASR-Nano-2512", "vad_model": "fsmn-vad"},
 }
 
 


### PR DESCRIPTION
Found dogfooding the CLI. `funasr --model fun-asr-nano` failed because the preset pointed to `FunAudioLLM/Fun-ASR-Nano` (HF **401, does not exist**); the real id is `FunAudioLLM/Fun-ASR-Nano-2512` (HF 200). Also adds `fsmn-vad` so long audio is segmented.