### PR TITLE
Track SGLang Fun-ASR integration

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -126,6 +126,7 @@ Set `GITHUB_TOKEN` when running this from CI or a shared network so GitHub's pub
 | Integration PR | Growth reason | Current maintainer action |
 |---|---|---|
 | `huggingface/transformers#46180` Fun-ASR-Nano model support | Makes Fun-ASR-Nano usable through the default HF API surface and model docs | Keep CI evidence current, address only actionable review threads, and avoid repeating maintainer pings unless new evidence appears. If `tests_processors` fails only in unrelated LightOnOCR cache setup, ask for a rerun once with the exact failing job. |
+| `sgl-project/sglang-omni#898` Fun-ASR serving support | Exposes Fun-ASR-Nano through a high-visibility serving runtime for ASR benchmarks and GPU deployment | Help keep benchmark claims precise: exact checkpoint/revision, dtype, GPU, concurrency, SeedTTS EN full-set comparison against Qwen3-ASR, and a copy-paste smoke command. |
 | `ray-project/ray#64053` Ray Serve FunASR ASR example | Puts FunASR in production serving docs for teams already using Ray | Monitor review, answer questions quickly, and keep the example command aligned with the current OpenAI-compatible API behavior. |
 | `huggingface/optimum-intel#1801` OpenVINO support | Helps CPU and edge users evaluate Fun-ASR on Intel hardware | Watch for CI or reviewer feedback, then validate a minimal inference path before promoting it in FunASR docs. |
 

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -29,6 +29,7 @@ DEFAULT_TARGET_ADDITIONAL_STARS = 20000
 DEFAULT_TARGET_DATE = "2026-09-30"
 DEFAULT_INTEGRATION_PRS = [
     "huggingface/transformers#46180",
+    "sgl-project/sglang-omni#898",
     "ray-project/ray#64053",
     "huggingface/optimum-intel#1801",
 ]

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -15,6 +15,12 @@ def load_growth_metrics_module():
     return module
 
 
+def test_default_integration_prs_include_sglang_omni_fun_asr():
+    module = load_growth_metrics_module()
+
+    assert "sgl-project/sglang-omni#898" in module.DEFAULT_INTEGRATION_PRS
+
+
 def test_collect_github_repo_metrics_splits_open_issues_and_pull_requests(monkeypatch):
     module = load_growth_metrics_module()
 


### PR DESCRIPTION
## Summary
- add sgl-project/sglang-omni#898 to the default external integration tracker
- document the SGLang/Fun-ASR validation focus in the growth plan
- add a regression test so this high-visibility runtime integration stays tracked

## Validation
- pytest tests/test_collect_growth_metrics.py -q
- python3 -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- GITHUB_TOKEN=... python3 scripts/collect_growth_metrics.py --integrations --format json