### PR TITLE
Use gh auth token for growth metrics

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -11,6 +11,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -62,6 +63,20 @@ def github_headers() -> Dict[str, str]:
         "User-Agent": "funasr-growth-metrics",
     }
     token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        try:
+            completed = subprocess.run(
+                ["gh", "auth", "token"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            token = None
+        else:
+            token = completed.stdout.strip()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -1,6 +1,7 @@
 import importlib.util
 import io
 import json
+import os
 import sys
 from datetime import date, datetime, timezone
 from contextlib import redirect_stdout
@@ -19,6 +20,19 @@ def test_default_integration_prs_include_sglang_omni_fun_asr():
     module = load_growth_metrics_module()
 
     assert "sgl-project/sglang-omni#898" in module.DEFAULT_INTEGRATION_PRS
+
+
+def test_github_headers_falls_back_to_gh_auth_token(tmp_path, monkeypatch):
+    module = load_growth_metrics_module()
+    gh = tmp_path / "gh"
+    gh.write_text("#!/bin/sh\nprintf 'cli-token\\n'\n")
+    gh.chmod(0o755)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    headers = module.github_headers()
+
+    assert headers["Authorization"] == "Bearer cli-token"
 
 
 def test_default_integration_prs_include_high_visibility_external_queue():

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -1,7 +1,7 @@
 import importlib.util
 import io
 import json
-import os
+import subprocess
 import sys
 from datetime import date, datetime, timezone
 from contextlib import redirect_stdout
@@ -22,13 +22,15 @@ def test_default_integration_prs_include_sglang_omni_fun_asr():
     assert "sgl-project/sglang-omni#898" in module.DEFAULT_INTEGRATION_PRS
 
 
-def test_github_headers_falls_back_to_gh_auth_token(tmp_path, monkeypatch):
+def test_github_headers_falls_back_to_gh_auth_token(monkeypatch):
     module = load_growth_metrics_module()
-    gh = tmp_path / "gh"
-    gh.write_text("#!/bin/sh\nprintf 'cli-token\\n'\n")
-    gh.chmod(0o755)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    def fake_run(args, **kwargs):
+        assert args == ["gh", "auth", "token"]
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="cli-token\n")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
 
     headers = module.github_headers()
 


### PR DESCRIPTION
## Summary

- fall back to `gh auth token` when `GITHUB_TOKEN` is not set for GitHub API calls in `scripts/collect_growth_metrics.py`
- keep `GITHUB_TOKEN` as the first-choice token source
- add a regression test using a fake `gh` executable so the test does not call the real CLI or expose a token

## Why

The growth metrics script can hit anonymous GitHub API rate limits during manual or heartbeat runs when the environment does not export `GITHUB_TOKEN`, even though the local maintainer session is already authenticated with `gh`.

## Validation

- `pytest tests/test_collect_growth_metrics.py -q`
- `python scripts/collect_growth_metrics.py --ecosystem --pypi-package funasr --baseline-stars 31224 --target-additional-stars 20000 --target-date 2026-09-30 --format json`
- `python scripts/collect_growth_metrics.py --integrations --integration-prs sgl-project/sglang-omni#898 --format json`
