### PR TITLE
Classify unknown-check review gates

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -220,9 +220,9 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
         return "wait for checks"
 
     mergeable_state = pull_request.get("mergeable_state")
-    if check_state == "success" and mergeable_state == "clean":
+    if check_state in {"success", "unknown"} and mergeable_state == "clean":
         return "request review"
-    if check_state == "success" and mergeable_state in {"blocked", "unstable"}:
+    if check_state in {"success", "unknown"} and mergeable_state in {"blocked", "unstable"}:
         return "review gate"
     return "inspect"
 

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -489,7 +489,29 @@ def test_collect_integration_metrics_classifies_vercel_authorization_gate(monkey
     ]
 
 
-def test_collect_integration_metrics_treats_empty_pending_status_as_unknown(monkeypatch):
+def test_recommend_integration_action_treats_blocked_unknown_checks_as_review_gate():
+    module = load_growth_metrics_module()
+
+    action = module.recommend_integration_action(
+        {"state": "open", "draft": False, "mergeable_state": "blocked"},
+        {"state": "unknown", "failed_check_runs": [], "pending_check_runs": []},
+    )
+
+    assert action == "review gate"
+
+
+def test_recommend_integration_action_treats_clean_unknown_checks_as_request_review():
+    module = load_growth_metrics_module()
+
+    action = module.recommend_integration_action(
+        {"state": "open", "draft": False, "mergeable_state": "clean"},
+        {"state": "unknown", "failed_check_runs": [], "pending_check_runs": []},
+    )
+
+    assert action == "request review"
+
+
+def test_collect_integration_metrics_treats_empty_pending_status_as_review_gate(monkeypatch):
     module = load_growth_metrics_module()
 
     def fake_fetch_json(url, headers=None):
@@ -520,7 +542,7 @@ def test_collect_integration_metrics_treats_empty_pending_status_as_unknown(monk
     integration = metrics["integrations"][0]
     assert integration["checks"]["state"] == "unknown"
     assert integration["checks"]["pending_check_runs"] == []
-    assert integration["next_action"] == "inspect"
+    assert integration["next_action"] == "review gate"
 
 
 def test_format_integration_markdown_includes_update_age_and_next_action():


### PR DESCRIPTION
## Summary

- classify PRs with no concrete failed/pending checks and `mergeable_state=blocked|unstable` as `review gate`
- classify PRs with no concrete checks and `mergeable_state=clean` as `request review`
- add regression tests for both unknown-check cases and update the empty-pending-status regression to keep showing `unknown` checks while recommending review follow-up

This makes the external integration tracker more actionable for PRs such as `huggingface/speech-to-speech#319`, `xinnan-tech/xiaozhi-esp32-server#3255`, and `ai4s-research/awesome-ai-for-science#69`.

## Validation

```text
python -m pytest tests/test_collect_growth_metrics.py -q
# 21 passed

git diff --check
# passed

python scripts/collect_growth_metrics.py --integrations --integration-prs huggingface/speech-to-speech#319 xinnan-tech/xiaozhi-esp32-server#3255 ai4s-research/awesome-ai-for-science#69 --format markdown
# speech-to-speech/xiaozhi => review gate; ai4s => request review
```
