### PR TITLE
feat(AutoModelVLLM): warn on over-long single-pass audio (silent truncation)

### DIFF
--- a/funasr/auto/auto_model_vllm.py
+++ b/funasr/auto/auto_model_vllm.py
@@ -296,7 +296,46 @@ class AutoModelVLLM:
         Returns:
             List of result dicts with "key" and "text" fields.
         """
+        self._warn_if_audio_too_long(inputs)
         return self._engine.generate(inputs, **kwargs)
+
+    def _warn_if_audio_too_long(self, inputs, max_safe_sec=40.0):
+        """Warn (once) if a single audio input is long enough to be truncated.
+
+        Fun-ASR-Nano is a segment-level (LLM-)ASR model. Decoding very long
+        audio in a single pass can silently truncate or degrade the output -- the
+        decode hits ``max_new_tokens`` long before the audio ends, so the user
+        gets a partial transcript with no error. The right usage is to
+        pre-segment with VAD; this warning points users there instead of letting
+        them get a silently truncated result. It does not change the output.
+        """
+        if getattr(self, "_warned_audio_too_long", False):
+            return
+        items = inputs if isinstance(inputs, (list, tuple)) else [inputs]
+        for item in items:
+            duration = None
+            try:
+                if isinstance(item, str):
+                    import soundfile as sf
+
+                    duration = sf.info(item).duration
+                elif isinstance(item, np.ndarray):
+                    duration = item.shape[-1] / 16000.0
+                elif isinstance(item, torch.Tensor):
+                    duration = item.shape[-1] / 16000.0
+            except Exception:
+                continue
+            if duration is not None and duration > max_safe_sec:
+                logger.warning(
+                    "AutoModelVLLM received a %.0fs audio input. Fun-ASR-Nano is a "
+                    "segment-level model; decoding very long audio in a single pass can "
+                    "truncate or degrade the result. Pre-segment with VAD and pass the "
+                    "segments, or use the high-level `funasr.AutoModel(model=..., "
+                    'vad_model="fsmn-vad")`, which segments long audio automatically.',
+                    duration,
+                )
+                self._warned_audio_too_long = True
+                break
 
     @classmethod
     def supported_models(cls):


### PR DESCRIPTION
feat(AutoModelVLLM): warn when a single audio input is too long to decode in one pass

Fun-ASR-Nano is a segment-level (LLM-)ASR model. Feeding very long audio (e.g. a
2-minute meeting recording) directly to AutoModelVLLM decodes it in a single pass,
which hits max_new_tokens long before the audio ends -> the user gets a silently
truncated transcript with no error (verified: a 126s clip returns ~half the text
of the VAD-segmented decode, 328 vs 680 chars).

Add a one-time warning when an input exceeds a safe length, pointing users to VAD
pre-segmentation or the high-level AutoModel (which segments automatically). This
does not change any output; it just makes the truncation visible instead of silent.

Refs #3031 (the catastrophic repetition reported there was the old hardcoded
repetition_penalty=1.3 crash in prompt-embeds mode, already fixed in #2974/1.3.10;
the remaining issue on long audio is this silent truncation).

Verified: warning fires on a 126s input (list / single / ndarray paths), does not fire on a 5s input, and does not change the transcription output.