### PR TITLE
Track Glama review gate for MCP integration

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -63,6 +63,12 @@ KNOWN_EXTERNAL_CHECK_FAILURES = {
         "reason": "LightOnOCR shared hub-cache read-only failure; PR CI status is the aggregate failure",
     }
 }
+KNOWN_REVIEW_GATES = {
+    "punkpeye/awesome-mcp-servers#7153": {
+        "action": "submit Glama",
+        "reason": "Glama listing and score badge required before review",
+    }
+}
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}
 
@@ -232,6 +238,7 @@ def recommend_integration_action(
     pull_request: Dict[str, Any],
     checks: Dict[str, Any],
     known_external_failure_reason: Optional[str] = None,
+    known_review_gate_action: Optional[str] = None,
 ) -> str:
     if pull_request.get("state") != "open":
         return "archive"
@@ -263,6 +270,8 @@ def recommend_integration_action(
         return "fix checks"
     if check_state == "pending":
         return "wait for checks"
+    if known_review_gate_action:
+        return known_review_gate_action
 
     if check_state in {"success", "unknown"} and mergeable_state == "clean":
         return "request review"
@@ -282,6 +291,7 @@ def collect_pull_request_metrics(spec: str, now: Optional[dt.datetime] = None) -
     head_sha = head.get("sha")
     checks = summarize_commit_checks(repo, head_sha) if head_sha else {"state": "unknown"}
     known_external_failure_reason = classify_known_external_failure(spec, checks)
+    known_review_gate = KNOWN_REVIEW_GATES.get(spec) or {}
     updated_at = pull_request.get("updated_at")
     return {
         "pr": f"{repo}#{pr_number}",
@@ -303,7 +313,13 @@ def collect_pull_request_metrics(spec: str, now: Optional[dt.datetime] = None) -
         "author": author.get("login"),
         "checks": checks,
         "known_external_failure_reason": known_external_failure_reason,
-        "next_action": recommend_integration_action(pull_request, checks, known_external_failure_reason),
+        "known_review_gate_reason": known_review_gate.get("reason"),
+        "next_action": recommend_integration_action(
+            pull_request,
+            checks,
+            known_external_failure_reason,
+            known_review_gate.get("action"),
+        ),
     }
 
 
@@ -533,6 +549,16 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
                 f"- [{integration['pr']}]({integration.get('html_url')}): "
                 f"{int(integration['repo_stars']):,} stars, "
                 f"{integration.get('next_action') or 'inspect'}"
+            )
+    review_gate_integrations = [
+        integration for integration in metrics["integrations"] if integration.get("known_review_gate_reason")
+    ]
+    if review_gate_integrations:
+        lines.extend(["", "## Manual review gates", ""])
+        for integration in review_gate_integrations:
+            lines.append(
+                f"- [{integration['pr']}]({integration.get('html_url')}): "
+                f"{integration['known_review_gate_reason']}"
             )
     lines.extend(["", "## Failed or pending checks", ""])
     for integration in metrics["integrations"]:

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -486,6 +486,46 @@ def test_collect_integration_metrics_recommends_review_for_clean_success_pr(monk
     assert metrics["integrations"][0]["next_action"] == "request review"
 
 
+def test_collect_integration_metrics_applies_known_review_gate(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/punkpeye/awesome-mcp-servers/pulls/7153":
+            return {
+                "number": 7153,
+                "title": "Add FunASR speech recognition MCP server",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "html_url": "https://github.com/punkpeye/awesome-mcp-servers/pull/7153",
+                "updated_at": "2026-06-16T04:21:55Z",
+                "head": {"sha": "d28680e", "ref": "add-funasr-mcp-server"},
+                "base": {"ref": "main"},
+                "user": {"login": "LauraGPT"},
+            }
+        if url == "https://api.github.com/repos/punkpeye/awesome-mcp-servers/commits/d28680e/status":
+            return {"state": "success", "statuses": []}
+        if url == "https://api.github.com/repos/punkpeye/awesome-mcp-servers/commits/d28680e/check-runs?per_page=100":
+            return {
+                "total_count": 2,
+                "check_runs": [
+                    {"name": "check-submission", "status": "completed", "conclusion": "success"},
+                    {"name": "welcome", "status": "completed", "conclusion": "skipped"},
+                ],
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["punkpeye/awesome-mcp-servers#7153"])
+
+    integration = metrics["integrations"][0]
+    assert integration["checks"]["state"] == "success"
+    assert integration["known_review_gate_reason"] == "Glama listing and score badge required before review"
+    assert integration["next_action"] == "submit Glama"
+
+
 def test_collect_integration_metrics_surfaces_pending_cla_status(monkeypatch):
     module = load_growth_metrics_module()
 
@@ -874,6 +914,36 @@ def test_format_integration_markdown_lists_high_exposure_priorities_by_stars():
     assert ray in output
     assert output.index(transformers) < output.index(ray)
     assert "deleted-org/deleted-repo#1" not in output.split("## High-exposure priorities", 1)[1].split("## Failed or pending checks", 1)[0]
+
+
+def test_format_integration_markdown_lists_known_review_gates():
+    module = load_growth_metrics_module()
+    metrics = {
+        "collected_at_utc": "2026-07-02T00:00:00+00:00",
+        "integrations": [
+            {
+                "pr": "punkpeye/awesome-mcp-servers#7153",
+                "html_url": "https://github.com/punkpeye/awesome-mcp-servers/pull/7153",
+                "state": "open",
+                "mergeable_state": "clean",
+                "repo_stars": 90_000,
+                "repo_forks": 12_000,
+                "updated_at": "2026-06-16T04:21:55Z",
+                "updated_age_days": 14,
+                "next_action": "submit Glama",
+                "known_review_gate_reason": "Glama listing and score badge required before review",
+                "checks": {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
+            }
+        ],
+    }
+
+    output = module.format_integration_markdown(metrics)
+
+    assert "## Manual review gates" in output
+    assert (
+        "- [punkpeye/awesome-mcp-servers#7153](https://github.com/punkpeye/awesome-mcp-servers/pull/7153): "
+        "Glama listing and score badge required before review"
+    ) in output
 
 
 def test_collect_issue_metrics_filters_pull_requests_and_assigns_waiting_on(monkeypatch):


### PR DESCRIPTION
## Summary
- classify the awesome-mcp-servers FunASR PR as a Glama submission gate instead of a review request
- surface manual review gates in integration markdown snapshots

## Verification
- curl -sS -o /tmp/glama-score.svg -w '%{http_code} %{url_effective}\n' https://glama.ai/mcp/servers/modelscope/FunASR/badges/score.svg
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m pytest tests/test_collect_growth_metrics.py tests/test_mcp_server_example.py -q
- git diff --check
- python scripts/collect_growth_metrics.py --integration-prs punkpeye/awesome-mcp-servers#7153 --integrations