### PR TITLE
ci: build portable llama.cpp release binaries

### DIFF
--- a/.github/workflows/build-llamacpp-binaries.yml
+++ b/.github/workflows/build-llamacpp-binaries.yml
@@ -33,7 +33,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure and build
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          # Release binaries must be portable across user machines, not tuned to
+          # the ephemeral CI runner CPU. A native ggml build may emit AVX512 or
+          # AVX-VNNI instructions and then crash with SIGILL on ordinary CPUs.
+          # Keep the prebuilt x64 package conservative; optimized AVX2/AVX512
+          # builds can be published as separate assets later.
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DGGML_NATIVE=OFF \
+            -DGGML_AVX=OFF \
+            -DGGML_AVX2=OFF \
+            -DGGML_AVX_VNNI=OFF \
+            -DGGML_AVX512=OFF \
+            -DGGML_AVX512_VBMI=OFF \
+            -DGGML_AVX512_VNNI=OFF \
+            -DGGML_AVX512_BF16=OFF \
+            -DGGML_FMA=OFF \
+            -DGGML_F16C=OFF \
+            -DGGML_BMI2=OFF
           cmake --build build --config Release -j 2
       - name: Package
         run: |


### PR DESCRIPTION
## Summary
- disable ggml native CPU tuning in the llama.cpp release workflow
- explicitly disable AVX/AVX2/AVX512/VNNI/FMA/F16C/BMI2 for conservative prebuilt x64 assets
- document why optimized builds should be separate release assets

## Why
The v0.1.2 Windows prebuilt binaries can crash with SIGILL / 0xC000001D on user machines because ggml defaults to native CPU optimization on CI runners. This makes the generic x64 release artifact depend on the runner CPU instruction set.

Fixes #3036. Also related to FunAudioLLM/SenseVoice#307.

## Verification
- `git diff --check`
- parsed `.github/workflows/build-llamacpp-binaries.yml` with PyYAML
- configured `runtime/llama.cpp` with the release flags and local pinned llama.cpp source
- built `llama-funasr-vad` successfully with the conservative flags
