### PR TITLE
ci: auto-create GitHub Release on version tag push

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,21 @@
+name: Release on tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" --generate-notes --verify-tag --title "${{ github.ref_name }}"


### PR DESCRIPTION
Adds a workflow that publishes a GitHub Release (with auto-generated notes) whenever a  tag is pushed, so PyPI releases stay in sync with GitHub Releases. Uses the built-in  CLI +  (no third-party action).