### PR TITLE
Add open issue growth metrics

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -95,6 +95,13 @@ Daily maintainer loop:
 - Turn repeated answers into docs or examples before closing the loop.
 - Keep actionable issues labelled as `good first issue`, `help wanted`, or `ready for PR` so contributors can help without guessing.
 
+Use the issue snapshot before each maintainer pass so waiting-on-reporter, waiting-on-contributor, and maintainer-owned items stay separate:
+
+```bash
+python scripts/collect_growth_metrics.py --issues
+python scripts/collect_growth_metrics.py --issues --format json
+```
+
 ## Workstream 5: External proof
 
 - Publish reproducible benchmark scripts and raw configuration for the 184-file benchmark.

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -33,6 +33,8 @@ DEFAULT_INTEGRATION_PRS = [
     "huggingface/optimum-intel#1801",
 ]
 FAILED_CHECK_CONCLUSIONS = {"action_required", "cancelled", "failure", "startup_failure", "timed_out"}
+REPORTER_WAITING_LABELS = {"needs feedback"}
+CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}
 
 
 def fetch_json(url: str, headers: Optional[Dict[str, str]] = None) -> Any:
@@ -162,6 +164,52 @@ def collect_integration_metrics(prs: Sequence[str]) -> Dict[str, Any]:
     return {
         "collected_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
         "integrations": [collect_pull_request_metrics(pr) for pr in prs],
+    }
+
+
+def classify_issue_waiting_on(labels: Sequence[str]) -> str:
+    normalized = {label.lower() for label in labels}
+    if normalized & REPORTER_WAITING_LABELS:
+        return "reporter"
+    if normalized & CONTRIBUTOR_WAITING_LABELS:
+        return "contributor"
+    return "maintainer"
+
+
+def collect_open_issues(repo: str) -> list[Dict[str, Any]]:
+    owner_repo = repo.strip("/")
+    payload = fetch_json(f"https://api.github.com/repos/{owner_repo}/issues?state=open&per_page=100", github_headers())
+    issues = []
+    for issue in payload:
+        if issue.get("pull_request"):
+            continue
+        labels = [label.get("name") for label in issue.get("labels", []) if label.get("name")]
+        author = issue.get("user") or {}
+        issues.append(
+            {
+                "repo": owner_repo,
+                "number": issue.get("number"),
+                "title": issue.get("title"),
+                "html_url": issue.get("html_url"),
+                "updated_at": issue.get("updated_at"),
+                "comments": issue.get("comments"),
+                "author": author.get("login"),
+                "labels": labels,
+                "waiting_on": classify_issue_waiting_on(labels),
+            }
+        )
+    return issues
+
+
+def collect_issue_metrics(repos: Sequence[str]) -> Dict[str, Any]:
+    repositories = []
+    for repo in repos:
+        owner_repo = repo.strip("/")
+        issues = collect_open_issues(owner_repo)
+        repositories.append({"repo": owner_repo, "open_issue_count": len(issues), "open_issues": issues})
+    return {
+        "collected_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "repositories": repositories,
     }
 
 
@@ -333,6 +381,31 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def format_issue_markdown(metrics: Dict[str, Any]) -> str:
+    lines = [
+        f"# FunASR Open Issue Snapshot ({metrics['collected_at_utc']})",
+        "",
+        "| Repository | Issue | Waiting on | Labels | Comments | Updated |",
+        "|---|---|---|---|---:|---|",
+    ]
+    any_issue = False
+    for repository in metrics["repositories"]:
+        for issue in repository["open_issues"]:
+            any_issue = True
+            labels = ", ".join(issue.get("labels") or [])
+            lines.append(
+                f"| {repository['repo']} | "
+                f"[#{issue['number']} {issue.get('title')}]({issue.get('html_url')}) | "
+                f"{issue.get('waiting_on')} | "
+                f"{labels} | "
+                f"{issue.get('comments') or 0:,} | "
+                f"`{issue.get('updated_at')}` |"
+            )
+    if not any_issue:
+        lines.append("| n/a | No open issues | n/a | n/a | 0 | n/a |")
+    return "\n".join(lines) + "\n"
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Collect FunASR growth metrics.")
     parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository, e.g. modelscope/FunASR")
@@ -344,6 +417,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--ecosystem", action="store_true", help="Collect the four-repository FunASR ecosystem")
     parser.add_argument("--integrations", action="store_true", help="Collect tracked external integration PRs")
