### PR TITLE
Track speech server integration PRs

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -203,6 +203,9 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
         return "archive"
     if pull_request.get("draft"):
         return "finish draft"
+    mergeable_state = pull_request.get("mergeable_state")
+    if mergeable_state == "dirty":
+        return "resolve conflicts"
 
     check_state = checks.get("state")
     pending_names = " ".join(
@@ -225,9 +228,6 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
     if check_state == "pending":
         return "wait for checks"
 
-    mergeable_state = pull_request.get("mergeable_state")
-    if mergeable_state == "dirty":
-        return "resolve conflicts"
     if check_state in {"success", "unknown"} and mergeable_state == "clean":
         return "request review"
     if check_state in {"success", "unknown"} and mergeable_state in {"blocked", "unstable"}:

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -42,7 +42,9 @@ DEFAULT_INTEGRATION_PRS = [
     "tmoroney/auto-subs#629",
     "infiniflow/ragflow#16473",
     "pipecat-ai/pipecat#4844",
+    "speaches-ai/speaches#658",
     "mudler/LocalAI#10090",
+    "getpaseo/paseo#1634",
     "agno-agi/agno#8501",
     "GetStream/Vision-Agents#606",
     "TEN-framework/ten-framework#2191",
@@ -224,6 +226,8 @@ def recommend_integration_action(pull_request: Dict[str, Any], checks: Dict[str,
         return "wait for checks"
 
     mergeable_state = pull_request.get("mergeable_state")
+    if mergeable_state == "dirty":
+        return "resolve conflicts"
     if check_state in {"success", "unknown"} and mergeable_state == "clean":
         return "request review"
     if check_state in {"success", "unknown"} and mergeable_state in {"blocked", "unstable"}:

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -566,6 +566,36 @@ def test_recommend_integration_action_treats_dirty_merge_state_as_conflict_resol
     assert action == "resolve conflicts"
 
 
+def test_recommend_integration_action_prioritizes_dirty_merge_state_over_failed_checks():
+    module = load_growth_metrics_module()
+
+    action = module.recommend_integration_action(
+        {"state": "open", "draft": False, "mergeable_state": "dirty"},
+        {
+            "state": "failure",
+            "failed_check_runs": [{"name": "ci", "conclusion": "failure"}],
+            "pending_check_runs": [],
+        },
+    )
+
+    assert action == "resolve conflicts"
+
+
+def test_recommend_integration_action_prioritizes_dirty_merge_state_over_pending_checks():
+    module = load_growth_metrics_module()
+
+    action = module.recommend_integration_action(
+        {"state": "open", "draft": False, "mergeable_state": "dirty"},
+        {
+            "state": "pending",
+            "failed_check_runs": [],
+            "pending_check_runs": [{"name": "ci", "status": "queued"}],
+        },
+    )
+
+    assert action == "resolve conflicts"
+
+
 def test_collect_integration_metrics_treats_empty_pending_status_as_review_gate(monkeypatch):
     module = load_growth_metrics_module()
 

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -96,6 +96,17 @@ def test_default_integration_prs_include_mcp_discovery_lanes():
     assert "punkpeye/awesome-mcp-servers#7153" in module.DEFAULT_INTEGRATION_PRS
 
 
+def test_default_integration_prs_include_speech_server_lanes():
+    module = load_growth_metrics_module()
+
+    expected_prs = {
+        "speaches-ai/speaches#658",
+        "getpaseo/paseo#1634",
+    }
+
+    assert expected_prs.issubset(set(module.DEFAULT_INTEGRATION_PRS))
+
+
 def test_default_integration_prs_exclude_archived_integration_prs():
     module = load_growth_metrics_module()
 
@@ -542,6 +553,17 @@ def test_recommend_integration_action_treats_clean_unknown_checks_as_request_rev
     )
 
     assert action == "request review"
+
+
+def test_recommend_integration_action_treats_dirty_merge_state_as_conflict_resolution():
+    module = load_growth_metrics_module()
+
+    action = module.recommend_integration_action(
+        {"state": "open", "draft": False, "mergeable_state": "dirty"},
+        {"state": "unknown", "failed_check_runs": [], "pending_check_runs": []},
+    )
+
+    assert action == "resolve conflicts"
 
 
 def test_collect_integration_metrics_treats_empty_pending_status_as_review_gate(monkeypatch):


### PR DESCRIPTION
## Summary
- add `speaches-ai/speaches#658` to the default external integration tracker
- add `getpaseo/paseo#1634` to the default external integration tracker
- classify `mergeable_state=dirty` as `resolve conflicts` so tracker output gives a concrete next action

## Context
These are high-visibility external speech/server surfaces discovered in the latest GitHub search pass:
- `speaches-ai/speaches`: 3.4k+ stars, OpenAI-compatible speech server
- `getpaseo/paseo`: 9.5k+ stars, local agent orchestration surface with SenseVoice local STT support

## Verification
- `python -m pytest tests/test_collect_growth_metrics.py tests/test_mcp_server_example.py -q` -> 30 passed
- `python scripts/collect_growth_metrics.py --integrations --integration-prs speaches-ai/speaches#658 getpaseo/paseo#1634 --format markdown` -> `review gate` for speaches and `resolve conflicts` for paseo
- `git diff --check`
