### PR TITLE
docs: fix README streaming example (runnable + actually streams)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,20 @@ model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", hub="hf", trust_remote_
                   vad_model="fsmn-vad", vad_kwargs={"max_single_segment_time": 30000}, device="cuda")
 result = model.generate(input="audio.wav", batch_size=1)
 
-# Streaming real-time
+# Streaming real-time (feed audio chunk by chunk)
+import soundfile as sf
 model = AutoModel(model="paraformer-zh-streaming", device="cuda")
-result = model.generate(input="chunk.wav", cache={}, chunk_size=[0, 10, 5])
+audio, sr = sf.read("speech.wav", dtype="float32")   # 16 kHz mono
+chunk_size = [0, 10, 5]                               # 600 ms chunks
+chunk_stride = chunk_size[1] * 960
+cache = {}
+n_chunks = (len(audio) - 1) // chunk_stride + 1
+for i in range(n_chunks):
+    chunk = audio[i * chunk_stride : (i + 1) * chunk_stride]
+    res = model.generate(input=chunk, cache=cache, is_final=(i == n_chunks - 1),
+                         chunk_size=chunk_size, encoder_chunk_look_back=4, decoder_chunk_look_back=1)
+    if res[0]["text"]:
+        print(res[0]["text"], end="", flush=True)
 
 # Emotion recognition
 model = AutoModel(model="emotion2vec_plus_large", device="cuda")

--- a/README_zh.md
+++ b/README_zh.md
@@ -189,9 +189,20 @@ model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", hub="hf", trust_remote_
                   vad_model="fsmn-vad", vad_kwargs={"max_single_segment_time": 30000}, device="cuda")
 result = model.generate(input="audio.wav", batch_size=1)
 
-# 流式实时识别
+# 流式实时识别(逐块喂音频)
+import soundfile as sf
 model = AutoModel(model="paraformer-zh-streaming", device="cuda")
-result = model.generate(input="chunk.wav", cache={}, chunk_size=[0, 10, 5])
+audio, sr = sf.read("speech.wav", dtype="float32")   # 16 kHz 单声道
+chunk_size = [0, 10, 5]                               # 每块 600ms
+chunk_stride = chunk_size[1] * 960
+cache = {}
+n_chunks = (len(audio) - 1) // chunk_stride + 1
+for i in range(n_chunks):
+    chunk = audio[i * chunk_stride : (i + 1) * chunk_stride]
+    res = model.generate(input=chunk, cache=cache, is_final=(i == n_chunks - 1),
+                         chunk_size=chunk_size, encoder_chunk_look_back=4, decoder_chunk_look_back=1)
+    if res[0]["text"]:
+        print(res[0]["text"], end="", flush=True)
 
 # 情感识别
 model = AutoModel(model="emotion2vec_plus_large", device="cuda")


### PR DESCRIPTION
## Problem

The Usage section's streaming example was broken and misleading:

```python
# Streaming real-time
model = AutoModel(model="paraformer-zh-streaming", device="cuda")
result = model.generate(input="chunk.wav", cache={}, chunk_size=[0, 10, 5])
```

1. **Not runnable** — `chunk.wav` is a placeholder file that doesn't exist.
2. **Doesn't actually stream** — a single one-shot `generate()` call missing `is_final`, `encoder_chunk_look_back`/`decoder_chunk_look_back`, and the chunk loop. A user can't learn streaming from it.

## Fix

Replace it with the real chunk-by-chunk loop, matching the repo's own example (`examples/industrial_data_pretraining/paraformer_streaming/demo.py`): read the audio, iterate fixed-stride chunks, pass `cache` + `is_final` + look-back, and print partial text per chunk. Applied to both `README.md` and `README_zh.md`.

## Verification

Ran the new snippet on GPU with `paraformer-zh-streaming` — it emits incremental text chunk by chunk and reconstructs the full sentence:

```
欢迎大 / 家来 / 体验达 / 摩院推 / 出的语 / 音识 / 别模型
-> 欢迎大家来体验达摩院推出的语音识别模型
```

Only the streaming code example changes — no header/structure edits.
