### PR TITLE
fix(paraformer): CIF crashes (IndexError) on segments with no fired boundaries

### DIFF
--- a/funasr/models/paraformer/cif_predictor.py
+++ b/funasr/models/paraformer/cif_predictor.py
@@ -616,6 +616,15 @@ def cif_v1_export(hidden, alphas, threshold: float):
     device = hidden.device
     dtype = hidden.dtype
     batch_size, len_time, hidden_size = hidden.size()
+    if fire_idxs.sum() == 0:
+        # No integration boundaries fired (e.g. a very short / silent
+        # segment): return zero frames instead of indexing into the
+        # resulting empty tensors, which raised an IndexError.
+        max_label_len = torch.round(alphas.sum(-1)).int().max()
+        return (
+            torch.zeros(batch_size, max_label_len, hidden_size, dtype=dtype, device=device),
+            fires,
+        )
     threshold = torch.tensor([threshold], dtype=alphas.dtype).to(alphas.device)
 
     frames = torch.zeros(batch_size, len_time, hidden_size, dtype=dtype, device=device)
@@ -853,6 +862,15 @@ def cif_v1(hidden, alphas, threshold):
     device = hidden.device
     dtype = hidden.dtype
     batch_size, len_time, hidden_size = hidden.size()
+    if fire_idxs.sum() == 0:
+        # No integration boundaries fired (e.g. a very short / silent
+        # segment): return zero frames instead of indexing into the
+        # resulting empty tensors, which raised an IndexError.
+        max_label_len = torch.round(alphas.sum(-1)).int().max()
+        return (
+            torch.zeros(batch_size, max_label_len, hidden_size, dtype=dtype, device=device),
+            fires,
+        )
     # frames = torch.zeros(batch_size, len_time, hidden_size, dtype=dtype, device=device)
     # prefix_sum_hidden = torch.cumsum(alphas.unsqueeze(-1).tile((1, 1, hidden_size)) * hidden, dim=1)
     frames = torch.zeros(batch_size, len_time, hidden_size, dtype=dtype, device=device)


### PR DESCRIPTION
`cif_v1` (and `cif_v1_export`) crash with `IndexError: index is out of bounds for dimension with size 0` when a segment produces **no CIF firings** (e.g. a very short or near-silent VAD segment): `frames = prefix_sum_hidden[fire_idxs]` is empty, so `shift_frames[shift_batch_idxs] = 0` indexes into an empty tensor.\n\nRepro: Paraformer-zh (`funasr/paraformer-zh`) on a 184-file Chinese benchmark crashed on 5 files. Added an early return of zero frames for the no-fire case.\n\n**Verified:** with the guard, all 184 files decode (was 179/184), and the micro-average CER is unchanged at 10.17% (matches the published benchmark).