### PR TITLE
Add root Glama metadata for MCP discovery

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://glama.ai/api/mcp/v1/schemas/glama.json",
+  "name": "funasr",
+  "display_name": "FunASR MCP Server",
+  "description": "Local speech recognition MCP server powered by FunASR and SenseVoice. It exposes a transcribe_audio tool for privacy-friendly audio transcription from local files.",
+  "repository": "https://github.com/modelscope/FunASR",
+  "license": "MIT",
+  "runtime": "python",
+  "tags": ["speech-to-text", "asr", "audio", "funasr", "sensevoice", "local", "mcp"],
+  "mcpServers": {
+    "funasr": {
+      "command": "python",
+      "args": ["examples/mcp_server/funasr_mcp.py"],
+      "env": {
+        "FUNASR_DEVICE": "cpu"
+      }
+    }
+  }
+}

--- a/tests/test_mcp_server_example.py
+++ b/tests/test_mcp_server_example.py
@@ -26,3 +26,16 @@ def test_mcp_server_example_has_glama_metadata():
     assert metadata["license"] == "MIT"
     assert metadata["mcpServers"]["funasr"]["command"] == "python"
     assert metadata["mcpServers"]["funasr"]["args"] == ["/app/funasr_mcp.py"]
+
+
+def test_repository_root_has_glama_metadata_for_mcp_directory_scanners():
+    repo_root = Path(__file__).resolve().parents[1]
+    metadata = json.loads((repo_root / "glama.json").read_text())
+
+    assert metadata["repository"] == "https://github.com/modelscope/FunASR"
+    assert metadata["runtime"] == "python"
+    assert metadata["license"] == "MIT"
+    assert metadata["mcpServers"]["funasr"]["command"] == "python"
+    assert metadata["mcpServers"]["funasr"]["args"] == [
+        "examples/mcp_server/funasr_mcp.py"
+    ]


### PR DESCRIPTION
## Summary
- add a repository-root glama.json so MCP directory scanners that inspect the repo root can discover the FunASR MCP server
- point the root metadata at examples/mcp_server/funasr_mcp.py while preserving the example-local container metadata
- cover the root metadata fields with tests

## Validation
- python -m pytest tests/test_mcp_server_example.py -q
- python -m pytest tests/test_collect_growth_metrics.py tests/test_mcp_server_example.py -q
- python -m json.tool glama.json
- python -m json.tool examples/mcp_server/glama.json
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs punkpeye/awesome-mcp-servers#7153 --format markdown
- python - <<'PY'
import json
import subprocess
import sys
requests = [
    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
]
payload = "".join(
    f"Content-Length: {len(json.dumps(req))}\r\n\r\n{json.dumps(req)}"
    for req in requests
)
proc = subprocess.run(
    [sys.executable, "examples/mcp_server/funasr_mcp.py"],
    input=payload,
    text=True,
    capture_output=True,
    timeout=5,
)
if proc.returncode != 0:
    raise SystemExit(proc.stderr or f"return code {proc.returncode}")
out = proc.stdout
assert "\"serverInfo\": {\"name\": \"funasr\"" in out, out
assert "\"name\": \"transcribe_audio\"" in out, out
print("mcp initialize/tools-list ok")
PY