### PR TITLE
fix(qwen3-asr): map ISO/short language codes to qwen-asr canonical names

### DIFF
--- a/funasr/models/qwen3_asr/model.py
+++ b/funasr/models/qwen3_asr/model.py
@@ -10,6 +10,22 @@ import torch.nn as nn
 from funasr.register import tables
 
 
+# qwen-asr's validate_language() only accepts canonical full names ("Chinese", "English",
+# ...), but FunASR documents short/ISO codes ("zh", "en", "auto") as valid language hints.
+# Defined at module level so the lookup table is built once, not on every inference call.
+_ISO_LANG_ALIASES = {
+    "zh": "Chinese", "zh-cn": "Chinese", "zho": "Chinese", "cmn": "Chinese",
+    "en": "English", "yue": "Cantonese", "ar": "Arabic", "de": "German",
+    "fr": "French", "es": "Spanish", "pt": "Portuguese", "id": "Indonesian",
+    "it": "Italian", "ko": "Korean", "ru": "Russian", "th": "Thai",
+    "vi": "Vietnamese", "ja": "Japanese", "tr": "Turkish", "hi": "Hindi",
+    "ms": "Malay", "nl": "Dutch", "sv": "Swedish", "da": "Danish",
+    "fi": "Finnish", "pl": "Polish", "cs": "Czech", "fil": "Filipino",
+    "fa": "Persian", "el": "Greek", "ro": "Romanian", "hu": "Hungarian",
+    "mk": "Macedonian",
+}
+
+
 @tables.register("model_classes", "Qwen3ASR")
 @tables.register("model_classes", "Qwen/Qwen3-ASR-1.7B")
 @tables.register("model_classes", "Qwen/Qwen3-ASR-0.6B")
@@ -150,6 +166,14 @@ class Qwen3ASR(nn.Module):
         time1 = time.perf_counter()
 
         language = kwargs.get("language", None)
+        # Normalize FunASR's documented short/ISO codes (and "auto") to qwen-asr full names
+        # so a hint like language="zh" doesn't raise "Unsupported language: Zh".
+        if language is not None:
+            _lk = str(language).strip().lower()
+            if _lk in ("auto", "none", ""):
+                language = None
+            else:
+                language = _ISO_LANG_ALIASES.get(_lk, language)
         return_time_stamps = kwargs.get("return_time_stamps", False) or kwargs.get("output_timestamp", False)
         context = kwargs.get("context", "")
 


### PR DESCRIPTION
## Problem

`Qwen3ASR.inference()` forwards the `language` hint straight to qwen-asr's `transcribe()`, but qwen-asr's `validate_language()` only accepts **canonical full names** (`Chinese`, `English`, …). FunASR, however, documents short/ISO codes as valid language hints — `funasr/auto/auto_model.py`:

```
- language (str): Language hint ("auto", "zh", "en", "Chinese", etc.)
```

So passing a documented hint like `language="zh"` crashes:

```python
from funasr import AutoModel
m = AutoModel(model="Qwen/Qwen3-ASR-1.7B")
m.generate(input="audio.wav", language="zh")
# ValueError: Unsupported language: Zh. Supported: ['Chinese', 'English', ...]
```

(qwen-asr's `normalize_language_name("zh")` → `"Zh"`, which is not in its full-name list.)

## Fix

In `Qwen3ASR.inference()`, map common ISO/short codes — and `"auto"` (→ auto-detect) — to qwen-asr's canonical names before calling `transcribe()`. Full names like `"Chinese"` pass through unchanged, so existing behavior is preserved.

## Verification

Same 12 s clip, `language="zh"`, `Qwen/Qwen3-ASR-1.7B`:

| | result |
|---|---|
| **before** | `ValueError: Unsupported language: Zh` |
| **after** | `不够，都叫运动当中的误差。每个误差都会影响。` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
