### PR TITLE
docs: make README quickstart runnable and output truthful

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,19 @@ pip install funasr
 
 ```python
 from funasr import AutoModel
+from funasr.utils.postprocess_utils import rich_transcription_postprocess
 
 model = AutoModel(model="iic/SenseVoiceSmall", vad_model="fsmn-vad", spk_model="cam++", device="cuda")
-result = model.generate(input="meeting.wav")
+result = model.generate(input="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav")
+
+# One call returns VAD segments with speaker id + timestamps — render them however you like:
+for seg in result[0]["sentence_info"]:
+    print(f"[{seg['start']/1000:.1f}s] Speaker {seg['spk']}: {rich_transcription_postprocess(seg['sentence'])}")
 ```
 
 **Output** — structured text with speaker labels, timestamps, and punctuation:
 ```
-[00:00.4 → 00:03.8] Speaker 0: Let's discuss the Q3 plan.
-[00:04.2 → 00:07.1] Speaker 1: Sounds good. I have three points.
-[00:07.5 → 00:12.3] Speaker 0: Go ahead. We have 30 minutes.
+[0.6s] Speaker 0: 欢迎大家来体验达摩院推出的语音识别模型
 ```
 
 That's it. **One model, one call** — VAD segmentation, speech recognition, punctuation, speaker diarization all happen automatically.
@@ -61,7 +64,7 @@ For highest accuracy across 31 languages (including Chinese dialects), use [Fun-
 from funasr import AutoModel
 
 model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", vad_model="fsmn-vad", device="cuda")
-result = model.generate(input="meeting.wav")
+result = model.generate(input="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav")
 ```
 
 With vLLM acceleration (16x faster, batch processing):
@@ -181,7 +184,7 @@ from funasr import AutoModel
 
 # Chinese production (VAD + ASR + punctuation + speaker)
 model = AutoModel(model="paraformer-zh", vad_model="fsmn-vad", punc_model="ct-punc", spk_model="cam++", device="cuda")
-result = model.generate(input="meeting.wav", hotword="关键词 20")
+result = model.generate(input="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav", hotword="关键词 20")
 
 # 31 languages with timestamps
 model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", hub="hf", trust_remote_code=True,

--- a/README_zh.md
+++ b/README_zh.md
@@ -38,16 +38,19 @@ pip install funasr
 
 ```python
 from funasr import AutoModel
+from funasr.utils.postprocess_utils import rich_transcription_postprocess
 
 model = AutoModel(model="iic/SenseVoiceSmall", vad_model="fsmn-vad", spk_model="cam++", device="cuda")
-result = model.generate(input="meeting.wav")
+result = model.generate(input="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav")
+
+# 一次调用即返回带说话人 id 和时间戳的 VAD 分段，可自由渲染：
+for seg in result[0]["sentence_info"]:
+    print(f"[{seg['start']/1000:.1f}s] 说话人{seg['spk']}: {rich_transcription_postprocess(seg['sentence'])}")
 ```
 
 **输出** — 带说话人标签、时间戳和标点的结构化文本：
 ```
-[00:00.4 → 00:03.8] 说话人0: 我们今天讨论一下 Q3 的计划。
-[00:04.2 → 00:07.1] 说话人1: 好的，我有三个要点。
-[00:07.5 → 00:12.3] 说话人0: 请讲，我们还有 30 分钟。
+[0.6s] 说话人0: 欢迎大家来体验达摩院推出的语音识别模型
 ```
 
 一个模型、一次调用 — VAD 分段、语音识别、标点恢复、说话人分离全部自动完成。
@@ -60,7 +63,7 @@ result = model.generate(input="meeting.wav")
 from funasr import AutoModel
 
 model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", vad_model="fsmn-vad", device="cuda")
-result = model.generate(input="meeting.wav")
+result = model.generate(input="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav")
 ```
 
 使用 vLLM 加速（批量处理快 16 倍）：
@@ -179,7 +182,7 @@ from funasr import AutoModel
 
 # 中文生产级（VAD + 识别 + 标点 + 说话人）
 model = AutoModel(model="paraformer-zh", vad_model="fsmn-vad", punc_model="ct-punc", spk_model="cam++", device="cuda")
-result = model.generate(input="meeting.wav", hotword="关键词 20")
+result = model.generate(input="https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/asr_example_zh.wav", hotword="关键词 20")
 
 # 31 种语言 + 时间戳
 model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", hub="hf", trust_remote_code=True,


### PR DESCRIPTION
## Problem

The README quickstart was broken for new users:

1. **It does not run.** The first example calls `model.generate(input="meeting.wav")`, but no `meeting.wav` ships with the repo, so the very first thing a new user copies fails with a file-not-found error.
2. **The output is not real.** It showed a hand-written `[time] Speaker N: text` block. `model.generate()` never returns that — it returns raw SenseVoice tags in `result[0]["text"]` and per-utterance speaker id + timestamps in `result[0]["sentence_info"]`.

## Fix

- Use the canonical FunASR sample URL (`asr_example_zh.wav`, already used throughout the examples) so the first run just works — AutoModel downloads and transcribes it with zero setup.
- Add the few lines that turn `sentence_info` into the labeled `[time] Speaker N: text` output, and show the **real** output for that sample.
- Replace the remaining `meeting.wav` placeholders (Fun-ASR-Nano example, hotword example) with the same URL so every snippet is runnable.

## Verification

Ran the exact new snippet end-to-end on GPU (SenseVoice + fsmn-vad + cam++):

```
[0.6s] Speaker 0: 欢迎大家来体验达摩院推出的语音识别模型
```

No structural/header changes — only the quickstart code and its output.
