### PR TITLE
Add integration update age metrics

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -139,14 +139,36 @@ def summarize_commit_checks(repo: str, head_sha: str) -> Dict[str, Any]:
     }
 
 
-def collect_pull_request_metrics(spec: str) -> Dict[str, Any]:
+def parse_github_datetime(value: Optional[str]) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def days_since(value: Optional[str], now: dt.datetime) -> Optional[int]:
+    parsed = parse_github_datetime(value)
+    if parsed is None:
+        return None
+    return max((now - parsed).days, 0)
+
+
+def collect_pull_request_metrics(spec: str, now: Optional[dt.datetime] = None) -> Dict[str, Any]:
     repo, pr_number = parse_pull_request_spec(spec)
+    now = now or dt.datetime.now(dt.timezone.utc)
     pull_request = fetch_json(f"https://api.github.com/repos/{repo}/pulls/{pr_number}", github_headers())
     head = pull_request.get("head") or {}
     base = pull_request.get("base") or {}
     author = pull_request.get("user") or {}
     head_sha = head.get("sha")
     checks = summarize_commit_checks(repo, head_sha) if head_sha else {"state": "unknown"}
+    updated_at = pull_request.get("updated_at")
     return {
         "pr": f"{repo}#{pr_number}",
         "repo": repo,
@@ -156,7 +178,8 @@ def collect_pull_request_metrics(spec: str) -> Dict[str, Any]:
         "draft": pull_request.get("draft"),
         "mergeable": pull_request.get("mergeable"),
         "mergeable_state": pull_request.get("mergeable_state"),
-        "updated_at": pull_request.get("updated_at"),
+        "updated_at": updated_at,
+        "updated_age_days": days_since(updated_at, now),
         "html_url": pull_request.get("html_url"),
         "head_ref": head.get("ref"),
         "head_sha": head_sha,
@@ -166,10 +189,11 @@ def collect_pull_request_metrics(spec: str) -> Dict[str, Any]:
     }
 
 
-def collect_integration_metrics(prs: Sequence[str]) -> Dict[str, Any]:
+def collect_integration_metrics(prs: Sequence[str], now: Optional[dt.datetime] = None) -> Dict[str, Any]:
+    collected_at = (now or dt.datetime.now(dt.timezone.utc)).replace(microsecond=0)
     return {
-        "collected_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
-        "integrations": [collect_pull_request_metrics(pr) for pr in prs],
+        "collected_at_utc": collected_at.isoformat(),
+        "integrations": [collect_pull_request_metrics(pr, collected_at) for pr in prs],
     }
 
 
@@ -349,13 +373,15 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
     lines = [
         f"# FunASR External Integration Snapshot ({metrics['collected_at_utc']})",
         "",
-        "| Pull request | State | Mergeable | Checks | Failed | Pending | Updated |",
-        "|---|---|---|---|---:|---:|---|",
+        "| Pull request | State | Mergeable | Checks | Failed | Pending | Age | Updated |",
+        "|---|---|---|---|---:|---:|---:|---|",
     ]
     for integration in metrics["integrations"]:
         checks = integration.get("checks", {})
         failed_count = len(checks.get("failed_check_runs") or [])
         pending_count = len(checks.get("pending_check_runs") or [])
+        updated_age_days = integration.get("updated_age_days")
+        age = f"{updated_age_days}d" if updated_age_days is not None else "n/a"
         lines.append(
             f"| [{integration['pr']}]({integration.get('html_url')}) | "
             f"{integration.get('state')} | "
@@ -363,6 +389,7 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
             f"{checks.get('state')} | "
             f"{failed_count:,} | "
             f"{pending_count:,} | "
+            f"{age} | "
             f"`{integration.get('updated_at')}` |"
         )
     lines.extend(["", "## Failed or pending checks", ""])

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -2,7 +2,7 @@ import importlib.util
 import io
 import json
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -216,11 +216,15 @@ def test_collect_integration_metrics_summarizes_pull_request_checks(monkeypatch)
 
     monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
 
-    metrics = module.collect_integration_metrics(["huggingface/transformers#46180"])
+    metrics = module.collect_integration_metrics(
+        ["huggingface/transformers#46180"],
+        now=datetime(2026, 7, 2, 0, 0, 0, tzinfo=timezone.utc),
+    )
 
     integration = metrics["integrations"][0]
     assert integration["pr"] == "huggingface/transformers#46180"
     assert integration["title"] == "Add Fun-ASR-Nano model"
+    assert integration["updated_age_days"] == 2
     assert integration["mergeable"] is True
     assert integration["checks"]["state"] == "failure"
     assert integration["checks"]["total_check_runs"] == 3
@@ -268,6 +272,32 @@ def test_format_ecosystem_markdown_includes_open_pull_requests():
 
     assert "| Repository | Stars | Forks | Open issues | Open PRs | Last push |" in output
     assert "| [modelscope/FunASR](https://github.com/modelscope/FunASR) | 18,716 | 3,100 | 3 | 2 |" in output
+
+
+def test_format_integration_markdown_includes_update_age():
+    module = load_growth_metrics_module()
+    metrics = {
+        "collected_at_utc": "2026-07-02T00:00:00+00:00",
+        "integrations": [
+            {
+                "pr": "huggingface/transformers#46180",
+                "html_url": "https://github.com/huggingface/transformers/pull/46180",
+                "state": "open",
+                "mergeable_state": "blocked",
+                "updated_at": "2026-06-29T23:45:57Z",
+                "updated_age_days": 2,
+                "checks": {"state": "failure", "failed_check_runs": [], "pending_check_runs": []},
+            }
+        ],
+    }
+
+    output = module.format_integration_markdown(metrics)
+
+    assert "| Pull request | State | Mergeable | Checks | Failed | Pending | Age | Updated |" in output
+    assert (
+        "| [huggingface/transformers#46180](https://github.com/huggingface/transformers/pull/46180) | "
+        "open | blocked | failure | 0 | 0 | 2d | `2026-06-29T23:45:57Z` |"
+    ) in output
 
 
 def test_collect_issue_metrics_filters_pull_requests_and_assigns_waiting_on(monkeypatch):


### PR DESCRIPTION
## Summary
- add updated_age_days to external integration PR metrics
- show an Age column in the integrations markdown snapshot
- add regression coverage for deterministic staleness and markdown output

## Validation
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m pytest /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py -q
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m py_compile /tmp/funasr-growth-main/scripts/collect_growth_metrics.py /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py
- GITHUB_TOKEN=$(gh auth token) /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 /tmp/funasr-growth-main/scripts/collect_growth_metrics.py --integrations --format json