### PR TITLE
Split issue and PR growth metrics

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -34,7 +34,7 @@ This plan focuses on useful adoption work rather than vanity marketing: if more 
 
 ## Current campaign snapshot
 
-As of 2026-06-30, the ecosystem has 34,623 combined GitHub stars, or 3,399 additional stars since the 31,224 baseline. The remaining gap to the +20,000 target is 16,601 stars by 2026-09-30.
+As of 2026-06-30, the ecosystem has 34,625 combined GitHub stars, or 3,401 additional stars since the 31,224 baseline. The remaining gap to the +20,000 target is 16,599 stars by 2026-09-30.
 
 Keep this snapshot fresh during weekly planning. The ecosystem mode also reports the remaining gap, days left to 2026-09-30, and the required daily average:
 
@@ -138,7 +138,7 @@ python scripts/collect_growth_metrics.py
 python scripts/collect_growth_metrics.py --format json
 ```
 
-The script captures GitHub stars, forks, watchers, open issues, latest push time, and the current PyPI version using public APIs. Set `GITHUB_TOKEN` when running it from CI or a shared network to avoid public GitHub API rate limits. Paste the Markdown output into launch notes, weekly community updates, or release retrospectives so the 20k-star effort stays measurable.
+The script captures GitHub stars, forks, watchers, open issues, open pull requests, latest push time, and the current PyPI version using public APIs. Set `GITHUB_TOKEN` when running it from CI or a shared network to avoid public GitHub API rate limits. Paste the Markdown output into launch notes, weekly community updates, or release retrospectives so the 20k-star effort stays measurable.
 
 ## 30-day execution checklist
 

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -62,12 +62,19 @@ def github_headers() -> Dict[str, str]:
 def collect_github_repo_metrics(repo: str) -> Dict[str, Any]:
     owner_repo = repo.strip("/")
     github = fetch_json(f"https://api.github.com/repos/{owner_repo}", github_headers())
+    open_pull_requests = len(
+        fetch_json(f"https://api.github.com/repos/{owner_repo}/pulls?state=open&per_page=100", github_headers())
+    )
+    open_items = github.get("open_issues_count")
+    open_issues = max((open_items or 0) - open_pull_requests, 0) if open_items is not None else None
     return {
         "repo": owner_repo,
         "stars": github.get("stargazers_count"),
         "forks": github.get("forks_count"),
         "watchers": github.get("subscribers_count"),
-        "open_issues": github.get("open_issues_count"),
+        "open_items": open_items,
+        "open_issues": open_issues,
+        "open_pull_requests": open_pull_requests,
         "default_branch": github.get("default_branch"),
         "pushed_at": github.get("pushed_at"),
         "html_url": github.get("html_url"),
@@ -227,6 +234,9 @@ def format_markdown(metrics: Dict[str, Any], star_goal: int) -> str:
         f"- GitHub forks: **{github.get('forks'):,}**" if github.get("forks") is not None else "- GitHub forks: n/a",
         f"- GitHub watchers: **{github.get('watchers'):,}**" if github.get("watchers") is not None else "- GitHub watchers: n/a",
         f"- Open issues: **{github.get('open_issues'):,}**" if github.get("open_issues") is not None else "- Open issues: n/a",
+        f"- Open pull requests: **{github.get('open_pull_requests'):,}**"
+        if github.get("open_pull_requests") is not None
+        else "- Open pull requests: n/a",
         f"- PyPI package: **{pypi.get('package')} {pypi.get('version')}**",
         f"- Last GitHub push: `{github.get('pushed_at')}`",
         "",
@@ -256,8 +266,8 @@ def format_ecosystem_markdown(metrics: Dict[str, Any]) -> str:
         "",
         "## Repositories",
         "",
-        "| Repository | Stars | Forks | Open issues | Last push |",
-        "|---|---:|---:|---:|---|",
+        "| Repository | Stars | Forks | Open issues | Open PRs | Last push |",
+        "|---|---:|---:|---:|---:|---|",
     ]
     for repo in ecosystem["repositories"]:
         lines.append(
@@ -265,6 +275,7 @@ def format_ecosystem_markdown(metrics: Dict[str, Any]) -> str:
             f"{(repo.get('stars') or 0):,} | "
             f"{(repo.get('forks') or 0):,} | "
             f"{(repo.get('open_issues') or 0):,} | "
+            f"{(repo.get('open_pull_requests') or 0):,} | "
             f"`{repo.get('pushed_at')}` |"
         )
     lines.extend(

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -15,6 +15,33 @@ def load_growth_metrics_module():
     return module
 
 
+def test_collect_github_repo_metrics_splits_open_issues_and_pull_requests(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/modelscope/FunASR":
+            return {
+                "stargazers_count": 18716,
+                "forks_count": 3100,
+                "subscribers_count": 210,
+                "open_issues_count": 5,
+                "default_branch": "main",
+                "pushed_at": "2026-06-30T02:26:33Z",
+                "html_url": "https://github.com/modelscope/FunASR",
+            }
+        if url == "https://api.github.com/repos/modelscope/FunASR/pulls?state=open&per_page=100":
+            return [{"number": 3056}, {"number": 3057}]
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_github_repo_metrics("modelscope/FunASR")
+
+    assert metrics["open_items"] == 5
+    assert metrics["open_pull_requests"] == 2
+    assert metrics["open_issues"] == 3
+
+
 def test_collect_ecosystem_metrics_sums_repositories_and_target_gap(monkeypatch):
     module = load_growth_metrics_module()
 
@@ -58,6 +85,8 @@ def test_collect_ecosystem_metrics_sums_repositories_and_target_gap(monkeypatch)
     }
 
     def fake_fetch_json(url, headers=None):
+        if url.endswith("/pulls?state=open&per_page=100"):
+            return []
         if url.startswith("https://api.github.com/repos/"):
             repo = url.removeprefix("https://api.github.com/repos/")
             return github_payloads[repo]
@@ -90,6 +119,8 @@ def test_collect_ecosystem_metrics_calculates_daily_target(monkeypatch):
     module = load_growth_metrics_module()
 
     def fake_fetch_json(url, headers=None):
+        if url.endswith("/pulls?state=open&per_page=100"):
+            return []
         if url.startswith("https://api.github.com/repos/"):
             repo = url.removeprefix("https://api.github.com/repos/")
             stars = {
@@ -185,6 +216,40 @@ def test_collect_integration_metrics_summarizes_pull_request_checks(monkeypatch)
     ]
 
 
+def test_format_ecosystem_markdown_includes_open_pull_requests():
+    module = load_growth_metrics_module()
+    metrics = {
+        "collected_at_utc": "2026-06-30T02:30:00+00:00",
+        "ecosystem": {
+            "repositories": [
+                {
+                    "repo": "modelscope/FunASR",
+                    "stars": 18716,
+                    "forks": 3100,
+                    "open_issues": 3,
+                    "open_pull_requests": 2,
+                    "pushed_at": "2026-06-30T02:26:33Z",
+                    "html_url": "https://github.com/modelscope/FunASR",
+                }
+            ],
+            "total_stars": 18716,
+            "baseline_stars": 31224,
+            "added_stars": -12508,
+            "target_additional_stars": 20000,
+            "remaining_to_target": 32508,
+            "target_date": "2026-09-30",
+            "days_remaining": 92,
+            "required_daily_average": 354,
+        },
+        "pypi": {"package": "funasr", "version": "1.3.14", "project_url": "https://pypi.org/project/funasr/"},
+    }
+
+    output = module.format_ecosystem_markdown(metrics)
+
+    assert "| Repository | Stars | Forks | Open issues | Open PRs | Last push |" in output
+    assert "| [modelscope/FunASR](https://github.com/modelscope/FunASR) | 18,716 | 3,100 | 3 | 2 |" in output
+
+
 def test_main_outputs_ecosystem_json(monkeypatch):
     module = load_growth_metrics_module()
 
@@ -196,6 +261,8 @@ def test_main_outputs_ecosystem_json(monkeypatch):
     }
 
     def fake_fetch_json(url, headers=None):
+        if url.endswith("/pulls?state=open&per_page=100"):
+            return []
         if url.startswith("https://api.github.com/repos/"):
             repo = url.removeprefix("https://api.github.com/repos/")
             return {


### PR DESCRIPTION
## Summary
- split GitHub repo operations metrics into open_items, open_issues, and open_pull_requests
- show Open PRs in the ecosystem Markdown table and single-repo snapshot
- refresh the growth plan snapshot to 34,625 combined stars

## Validation
- pytest tests/test_collect_growth_metrics.py -q
- python3 -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- GITHUB_TOKEN=... python3 scripts/collect_growth_metrics.py --ecosystem --format json