### PR TITLE
docs(i18n README): align benchmark with canonical (add Chinese CER, flagship Nano 340x)

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -77,13 +77,13 @@ result = model.generate(input="meeting.wav")
 
 > 184件の長時間音声（計192分）。[詳細レポート →](https://modelscope.github.io/FunASR/benchmark.html)
 
-| モデル | GPU速度 | CPU速度 | Whisper-large-v3比 |
-|--------|---------|---------|-------------------|
-| **SenseVoice-Small** | **170倍**リアルタイム | **17倍**リアルタイム | 🚀 **13倍高速** |
-| **Paraformer-Large** | **120倍**リアルタイム | **15倍**リアルタイム | 🚀 **9倍高速** |
-| Whisper-large-v3-turbo | 46倍リアルタイム | ❌ | 3.4倍高速 |
-| **Fun-ASR-Nano** | 17倍リアルタイム | 3.6倍リアルタイム | 1.3倍高速 |
-| Whisper-large-v3 | 13倍リアルタイム | ❌ | ベースライン |
+| モデル | 中国語 CER ↓ | GPU速度 | CPU速度 | Whisper-large-v3比 |
+|--------|------|---------|---------|-------------------|
+| **Fun-ASR-Nano**（vLLM） | **8.20%** | **340倍**リアルタイム | — | 🚀 **26倍高速** |
+| **SenseVoice-Small** | **7.81%** | **170倍**リアルタイム | **17倍**リアルタイム | 🚀 **13倍高速** |
+| **Paraformer-Large** | 10.18% | **120倍**リアルタイム | **15倍**リアルタイム | 🚀 **9倍高速** |
+| Whisper-large-v3-turbo | 21.71% | 46倍リアルタイム | ❌ | 3.4倍高速 |
+| Whisper-large-v3 | 20.02% | 13倍リアルタイム | ❌ | ベースライン |
 
 > **ポイント：** FunASRのCPU速度は、WhisperのGPU速度より速い。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -77,13 +77,13 @@ result = model.generate(input="meeting.wav")
 
 > 184개 장시간 오디오(총 192분). [상세 보고서 →](https://modelscope.github.io/FunASR/benchmark.html)
 
-| 모델 | GPU 속도 | CPU 속도 | Whisper-large-v3 대비 |
-|------|----------|----------|---------------------|
-| **SenseVoice-Small** | **170배** 실시간 | **17배** 실시간 | 🚀 **13배 빠름** |
-| **Paraformer-Large** | **120배** 실시간 | **15배** 실시간 | 🚀 **9배 빠름** |
-| Whisper-large-v3-turbo | 46배 실시간 | ❌ | 3.4배 빠름 |
-| **Fun-ASR-Nano** | 17배 실시간 | 3.6배 실시간 | 1.3배 빠름 |
-| Whisper-large-v3 | 13배 실시간 | ❌ | 기준선 |
+| 모델 | 중국어 CER ↓ | GPU 속도 | CPU 속도 | Whisper-large-v3 대비 |
+|------|------|----------|----------|---------------------|
+| **Fun-ASR-Nano**(vLLM) | **8.20%** | **340배** 실시간 | — | 🚀 **26배 빠름** |
+| **SenseVoice-Small** | **7.81%** | **170배** 실시간 | **17배** 실시간 | 🚀 **13배 빠름** |
+| **Paraformer-Large** | 10.18% | **120배** 실시간 | **15배** 실시간 | 🚀 **9배 빠름** |
+| Whisper-large-v3-turbo | 21.71% | 46배 실시간 | ❌ | 3.4배 빠름 |
+| Whisper-large-v3 | 20.02% | 13배 실시간 | ❌ | 기준선 |
 
 > **핵심:** FunASR의 CPU 속도가 Whisper의 GPU 속도보다 빠릅니다.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -102,13 +102,13 @@ results = model.generate(["audio1.wav", "audio2.wav"], language="auto")
 
 > 184 条长音频（共 192 分钟）。[完整报告 →](https://modelscope.github.io/FunASR/zh/benchmark.html)
 
-| 模型 | GPU 速度 | CPU 速度 | 对比 Whisper-large-v3 |
-|------|----------|----------|---------------------|
-| **SenseVoice-Small** | **170 倍**实时 | **17 倍**实时 | 🚀 **快 13 倍** |
-| **Paraformer-Large** | **120 倍**实时 | **15 倍**实时 | 🚀 **快 9 倍** |
-| Whisper-large-v3-turbo | 46 倍实时 | ❌ | 快 3.4 倍 |
-| **Fun-ASR-Nano** | 17 倍实时 | 3.6 倍实时 | 快 1.3 倍 |
-| Whisper-large-v3 | 13 倍实时 | ❌ | 基准 |
+| 模型 | 中文 CER ↓ | GPU 速度 | CPU 速度 | 对比 Whisper-large-v3 |
+|------|------|----------|----------|---------------------|
+| **Fun-ASR-Nano**（vLLM） | **8.20%** | **340 倍**实时 | — | 🚀 **快 26 倍** |
+| **SenseVoice-Small** | **7.81%** | **170 倍**实时 | **17 倍**实时 | 🚀 **快 13 倍** |
+| **Paraformer-Large** | 10.18% | **120 倍**实时 | **15 倍**实时 | 🚀 **快 9 倍** |
+| Whisper-large-v3-turbo | 21.71% | 46 倍实时 | ❌ | 快 3.4 倍 |
+| Whisper-large-v3 | 20.02% | 13 倍实时 | ❌ | 基准 |
 
 > **一句话：** FunASR 在 CPU 上的速度，比 Whisper 在 GPU 上还快。
 


### PR DESCRIPTION
The zh/ja/ko READMEs still had the old benchmark table — no CER column, and Fun-ASR-Nano shown at its torch speed (17x), which undersold the flagship and was inconsistent with README.md and funasr.com. Aligned all three to the canonical numbers: Chinese CER (Nano 8.20%/SenseVoice 7.81%/Paraformer 10.18%/Whisper 20.02%) and Fun-ASR-Nano at its vLLM speed (340x, 26x faster), moved to the top row.