### PR TITLE
Track external FunASR integration queue

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -129,6 +129,11 @@ Set `GITHUB_TOKEN` when running this from CI or a shared network so GitHub's pub
 | `sgl-project/sglang-omni#898` Fun-ASR serving support | Exposes Fun-ASR-Nano through a high-visibility serving runtime for ASR benchmarks and GPU deployment | Help keep benchmark claims precise: exact checkpoint/revision, dtype, GPU, concurrency, SeedTTS EN full-set comparison against Qwen3-ASR, and a copy-paste smoke command. |
 | `ray-project/ray#64053` Ray Serve FunASR ASR example | Puts FunASR in production serving docs for teams already using Ray | Monitor review, answer questions quickly, and keep the example command aligned with the current OpenAI-compatible API behavior. |
 | `huggingface/optimum-intel#1801` OpenVINO support | Helps CPU and edge users evaluate Fun-ASR on Intel hardware | Watch for CI or reviewer feedback, then validate a minimal inference path before promoting it in FunASR docs. |
+| `infiniflow/ragflow#16473` FunASR / SenseVoice STT provider | Adds FunASR to a high-star RAG workflow product where local STT can become a visible configuration choice | Track duplicate/conflict cleanup, keep provider naming consistent, and verify that skipped CI is expected rather than a hidden regression. |
+| `pipecat-ai/pipecat#4844` FunASR local STT service | Puts SenseVoice/FunASR into realtime voice agent pipelines used by builders comparing local STT backends | Watch review, keep docs/readthedocs evidence fresh, and make sure the service degrades clearly when optional FunASR dependencies are missing. |
+| `TEN-framework/ten-framework#2191` FunASR ASR extension | Places SenseVoice/FunASR in a realtime multimodal agent framework with extension discovery | Resolve review comments and failing review automation with concrete code/doc fixes rather than status pings. |
+| `activepieces/activepieces#13985` FunASR speech recognition piece | Gives no-code workflow users a direct FunASR speech recognition action | The CLA status is author-controlled; monitor only for maintainer feedback or test failures until the author-side gate clears. |
+| `Uberi/speech_recognition#903` FunASR recognizer | Exposes FunASR through a widely known Python speech-recognition wrapper | Keep the recognizer optional and lightweight, and be ready with a minimal install/import smoke test if maintainers ask for scope reduction. |
 
 Operating rules:
 

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -32,6 +32,11 @@ DEFAULT_INTEGRATION_PRS = [
     "sgl-project/sglang-omni#898",
     "ray-project/ray#64053",
     "huggingface/optimum-intel#1801",
+    "infiniflow/ragflow#16473",
+    "pipecat-ai/pipecat#4844",
+    "TEN-framework/ten-framework#2191",
+    "activepieces/activepieces#13985",
+    "Uberi/speech_recognition#903",
 ]
 FAILED_CHECK_CONCLUSIONS = {"action_required", "cancelled", "failure", "startup_failure", "timed_out"}
 REPORTER_WAITING_LABELS = {"needs feedback"}

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -21,6 +21,20 @@ def test_default_integration_prs_include_sglang_omni_fun_asr():
     assert "sgl-project/sglang-omni#898" in module.DEFAULT_INTEGRATION_PRS
 
 
+def test_default_integration_prs_include_high_visibility_external_queue():
+    module = load_growth_metrics_module()
+
+    expected_prs = {
+        "infiniflow/ragflow#16473",
+        "pipecat-ai/pipecat#4844",
+        "TEN-framework/ten-framework#2191",
+        "activepieces/activepieces#13985",
+        "Uberi/speech_recognition#903",
+    }
+
+    assert expected_prs.issubset(set(module.DEFAULT_INTEGRATION_PRS))
+
+
 def test_collect_github_repo_metrics_splits_open_issues_and_pull_requests(monkeypatch):
     module = load_growth_metrics_module()
 


### PR DESCRIPTION
## Summary
- add five high-visibility external FunASR/SenseVoice integration PRs to the default integration metrics queue
- document each new integration's growth reason and maintainer action
- add a regression test so the default queue keeps covering these external entry points

## Validation
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m pytest /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py -q
- GITHUB_TOKEN=$(gh auth token) /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 /tmp/funasr-growth-main/scripts/collect_growth_metrics.py --integrations --format json