### PR TITLE
Clarify Fun-ASR-Nano NPU support status

### DIFF
--- a/docs/deployment_matrix.md
+++ b/docs/deployment_matrix.md
@@ -52,6 +52,10 @@ Use the runtime WebSocket service. Validate chunk size, VAD, endpointing, punctu
 
 Use the vLLM path for Fun-ASR-Nano. Benchmark with your own audio distribution and watch GPU memory, tensor parallel size, first-token latency, and warmup time.
 
+### I want to run Fun-ASR-Nano on Ascend NPU
+
+Fun-ASR-Nano's LLM-based path is currently documented and validated for CUDA/vLLM, standard PyTorch CPU/GPU runs, and CPU/edge GGUF runtimes. Ascend NPU (`torch_npu`) is not an officially validated runtime for this model yet. Do not assume that a SenseVoice or Paraformer NPU deployment means Fun-ASR-Nano will also work, because Nano also exercises the Qwen decoder, `inputs_embeds`, and autocast path. If you are adapting it, start with `torch.bfloat16`, capture the `torch` / `torch_npu` / CANN versions, and open a focused PR or deployment issue with a minimal command and full stack trace.
+
 ## Readiness checklist
 
 - Pick a model alias and pin it in deployment notes.

--- a/docs/deployment_matrix_zh.md
+++ b/docs/deployment_matrix_zh.md
@@ -52,6 +52,10 @@ docker compose up --build
 
 Fun-ASR-Nano 走 vLLM 路径。请用自己的音频分布做 benchmark，并关注 GPU 显存、tensor parallel size、首 token 延迟和 warmup 时间。
 
+### 我想在昇腾 NPU 上跑 Fun-ASR-Nano
+
+Fun-ASR-Nano 的 LLM-based 路径目前主要按 CUDA/vLLM、标准 PyTorch CPU/GPU，以及 CPU/边缘 GGUF runtime 记录和验证；Ascend NPU（`torch_npu`）还不是这个模型的官方验证运行时。不要因为 SenseVoice 或 Paraformer 能在 NPU 上跑，就默认 Fun-ASR-Nano 也能直接跑通，因为 Nano 还会经过 Qwen 解码器、`inputs_embeds` 和 autocast 路径。若要适配，请先从 `torch.bfloat16` 开始，记录 `torch` / `torch_npu` / CANN 版本，并在最小 PR 或 deployment issue 里附上最小命令和完整错误栈。
+
 ## 上线检查清单
 
 - 选择模型 alias，并写入部署说明。

--- a/docs/model_selection.md
+++ b/docs/model_selection.md
@@ -53,6 +53,8 @@ The `examples/openai_api` server exposes short aliases so application teams do n
 | `paraformer-en` | `paraformer-en` with VAD | You want a compact English route in OpenAI-style clients. |
 | `fun-asr-nano` | `FunAudioLLM/Fun-ASR-Nano-2512` | You are evaluating LLM-based ASR, 31-language coverage, or vLLM acceleration. |
 
+For Ascend NPU deployments, treat `fun-asr-nano` separately from SenseVoice / Paraformer. The Fun-ASR-Nano path is not officially validated on `torch_npu` yet; use CUDA/vLLM, standard PyTorch CPU/GPU, or GGUF runtime unless you are doing a backend adaptation.
+
 Check the live service before wiring clients:
 
 ```bash

--- a/docs/model_selection_zh.md
+++ b/docs/model_selection_zh.md
@@ -53,6 +53,8 @@ result = model.generate(input="meeting.wav")
 | `paraformer-en` | `paraformer-en` + VAD | OpenAI 风格客户端里的英文轻量路由。 |
 | `fun-asr-nano` | `FunAudioLLM/Fun-ASR-Nano-2512` | 评估 LLM-based ASR、31 语种覆盖或 vLLM 加速。 |
 
+如果部署目标是昇腾 NPU，请把 `fun-asr-nano` 和 SenseVoice / Paraformer 分开看。Fun-ASR-Nano 路径目前尚未在 `torch_npu` 上官方验证；除非正在做后端适配，否则优先使用 CUDA/vLLM、标准 PyTorch CPU/GPU 或 GGUF runtime。
+
 接入客户端前先检查在线服务：
 
 ```bash


### PR DESCRIPTION
## Summary

- document that Fun-ASR-Nano is not yet an officially validated Ascend NPU / `torch_npu` runtime
- clarify that SenseVoice or Paraformer NPU success should not be assumed to transfer to the Fun-ASR-Nano LLM path
- add the note to both deployment matrix and model selection docs in English and Chinese

## Why

Users trying SenseVoice on NPU may reasonably try Fun-ASR-Nano next, but Nano also exercises the Qwen decoder, `inputs_embeds`, and autocast path. This makes the current support boundary explicit and gives contributors the minimal adaptation information to include.

## Validation

- `git diff --check`
- checked the English and Chinese docs contain the new NPU support-status guidance and key backend terms
