### PR TITLE
Track integration status contexts

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -120,6 +120,15 @@ def summarize_commit_checks(repo: str, head_sha: str) -> Dict[str, Any]:
         elif check_run.get("conclusion") in FAILED_CHECK_CONCLUSIONS:
             failed_check_runs.append({"name": name, "conclusion": check_run.get("conclusion"), "url": url})
 
+    for status_context in status.get("statuses", []):
+        name = status_context.get("context")
+        url = status_context.get("target_url")
+        state = status_context.get("state")
+        if state in {"error", "failure"}:
+            failed_check_runs.append({"name": name, "conclusion": state, "url": url})
+        elif state == "pending":
+            pending_check_runs.append({"name": name, "status": state, "url": url})
+
     status_state = status.get("state")
     if failed_check_runs or status_state in {"error", "failure"}:
         state = "failure"
@@ -166,6 +175,11 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
         return "finish draft"
 
     check_state = checks.get("state")
+    pending_names = " ".join(
+        str(check.get("name") or "") for check in checks.get("pending_check_runs") or []
+    ).lower()
+    if "cla" in pending_names:
+        return "resolve CLA"
     if check_state == "failure":
         return "fix checks"
     if check_state == "pending":

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -311,6 +311,59 @@ def test_collect_integration_metrics_recommends_review_for_clean_success_pr(monk
     assert metrics["integrations"][0]["next_action"] == "request review"
 
 
+def test_collect_integration_metrics_surfaces_pending_cla_status(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/activepieces/activepieces/pulls/13985":
+            return {
+                "number": 13985,
+                "title": "feat: add FunASR speech recognition piece",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "html_url": "https://github.com/activepieces/activepieces/pull/13985",
+                "updated_at": "2026-06-30T01:17:07Z",
+                "head": {"sha": "f9d22ee", "ref": "funasr/activepieces-13450-conflict-fix"},
+                "base": {"ref": "main"},
+                "user": {"login": "LauraGPT"},
+            }
+        if url == "https://api.github.com/repos/activepieces/activepieces/commits/f9d22ee/status":
+            return {
+                "state": "pending",
+                "statuses": [
+                    {
+                        "context": "license/cla",
+                        "state": "pending",
+                        "target_url": "https://cla-assistant.io/activepieces/activepieces?pullRequest=13985",
+                    }
+                ],
+            }
+        if url == "https://api.github.com/repos/activepieces/activepieces/commits/f9d22ee/check-runs?per_page=100":
+            return {
+                "total_count": 1,
+                "check_runs": [
+                    {"name": "GitGuardian Security Checks", "status": "completed", "conclusion": "success"},
+                ],
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["activepieces/activepieces#13985"])
+
+    integration = metrics["integrations"][0]
+    assert integration["next_action"] == "resolve CLA"
+    assert integration["checks"]["pending_check_runs"] == [
+        {
+            "name": "license/cla",
+            "status": "pending",
+            "url": "https://cla-assistant.io/activepieces/activepieces?pullRequest=13985",
+        }
+    ]
+
+
 def test_format_integration_markdown_includes_update_age_and_next_action():
     module = load_growth_metrics_module()
     metrics = {


### PR DESCRIPTION
## Summary
- include pending and failing commit status contexts in external integration metrics
- surface CLA blockers in the failed/pending details list
- recommend `resolve CLA` when a tracked integration is blocked on CLA status

## Validation
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m pytest /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py -q
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m py_compile /tmp/funasr-growth-main/scripts/collect_growth_metrics.py /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py
- GITHUB_TOKEN=$(gh auth token) /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 /tmp/funasr-growth-main/scripts/collect_growth_metrics.py --integrations