### PR TITLE
docs: python wss server now supports multiple concurrent clients

### DIFF
--- a/runtime/quick_start.md
+++ b/runtime/quick_start.md
@@ -11,7 +11,7 @@ You can use FunASR in the following ways:
 ## Service Deployment SDK
 
 ### Python version Example
-Supports real-time streaming speech recognition, uses non-streaming models for error correction, and outputs text with punctuation. Currently, only single client is supported. For multi-concurrency, please refer to the C++ version service deployment SDK below.
+Supports real-time streaming speech recognition, uses non-streaming models for error correction, and outputs text with punctuation. It now supports multiple concurrent clients with non-blocking inference (tune per-stage concurrency via --concurrent_vad / --concurrent_asr_online / --concurrent_asr_offline / --concurrent_punc / --concurrent_sv). For maximum throughput, the C++ version service deployment SDK below is still recommended.
 
 #### Server Deployment
 

--- a/runtime/quick_start_zh.md
+++ b/runtime/quick_start_zh.md
@@ -13,7 +13,7 @@
 
 #### python版本示例
 
-支持实时流式语音识别，并且会用非流式模型进行纠错，输出文本带有标点。目前只支持单个client，如需多并发请参考下方c++版本服务部署SDK
+支持实时流式语音识别，并且会用非流式模型进行纠错，输出文本带有标点。现已支持多个客户端并发(非阻塞推理,可用 --concurrent_vad / --concurrent_asr_online / --concurrent_asr_offline / --concurrent_punc / --concurrent_sv 调节各阶段并发度);如需更高吞吐,仍推荐下方 c++ 版本服务部署 SDK
 
 ##### 服务端部署
 ```shell


### PR DESCRIPTION
`runtime/python/websocket/funasr_wss_server.py` was upgraded to handle **multiple concurrent clients** (non-blocking inference + per-stage concurrency semaphores `--concurrent_vad/asr_online/asr_offline/punc/sv`; the server even prints "now supports multi-client"), but `quick_start.md`/`quick_start_zh.md` still said only a single client is supported. Updated both EN + ZH. Reported by @Chaiyym in #2976.