### PR TITLE
Classify integration review bot gates

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -178,8 +178,13 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
     pending_names = " ".join(
         str(check.get("name") or "") for check in checks.get("pending_check_runs") or []
     ).lower()
+    failed_names = " ".join(
+        str(check.get("name") or "") for check in checks.get("failed_check_runs") or []
+    ).lower()
     if "cla" in pending_names:
         return "resolve CLA"
+    if "claude-review" in failed_names or "review bot" in failed_names:
+        return "review bot gate"
     if check_state == "failure":
         return "fix checks"
     if check_state == "pending":

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -364,6 +364,49 @@ def test_collect_integration_metrics_surfaces_pending_cla_status(monkeypatch):
     ]
 
 
+def test_collect_integration_metrics_classifies_review_bot_failure(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/TEN-framework/ten-framework/pulls/2191":
+            return {
+                "number": 2191,
+                "title": "feat: add funasr_asr_python local FunASR ASR extension",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "html_url": "https://github.com/TEN-framework/ten-framework/pull/2191",
+                "updated_at": "2026-06-29T23:02:41Z",
+                "head": {"sha": "43cbedc", "ref": "add-funasr-asr-extension"},
+                "base": {"ref": "main"},
+                "user": {"login": "LauraGPT"},
+            }
+        if url == "https://api.github.com/repos/TEN-framework/ten-framework/commits/43cbedc/status":
+            return {"state": "pending", "statuses": []}
+        if url == "https://api.github.com/repos/TEN-framework/ten-framework/commits/43cbedc/check-runs?per_page=100":
+            return {
+                "total_count": 1,
+                "check_runs": [
+                    {
+                        "name": "claude-review",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "html_url": "https://github.com/TEN-framework/ten-framework/actions/runs/27985905295/job/82827178776",
+                    },
+                ],
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["TEN-framework/ten-framework#2191"])
+
+    integration = metrics["integrations"][0]
+    assert integration["next_action"] == "review bot gate"
+    assert integration["checks"]["failed_check_runs"][0]["name"] == "claude-review"
+
+
 def test_format_integration_markdown_includes_update_age_and_next_action():
     module = load_growth_metrics_module()
     metrics = {


### PR DESCRIPTION
## Summary
- classify review-bot-only failures as `review bot gate` instead of generic `fix checks`
- add regression coverage for the TEN framework claude-review failure pattern
- keep code/test failures classified separately for integration triage

## Validation
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m pytest /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py -q
- /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 -m py_compile /tmp/funasr-growth-main/scripts/collect_growth_metrics.py /tmp/funasr-growth-main/tests/test_collect_growth_metrics.py
- GITHUB_TOKEN=$(gh auth token) /Users/zhifu.gzf/.real/.bin/python-3.12-mac-arm64/bin/python3 /tmp/funasr-growth-main/scripts/collect_growth_metrics.py --integrations