### PR TITLE
Add daily target to ecosystem metrics

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -36,7 +36,7 @@ This plan focuses on useful adoption work rather than vanity marketing: if more 
 
 As of 2026-06-30, the ecosystem has 34,622 combined GitHub stars, or 3,398 additional stars since the 31,224 baseline. The remaining gap to the +20,000 target is 16,602 stars by 2026-09-30.
 
-Keep this snapshot fresh during weekly planning:
+Keep this snapshot fresh during weekly planning. The ecosystem mode also reports the remaining gap, days left to 2026-09-30, and the required daily average:
 
 ```bash
 python scripts/collect_growth_metrics.py --ecosystem

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -26,6 +26,7 @@ DEFAULT_ECOSYSTEM_REPOS = [
 DEFAULT_PACKAGE = "funasr"
 DEFAULT_BASELINE_STARS = 31224
 DEFAULT_TARGET_ADDITIONAL_STARS = 20000
+DEFAULT_TARGET_DATE = "2026-09-30"
 
 
 def fetch_json(url: str, headers: Optional[Dict[str, str]] = None) -> Any:
@@ -88,12 +89,20 @@ def collect_ecosystem_metrics(
     package: str,
     baseline_stars: int,
     target_additional_stars: int,
+    target_date: str = DEFAULT_TARGET_DATE,
+    today: Optional[dt.date] = None,
 ) -> Dict[str, Any]:
     repositories = [collect_github_repo_metrics(repo) for repo in repos]
     pypi = fetch_json(f"https://pypi.org/pypi/{package}/json", {"User-Agent": "funasr-growth-metrics"})
     total_stars = sum(repo.get("stars") or 0 for repo in repositories)
     added_stars = total_stars - baseline_stars
     remaining_to_target = max(target_additional_stars - added_stars, 0)
+    target_day = dt.date.fromisoformat(target_date)
+    current_day = today or dt.datetime.now(dt.timezone.utc).date()
+    days_remaining = max((target_day - current_day).days, 0)
+    required_daily_average = (
+        (remaining_to_target + days_remaining - 1) // days_remaining if days_remaining else remaining_to_target
+    )
     return {
         "collected_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
         "ecosystem": {
@@ -103,6 +112,9 @@ def collect_ecosystem_metrics(
             "target_additional_stars": target_additional_stars,
             "added_stars": added_stars,
             "remaining_to_target": remaining_to_target,
+            "target_date": target_date,
+            "days_remaining": days_remaining,
+            "required_daily_average": required_daily_average,
         },
         "pypi": {
             "package": package,
@@ -148,6 +160,8 @@ def format_ecosystem_markdown(metrics: Dict[str, Any]) -> str:
         f"- Baseline stars: **{ecosystem['baseline_stars']:,}**",
         f"- Added since baseline: **{ecosystem['added_stars']:,}** / {ecosystem['target_additional_stars']:,}",
         f"- Remaining to target: **{ecosystem['remaining_to_target']:,}**",
+        f"- Target date: **{ecosystem['target_date']}** ({ecosystem['days_remaining']:,} days remaining)",
+        f"- Required daily average: **{ecosystem['required_daily_average']:,}** stars/day",
         f"- PyPI package: **{pypi.get('package')} {pypi.get('version')}**",
         "",
         "## Repositories",
@@ -195,6 +209,7 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_TARGET_ADDITIONAL_STARS,
         help="Ecosystem added-star target",
     )
+    parser.add_argument("--target-date", default=DEFAULT_TARGET_DATE, help="Ecosystem target date in YYYY-MM-DD format")
     parser.add_argument("--format", choices=["markdown", "json"], default="markdown", help="Output format")
     return parser.parse_args()
 
@@ -208,6 +223,7 @@ def main() -> int:
                 args.pypi_package,
                 args.baseline_stars,
                 args.target_additional_stars,
+                args.target_date,
             )
         else:
             metrics = collect_metrics(args.repo, args.pypi_package)

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -2,6 +2,7 @@ import importlib.util
 import io
 import json
 import sys
+from datetime import date
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -83,6 +84,47 @@ def test_collect_ecosystem_metrics_sums_repositories_and_target_gap(monkeypatch)
         "FunAudioLLM/SenseVoice",
         "modelscope/FunClip",
     ]
+
+
+def test_collect_ecosystem_metrics_calculates_daily_target(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url.startswith("https://api.github.com/repos/"):
+            repo = url.removeprefix("https://api.github.com/repos/")
+            stars = {
+                "modelscope/FunASR": 18715,
+                "FunAudioLLM/Fun-ASR": 1318,
+                "FunAudioLLM/SenseVoice": 8718,
+                "modelscope/FunClip": 5872,
+            }[repo]
+            return {
+                "stargazers_count": stars,
+                "forks_count": 0,
+                "subscribers_count": 0,
+                "open_issues_count": 0,
+                "default_branch": "main",
+                "pushed_at": "2026-06-30T00:00:00Z",
+                "html_url": f"https://github.com/{repo}",
+            }
+        if url == "https://pypi.org/pypi/funasr/json":
+            return {"info": {"version": "1.3.14", "summary": "FunASR", "project_url": "https://pypi.org/project/funasr/"}}
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_ecosystem_metrics(
+        ["modelscope/FunASR", "FunAudioLLM/Fun-ASR", "FunAudioLLM/SenseVoice", "modelscope/FunClip"],
+        package="funasr",
+        baseline_stars=31224,
+        target_additional_stars=20000,
+        target_date="2026-09-30",
+        today=date(2026, 6, 30),
+    )
+
+    assert metrics["ecosystem"]["target_date"] == "2026-09-30"
+    assert metrics["ecosystem"]["days_remaining"] == 92
+    assert metrics["ecosystem"]["required_daily_average"] == 181
 
 
 def test_main_outputs_ecosystem_json(monkeypatch):


### PR DESCRIPTION
## Summary
- add a target date to the ecosystem growth metrics output
- report days remaining and required daily star average toward the +20,000 goal
- document that the ecosystem command now includes the remaining gap and daily target
- add a unit test for the daily target calculation

## Verification
- `pytest tests/test_collect_growth_metrics.py -q`
- `python3 -m py_compile scripts/collect_growth_metrics.py`
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) python3 scripts/collect_growth_metrics.py --ecosystem --format json`