### PR TITLE
Classify Vercel preview auth gates

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -205,10 +205,15 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
     failed_names = " ".join(
         str(check.get("name") or "") for check in checks.get("failed_check_runs") or []
     ).lower()
+    failed_urls = " ".join(
+        str(check.get("url") or "") for check in checks.get("failed_check_runs") or []
+    ).lower()
     if "cla" in pending_names:
         return "resolve CLA"
     if "claude-review" in failed_names or "review bot" in failed_names:
         return "review bot gate"
+    if "vercel" in failed_names and "vercel.com/git/authorize" in failed_urls:
+        return "preview auth gate"
     if check_state == "failure":
         return "fix checks"
     if check_state == "pending":

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -441,6 +441,54 @@ def test_collect_integration_metrics_classifies_review_bot_failure(monkeypatch):
     assert integration["checks"]["failed_check_runs"][0]["name"] == "claude-review"
 
 
+def test_collect_integration_metrics_classifies_vercel_authorization_gate(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/mem0ai/mem0/pulls/5571":
+            return {
+                "number": 5571,
+                "title": "feat: add optional FunASR audio transcription helper",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "html_url": "https://github.com/mem0ai/mem0/pull/5571",
+                "updated_at": "2026-06-30T05:20:27Z",
+                "head": {"sha": "d0b1cfa", "ref": "funasr-audio-helper"},
+                "base": {"ref": "main"},
+                "user": {"login": "anneheartrecord"},
+            }
+        if url == "https://api.github.com/repos/mem0ai/mem0/commits/d0b1cfa/status":
+            return {
+                "state": "failure",
+                "statuses": [
+                    {
+                        "context": "Vercel",
+                        "state": "failure",
+                        "target_url": "https://vercel.com/git/authorize?team=Mem0&slug=mem0&pullRequest=5571",
+                    }
+                ],
+            }
+        if url == "https://api.github.com/repos/mem0ai/mem0/commits/d0b1cfa/check-runs?per_page=100":
+            return {"total_count": 0, "check_runs": []}
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["mem0ai/mem0#5571"])
+
+    integration = metrics["integrations"][0]
+    assert integration["next_action"] == "preview auth gate"
+    assert integration["checks"]["failed_check_runs"] == [
+        {
+            "name": "Vercel",
+            "conclusion": "failure",
+            "url": "https://vercel.com/git/authorize?team=Mem0&slug=mem0&pullRequest=5571",
+        }
+    ]
+
+
 def test_collect_integration_metrics_treats_empty_pending_status_as_unknown(monkeypatch):
     module = load_growth_metrics_module()
 


### PR DESCRIPTION
## Summary

- classify Vercel preview authorization failures as `preview auth gate` instead of generic `fix checks`
- use failed check URLs to distinguish `vercel.com/git/authorize` gates from real Vercel build failures
- add a regression test for the current `mem0ai/mem0#5571` status shape

## Validation

```text
python -m pytest tests/test_collect_growth_metrics.py::test_collect_integration_metrics_classifies_vercel_authorization_gate -q
# 1 passed

python -m pytest tests/test_collect_growth_metrics.py -q
# 19 passed

git diff --check
# passed

python scripts/collect_growth_metrics.py --integrations --integration-prs mem0ai/mem0#5571 --format markdown
# action is preview auth gate
```
