### PR TITLE
docs(README): benchmark — show flagship Fun-ASR-Nano at its vLLM speed (340x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Trying FunASR for the first time? Use the [Colab quickstart](./examples/colab/) 
 
 | Model | GPU Speed | CPU Speed | vs Whisper-large-v3 |
 |-------|-----------|-----------|-------------------|
+| **Fun-ASR-Nano** (vLLM) | **340x** realtime | — | 🚀 **26x faster** |
 | **SenseVoice-Small** | **170x** realtime | **17x** realtime | 🚀 **13x faster** |
 | **Paraformer-Large** | **120x** realtime | **15x** realtime | 🚀 **9x faster** |
 | Whisper-large-v3-turbo | 46x realtime | ❌ | 3.4x faster |
-| **Fun-ASR-Nano** | 17x realtime | 3.6x realtime | 1.3x faster |
 | Whisper-large-v3 | 13x realtime | ❌ | baseline |
 
 > **Key takeaway:** FunASR models run on CPU faster than Whisper runs on GPU.


### PR DESCRIPTION
The benchmark table listed Fun-ASR-Nano at its **torch** GPU speed (17x), which made the flagship look slower than SenseVoice/Paraformer and barely faster than Whisper. Fun-ASR-Nano's headline is the **vLLM** path — **340x realtime, 26x faster than Whisper-large-v3** — same number shown on funasr.com/vs-whisper. Moved it to the top row and labelled `(vLLM)`.