### PR TITLE
feat(cli): add model hub option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,7 @@ funasr audio.wav --output-format srt --output-dir ./subs
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--model` | `-m` | sensevoice | Model: sensevoice, paraformer, paraformer-en, fun-asr-nano |
+| `--hub` | `-H` | ms | Model hub: ms (ModelScope) or hf (Hugging Face) |
 | `--language` | `-l` | auto | Language: zh, en, ja, ko, yue, auto |
 | `--device` | | auto | Device: cuda:0, cpu |
 | `--output-format` | `-f` | text | Output: text, json, srt, tsv |
@@ -90,6 +91,9 @@ funasr audio.wav --model paraformer --language zh --hotwords "FunASR,达摩院"
 
 # Pipe to jq for processing
 funasr audio.wav -f json | jq '.text'
+
+# Load models from Hugging Face instead of ModelScope
+funasr audio.wav --hub hf --model fun-asr-nano
 
 # Use with AI agents
 result=$(funasr audio.wav -f json)

--- a/funasr/cli.py
+++ b/funasr/cli.py
@@ -86,11 +86,13 @@ def main():
                "  funasr audio.wav\n"
                "  funasr audio.wav --model sensevoice -f json\n"
                "  funasr audio.wav -f srt -o ./subs\n"
-               "  funasr audio.wav --spk --timestamps\n",
+               "  funasr audio.wav --spk --timestamps\n"
+               "  funasr audio.wav --hub hf --model fun-asr-nano\n",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("audio", nargs="+", help="Audio file(s) to transcribe")
     p.add_argument("--model", "-m", default="sensevoice", choices=list(MODEL_CONFIGS), help="Model (default: sensevoice)")
+    p.add_argument("--hub", "-H", default="ms", choices=["ms", "hf"], help="Model hub: ms (ModelScope) or hf (Hugging Face). Default: ms")
     p.add_argument("--language", "-l", default=None, help="Language: zh, en, ja, ko, yue, auto")
     p.add_argument("--device", default=None, help="Device: cuda:0, cpu (default: auto)")
     p.add_argument("--output-format", "-f", default="text", choices=["text", "json", "srt", "tsv"], help="Output format (default: text)")
@@ -110,6 +112,7 @@ def main():
 
     device = args.device or ("cuda:0" if torch.cuda.is_available() else "cpu")
     config = MODEL_CONFIGS[args.model].copy()
+    config["hub"] = args.hub
     if args.spk and "spk_model" not in config:
         config["spk_model"] = "cam++"
     if "punc_model" not in config and args.model not in ("fun-asr-nano", "sensevoice"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import io
+import sys
+import types
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from funasr import cli
+
+
+class DummyAutoModel:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.instances.append(self)
+
+    def generate(self, **kwargs):
+        return [{"text": "hello"}]
+
+
+def test_cli_passes_hub_to_auto_model(tmp_path):
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"not a real wav")
+    fake_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+
+    DummyAutoModel.instances = []
+    argv = ["funasr", "--hub", "hf", str(audio_path)]
+
+    with (
+        patch.object(sys, "argv", argv),
+        patch.dict(sys.modules, {"torch": fake_torch}),
+        patch("funasr.AutoModel", DummyAutoModel),
+        redirect_stdout(io.StringIO()) as stdout,
+    ):
+        cli.main()
+
+    assert DummyAutoModel.instances[0].kwargs["hub"] == "hf"
+    assert stdout.getvalue().strip() == "hello"
+


### PR DESCRIPTION
## Summary
- add `--hub/-H` to the `funasr` CLI with `ms` as the default and `hf` for Hugging Face
- pass the selected hub into `AutoModel` so VAD/punctuation/speaker sub-models inherit the same hub preference
- document the option and a Hugging Face CLI example

Fixes #3045.

## Tests
- `python -m pytest tests/test_cli.py -q`
- `python -m py_compile funasr/cli.py tests/test_cli.py`
- `python -m funasr.cli --help`
- `git diff --check`
