### PR TITLE
Add Glama metadata for MCP server

### DIFF
--- a/examples/mcp_server/README.md
+++ b/examples/mcp_server/README.md
@@ -25,6 +25,8 @@ docker run --rm -i \
 
 When submitting this server to MCP directories such as Glama, use this folder as
 the Docker build context so the container entrypoint runs `funasr_mcp.py`.
+The `glama.json` file in this directory declares the MCP server command and
+metadata for directory scanners.
 
 ### 3. Configure your AI tool
 

--- a/examples/mcp_server/glama.json
+++ b/examples/mcp_server/glama.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://glama.ai/api/mcp/v1/schemas/glama.json",
+  "name": "funasr",
+  "display_name": "FunASR MCP Server",
+  "description": "Local speech recognition MCP server powered by FunASR and SenseVoice. It exposes a transcribe_audio tool for privacy-friendly audio transcription from local files.",
+  "repository": "https://github.com/modelscope/FunASR",
+  "license": "MIT",
+  "runtime": "python",
+  "tags": ["speech-to-text", "asr", "audio", "funasr", "sensevoice", "local", "mcp"],
+  "mcpServers": {
+    "funasr": {
+      "command": "python",
+      "args": ["/app/funasr_mcp.py"],
+      "env": {
+        "FUNASR_DEVICE": "cpu"
+      }
+    }
+  }
+}

--- a/tests/test_mcp_server_example.py
+++ b/tests/test_mcp_server_example.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 
@@ -12,3 +13,16 @@ def test_mcp_server_example_has_glama_ready_dockerfile():
     assert "funasr" in dockerfile_text
     assert "COPY funasr_mcp.py /app/funasr_mcp.py" in dockerfile_text
     assert 'CMD ["python", "/app/funasr_mcp.py"]' in dockerfile_text
+
+
+def test_mcp_server_example_has_glama_metadata():
+    example_dir = Path(__file__).resolve().parents[1] / "examples" / "mcp_server"
+    metadata_path = example_dir / "glama.json"
+
+    metadata = json.loads(metadata_path.read_text())
+
+    assert metadata["repository"] == "https://github.com/modelscope/FunASR"
+    assert metadata["runtime"] == "python"
+    assert metadata["license"] == "MIT"
+    assert metadata["mcpServers"]["funasr"]["command"] == "python"
+    assert metadata["mcpServers"]["funasr"]["args"] == ["/app/funasr_mcp.py"]


### PR DESCRIPTION
## Summary
- add examples/mcp_server/glama.json with FunASR MCP server metadata for directory scanners
- document the Glama metadata next to the Docker-based MCP submission flow
- test the Glama metadata command, args, repository, runtime, and license fields

## Validation
- python -m pytest tests/test_mcp_server_example.py -q
- python -m pytest tests/test_collect_growth_metrics.py tests/test_mcp_server_example.py -q
- python -m json.tool examples/mcp_server/glama.json
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs punkpeye/awesome-mcp-servers#7153 --format markdown
- python - <<'PY'
import json
import subprocess
import sys
requests = [
    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
]
payload = "".join(
    f"Content-Length: {len(json.dumps(req))}\r\n\r\n{json.dumps(req)}"
    for req in requests
)
proc = subprocess.run(
    [sys.executable, "examples/mcp_server/funasr_mcp.py"],
    input=payload,
    text=True,
    capture_output=True,
    timeout=5,
)
if proc.returncode != 0:
    raise SystemExit(proc.stderr or f"return code {proc.returncode}")
out = proc.stdout
assert "\"serverInfo\": {\"name\": \"funasr\"" in out, out
assert "\"name\": \"transcribe_audio\"" in out, out
print("mcp initialize/tools-list ok")
PY