### PR TITLE
Fix subtitle SRT timestamp generation

### DIFF
--- a/examples/subtitle/generate_subtitle.py
+++ b/examples/subtitle/generate_subtitle.py
@@ -15,6 +15,10 @@ import os
 import re
 
 
+def clean_text(text):
+    return re.sub(r'<\|[^|]*\|>', '', text or "").strip()
+
+
 def format_time_srt(ms):
     h = ms // 3600000
     m = (ms % 3600000) // 60000
@@ -29,6 +33,29 @@ def format_time_vtt(ms):
     s = (ms % 60000) // 1000
     ms_rem = ms % 1000
     return f"{h:02d}:{m:02d}:{s:02d}.{ms_rem:03d}"
+
+
+def timestamp_bounds_ms(result):
+    bounds = []
+    for key in ("timestamp", "timestamps"):
+        for ts in result.get(key, []) or []:
+            if isinstance(ts, dict):
+                start = ts.get("start_time", ts.get("start"))
+                end = ts.get("end_time", ts.get("end"))
+                if start is None or end is None:
+                    continue
+                start_ms = int(float(start) * 1000)
+                end_ms = int(float(end) * 1000)
+            elif isinstance(ts, (list, tuple)) and len(ts) >= 2:
+                start_ms = int(ts[0])
+                end_ms = int(ts[1])
+            else:
+                continue
+            if end_ms > start_ms:
+                bounds.append((start_ms, end_ms))
+    if not bounds:
+        return None
+    return min(start for start, _ in bounds), max(end for _, end in bounds)
 
 
 def main():
@@ -52,7 +79,7 @@ def main():
 
     from funasr import AutoModel
 
