### PR TITLE
Document Glama MCP submission checklist

### DIFF
--- a/examples/mcp_server/README.md
+++ b/examples/mcp_server/README.md
@@ -28,6 +28,28 @@ the Docker build context so the container entrypoint runs `funasr_mcp.py`.
 The `glama.json` file in this directory declares the MCP server command and
 metadata for directory scanners.
 
+### Glama submission checklist
+
+Use these values when adding the server at <https://glama.ai/mcp/servers>:
+
+| Field | Value |
+|------|-------|
+| Repository URL | <https://github.com/modelscope/FunASR> |
+| Docker build context | `examples/mcp_server` |
+| Dockerfile path | `examples/mcp_server/Dockerfile` |
+| Server command | `python /app/funasr_mcp.py` |
+| Expected MCP tool | `transcribe_audio` |
+
+After Glama finishes evaluation, verify that the score badge endpoint returns
+success before adding it to directory PRs:
+
+```markdown
+[![modelscope/FunASR MCP server](https://glama.ai/mcp/servers/modelscope/FunASR/badges/score.svg)](https://glama.ai/mcp/servers/modelscope/FunASR)
+```
+
+If the badge endpoint still returns 404, keep the badge out of external
+directory submissions until the Glama listing is live.
+
 ### 3. Configure your AI tool
 
 **Claude Code** (`~/.claude.json`):

--- a/tests/test_mcp_server_example.py
+++ b/tests/test_mcp_server_example.py
@@ -39,3 +39,15 @@ def test_repository_root_has_glama_metadata_for_mcp_directory_scanners():
     assert metadata["mcpServers"]["funasr"]["args"] == [
         "examples/mcp_server/funasr_mcp.py"
     ]
+
+
+def test_mcp_server_readme_has_glama_submission_checklist():
+    example_dir = Path(__file__).resolve().parents[1] / "examples" / "mcp_server"
+    readme = (example_dir / "README.md").read_text()
+
+    assert "### Glama submission checklist" in readme
+    assert "https://github.com/modelscope/FunASR" in readme
+    assert "`examples/mcp_server`" in readme
+    assert "`python /app/funasr_mcp.py`" in readme
+    assert "`transcribe_audio`" in readme
+    assert "https://glama.ai/mcp/servers/modelscope/FunASR/badges/score.svg" in readme


### PR DESCRIPTION
## Summary
- add a Glama submission checklist to the MCP server README
- document the repository URL, Docker build context, Dockerfile path, server command, expected tool, and badge URL
- add a regression test that keeps the Glama submission details present in the README

## Why
The awesome-mcp-servers FunASR PR is currently blocked on a Glama listing and score badge. This makes the required submission fields copyable from the source repo and reduces the chance of another failed directory submission.

## Validation
- python -m pytest tests/test_mcp_server_example.py tests/test_collect_growth_metrics.py -q
- git diff --check HEAD~1 HEAD