### PR TITLE
docs(vllm_guide): drop stale repetition_penalty hardcode note

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -307,7 +307,6 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 | 1.5–3.0 s | Partially correct |
 | > 3.0 s | Accurate output |
 
-> Note: `repetition_penalty=1.3` is hardcoded internally to prevent short-chunk repetition degradation.
 
 ---
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -306,7 +306,6 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 | 1.5-3.0s | 部分正确 |
 | > 3.0s | 准确输出 |
 
-> Note: `repetition_penalty=1.3` 内部硬编码，防止短 chunk 重复退化。
 
 ---
 

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -307,7 +307,6 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 | 1.5-3.0s | 部分正确 |
 | > 3.0s | 准确输出 |
 
-> Note: `repetition_penalty=1.3` 内部硬编码，防止短 chunk 重复退化。
 
 ---
 


### PR DESCRIPTION
Removes the stale note `repetition_penalty=1.3 is hardcoded internally...` from the vLLM guides. The forced repetition_penalty was removed in #2974 (it over-penalized naturally repeated Chinese characters), so the note is now incorrect. Reported by @qiulang in #3006 (point 1).