-    kwargs = {"model": args.model, "vad_model": "fsmn-vad",
+    kwargs = {"model": args.model, "vad_model": "fsmn-vad", "punc_model": "ct-punc",
               "vad_kwargs": {"max_single_segment_time": 30000},
               "device": args.device, "disable_update": True}
     if args.spk:
@@ -64,19 +91,31 @@ def main():
     print("Loading model...")
     model = AutoModel(**kwargs)
     print("Transcribing...")
-    result = model.generate(input=args.input, batch_size=1)
+    generate_kwargs = {
+        "input": args.input,
+        "batch_size": 1,
+        "sentence_timestamp": True,
+        "output_timestamp": True,
+        "return_time_stamps": True,
+    }
+    if args.lang != "auto":
+        generate_kwargs["language"] = args.lang
+    result = model.generate(**generate_kwargs)
 
     segments = []
-    if "sentence_info" in result[0]:
-        for seg in result[0]["sentence_info"]:
-            text = re.sub(r'<\|[^|]*\|>', '', seg.get("text", "")).strip()
-            if text:
-                segments.append({"start": seg.get("start", 0), "end": seg.get("end", 0),
-                                 "text": text, "spk": seg.get("spk")})
-    else:
-        text = re.sub(r'<\|[^|]*\|>', '', result[0].get("text", "")).strip()
+    result_item = result[0]
+    for seg in result_item.get("sentence_info", []) or []:
+        text = clean_text(seg.get("sentence") or seg.get("text", ""))
+        start = int(seg.get("start", 0) or 0)
+        end = int(seg.get("end", 0) or 0)
+        if text and end > start:
+            segments.append({"start": start, "end": end, "text": text, "spk": seg.get("spk")})
+
+    if not segments:
+        text = clean_text(result_item.get("text", ""))
         if text:
-            segments.append({"start": 0, "end": 0, "text": text, "spk": None})
+            start, end = timestamp_bounds_ms(result_item) or (0, 0)
+            segments.append({"start": start, "end": end, "text": text, "spk": None})
 
     if not segments:
         print("No speech detected.")

--- a/tests/test_generate_subtitle.py
+++ b/tests/test_generate_subtitle.py
@@ -1,0 +1,115 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_generate_subtitle_module():
+    script_path = Path(__file__).resolve().parents[1] / "examples" / "subtitle" / "generate_subtitle.py"
+    spec = importlib.util.spec_from_file_location("generate_subtitle", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_subtitle_requests_sentence_timestamps_and_writes_segmented_srt(
+    monkeypatch, tmp_path
+):
+    module = load_generate_subtitle_module()
+    captured = {}
+
+    class FakeAutoModel:
+        def __init__(self, **kwargs):
+            captured["model_kwargs"] = kwargs
+
+        def generate(self, **kwargs):
+            captured["generate_kwargs"] = kwargs
+            if kwargs.get("sentence_timestamp") and kwargs.get("output_timestamp"):
+                return [
+                    {
+                        "text": "<|zh|>First segment Second segment",
+                        "sentence_info": [
+                            {"start": 0, "end": 3500, "text": "<|zh|>First segment"},
+                            {"start": 3500, "end": 7200, "sentence": "Second segment", "spk": 1},
+                        ],
+                    }
+                ]
+            return [{"text": "<|zh|>First segment Second segment"}]
+
+    fake_funasr = types.ModuleType("funasr")
+    fake_funasr.AutoModel = FakeAutoModel
+    monkeypatch.setitem(sys.modules, "funasr", fake_funasr)
+
+    input_path = tmp_path / "input.mp4"
+    input_path.write_bytes(b"fake media")
+    output_path = tmp_path / "sub.srt"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_subtitle.py",
+            str(input_path),
+            "-o",
+            str(output_path),
+            "--lang",
+            "zh",
+            "--device",
+            "cpu",
+            "--spk",
+        ],
+    )
+
+    module.main()
+
+    assert captured["model_kwargs"]["punc_model"] == "ct-punc"
+    assert captured["generate_kwargs"]["language"] == "zh"
+    assert captured["generate_kwargs"]["sentence_timestamp"] is True
+    assert captured["generate_kwargs"]["output_timestamp"] is True
+    assert captured["generate_kwargs"]["return_time_stamps"] is True
+    assert output_path.read_text(encoding="utf-8") == (
+        "1\n"
+        "00:00:00,000 --> 00:00:03,500\n"
+        "First segment\n\n"
+        "2\n"
+        "00:00:03,500 --> 00:00:07,200\n"
+        "[Speaker 1] Second segment\n\n"
+    )
+
+
+def test_generate_subtitle_falls_back_to_timestamp_bounds_when_sentence_info_missing(
+    monkeypatch, tmp_path
+):
+    module = load_generate_subtitle_module()
+
+    class FakeAutoModel:
+        def __init__(self, **kwargs):
+            pass
+
+        def generate(self, **kwargs):
+            return [
+                {
+                    "text": "<|zh|>Full text",
+                    "timestamp": [[250, 1000], [1000, 3200]],
+                }
+            ]
+
+    fake_funasr = types.ModuleType("funasr")
+    fake_funasr.AutoModel = FakeAutoModel
+    monkeypatch.setitem(sys.modules, "funasr", fake_funasr)
+
+    input_path = tmp_path / "input.mp4"
+    input_path.write_bytes(b"fake media")
+    output_path = tmp_path / "sub.srt"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_subtitle.py", str(input_path), "-o", str(output_path), "--device", "cpu"],
+    )
+
+    module.main()
+
+    assert output_path.read_text(encoding="utf-8") == (
+        "1\n"
+        "00:00:00,250 --> 00:00:03,200\n"
+        "Full text\n\n"
+    )


### PR DESCRIPTION
## Summary
- request sentence-level and output timestamps from the subtitle generation script
- pass the language hint through to model.generate
- fall back to timestamp bounds instead of emitting a 00:00:00,000 --> 00:00:00,000 cue when sentence_info is unavailable
- add mocked tests for segmented SRT output and timestamp-bound fallback

Fixes #3059

## Validation
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m pytest /tmp/funasr-growth-main/tests/test_generate_subtitle.py -q
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m py_compile /tmp/funasr-growth-main/examples/subtitle/generate_subtitle.py /tmp/funasr-growth-main/tests/test_generate_subtitle.py