+    parser.add_argument("--issues", action="store_true", help="Collect open issue triage status for repositories")
     parser.add_argument(
         "--integration-prs",
         nargs="+",
@@ -369,6 +443,8 @@ def main() -> int:
     try:
         if args.integrations:
             metrics = collect_integration_metrics(args.integration_prs)
+        elif args.issues:
+            metrics = collect_issue_metrics(args.repos)
         elif args.ecosystem:
             metrics = collect_ecosystem_metrics(
                 args.repos,
@@ -387,6 +463,8 @@ def main() -> int:
         print(json.dumps(metrics, ensure_ascii=False, indent=2))
     elif args.integrations:
         print(format_integration_markdown(metrics), end="")
+    elif args.issues:
+        print(format_issue_markdown(metrics), end="")
     elif args.ecosystem:
         print(format_ecosystem_markdown(metrics), end="")
     else:

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -250,6 +250,92 @@ def test_format_ecosystem_markdown_includes_open_pull_requests():
     assert "| [modelscope/FunASR](https://github.com/modelscope/FunASR) | 18,716 | 3,100 | 3 | 2 |" in output
 
 
+def test_collect_issue_metrics_filters_pull_requests_and_assigns_waiting_on(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/modelscope/FunASR/issues?state=open&per_page=100":
+            return [
+                {
+                    "number": 3038,
+                    "title": "realtime websocket falls behind with two clients",
+                    "html_url": "https://github.com/modelscope/FunASR/issues/3038",
+                    "updated_at": "2026-06-29T19:22:38Z",
+                    "comments": 4,
+                    "user": {"login": "liujixingit"},
+                    "labels": [{"name": "bug"}, {"name": "needs feedback"}],
+                },
+                {
+                    "number": 3034,
+                    "title": "Fun-ASR-Nano on Ascend NPU",
+                    "html_url": "https://github.com/modelscope/FunASR/issues/3034",
+                    "updated_at": "2026-06-29T19:49:07Z",
+                    "comments": 3,
+                    "user": {"login": "pubulichen"},
+                    "labels": [{"name": "help wanted"}, {"name": "ready for PR"}],
+                },
+                {
+                    "number": 3057,
+                    "title": "open pull request should be ignored",
+                    "pull_request": {"url": "https://api.github.com/repos/modelscope/FunASR/pulls/3057"},
+                    "labels": [],
+                },
+            ]
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_issue_metrics(["modelscope/FunASR"])
+
+    repository = metrics["repositories"][0]
+    assert repository["repo"] == "modelscope/FunASR"
+    assert repository["open_issue_count"] == 2
+    assert [issue["number"] for issue in repository["open_issues"]] == [3038, 3034]
+    assert repository["open_issues"][0]["labels"] == ["bug", "needs feedback"]
+    assert repository["open_issues"][0]["waiting_on"] == "reporter"
+    assert repository["open_issues"][1]["waiting_on"] == "contributor"
+
+
+def test_main_outputs_issues_json(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/modelscope/FunASR/issues?state=open&per_page=100":
+            return [
+                {
+                    "number": 2959,
+                    "title": "postprocess hotwords",
+                    "html_url": "https://github.com/modelscope/FunASR/issues/2959",
+                    "updated_at": "2026-06-29T19:46:28Z",
+                    "comments": 2,
+                    "user": {"login": "HaujetZhao"},
+                    "labels": [{"name": "good first issue"}, {"name": "ready for PR"}],
+                }
+            ]
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_growth_metrics.py",
+            "--issues",
+            "--repos",
+            "modelscope/FunASR",
+            "--format",
+            "json",
+        ],
+    )
+
+    with redirect_stdout(io.StringIO()) as stdout:
+        assert module.main() == 0
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["repositories"][0]["open_issues"][0]["number"] == 2959
+    assert payload["repositories"][0]["open_issues"][0]["waiting_on"] == "contributor"
+
+
 def test_main_outputs_ecosystem_json(monkeypatch):
     module = load_growth_metrics_module()
 


### PR DESCRIPTION
## Summary
- add an --issues mode to collect open issue triage status across the FunASR ecosystem repos
- classify each issue as waiting on reporter, contributor, or maintainer based on labels
- document the issue snapshot command in the community growth maintainer loop

## Validation
- pytest tests/test_collect_growth_metrics.py -q
- python3 -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- GITHUB_TOKEN=... python3 scripts/collect_growth_metrics.py --issues --format json