### PR TITLE
fix: keep Fun-ASR-Nano vLLM repetition penalty neutral

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -307,7 +307,7 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 | 1.5–3.0 s | Partially correct |
 | > 3.0 s | Accurate output |
 
-> Note: `repetition_penalty=1.3` is hardcoded internally to prevent short-chunk repetition degradation.
+> Note: `repetition_penalty` defaults to `1.0` for Fun-ASR-Nano vLLM paths. Tune it explicitly only after validating that it improves your workload.
 
 ---
 

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -306,7 +306,7 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 | 1.5-3.0s | 部分正确 |
 | > 3.0s | 准确输出 |
 
-> Note: `repetition_penalty=1.3` 内部硬编码，防止短 chunk 重复退化。
+> Note: Fun-ASR-Nano 的 vLLM 路径默认使用 `repetition_penalty=1.0`。只有在你的业务音频上确认有收益时，才建议显式调参。
 
 ---
 

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -307,7 +307,7 @@ for result in engine.streaming_generate("audio.wav", language="中文"):
 | 1.5-3.0s | 部分正确 |
 | > 3.0s | 准确输出 |
 
-> Note: `repetition_penalty=1.3` 内部硬编码，防止短 chunk 重复退化。
+> Note: Fun-ASR-Nano 的 vLLM 路径默认使用 `repetition_penalty=1.0`。只有在你的业务音频上确认有收益时，才建议显式调参。
 
 ---
 

--- a/funasr/bin/_server_app.py
+++ b/funasr/bin/_server_app.py
@@ -132,8 +132,8 @@ def create_app(device: str = "cuda", preload_model: str = "auto") -> FastAPI:
         if not seg_audios:
             return {"text": "", "segments": [], "duration": len(audio_data)/sr}
 
-        # vLLM generate with repetition_penalty
-        gen_kwargs = {"max_new_tokens": 500, "repetition_penalty": 1.3}
+        # Keep repetition penalty neutral by default; prompt-embeds generation can be destabilized by penalties.
+        gen_kwargs = {"max_new_tokens": 500, "repetition_penalty": 1.0}
         if language:
             gen_kwargs["language"] = language
         if hotwords:

--- a/funasr/models/fun_asr_nano/inference_vllm_pipeline.py
+++ b/funasr/models/fun_asr_nano/inference_vllm_pipeline.py
@@ -219,7 +219,7 @@ class FunASRNanoVLLMPipeline:
         params = SamplingParams(
             max_tokens=kwargs.get("max_new_tokens", 512),
             temperature=0.0,
-            repetition_penalty=1.3,
+            repetition_penalty=kwargs.get("repetition_penalty", 1.0),
             skip_special_tokens=True,
         )
 

--- a/funasr/models/fun_asr_nano/inference_vllm_streaming.py
+++ b/funasr/models/fun_asr_nano/inference_vllm_streaming.py
@@ -189,7 +189,8 @@ class FunASRNanoStreamingVLLM:
 
     def streaming_generate(self, audio_input, chunk_ms=None, rollback_chars=None,
                            hotwords=None, language=None, itn=True,
-                           max_new_tokens=200, temperature=0.0, **kwargs):
+                           max_new_tokens=200, temperature=0.0,
+                           repetition_penalty=1.0, **kwargs):
         """Streaming ASR: process all chunks and yield results per chunk.
 
         All chunks are batched into a single vLLM generate() call for
@@ -204,6 +205,7 @@ class FunASRNanoStreamingVLLM:
             itn: Inverse text normalization.
             max_new_tokens: Max tokens per chunk generation.
             temperature: Sampling temperature (0 = greedy).
+            repetition_penalty: Repetition penalty factor (default 1.0).
 
         Yields:
             {"text": full_text, "fixed_text": confirmed_text,
@@ -235,7 +237,7 @@ class FunASRNanoStreamingVLLM:
         num_chunks = (total_samples + chunk_samples - 1) // chunk_samples
 
         params = SamplingParams(max_tokens=max_new_tokens, temperature=temperature,
-                                repetition_penalty=1.3, skip_special_tokens=True)
+                                repetition_penalty=repetition_penalty, skip_special_tokens=True)
 
         # Two-stage approach for long audio:
         # Stage 1: batch first N chunks fresh (no prev_text) to find stable output


### PR DESCRIPTION
## Summary
- keep Fun-ASR-Nano vLLM repetition penalty neutral by default in server, pipeline, and streaming paths
- allow pipeline/streaming callers to opt into `repetition_penalty` explicitly
- update vLLM guides to remove the outdated `repetition_penalty=1.3` hardcoding note

## Why
Fun-ASR-Nano uses prompt-embeds with vLLM. A non-neutral repetition penalty can destabilize repeated API calls / segmented decoding in some vLLM environments, and users in #3031 are currently debugging repeated output from an API wrapper. The base `AutoModelVLLM.generate()` path already defaults to `repetition_penalty=1.0`; this PR aligns the remaining service and helper paths with that safer default.

## Verification
- `git diff --check`
- `python3 -m py_compile funasr/bin/_server_app.py funasr/models/fun_asr_nano/inference_vllm_pipeline.py funasr/models/fun_asr_nano/inference_vllm_streaming.py`
- AST parse of the three changed Python files
- `rg` scan confirmed no remaining docs/server hardcoding of `repetition_penalty=1.3`

Refs #3031
