### PR TITLE
Track assisted integration review waits

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -69,6 +69,17 @@ KNOWN_REVIEW_GATES = {
         "reason": "Glama listing and score badge required before review",
     }
 }
+KNOWN_ASSISTED_REVIEW_REQUESTS = {
+    "infiniflow/ragflow#16473": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "lukasmasuch/best-of-ml-python#455": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "tmoroney/auto-subs#629": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+}
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}
 
@@ -239,6 +250,7 @@ def recommend_integration_action(
     checks: Dict[str, Any],
     known_external_failure_reason: Optional[str] = None,
     known_review_gate_action: Optional[str] = None,
+    known_assisted_review_reason: Optional[str] = None,
 ) -> str:
     if pull_request.get("state") != "open":
         return "archive"
@@ -272,6 +284,12 @@ def recommend_integration_action(
         return "wait for checks"
     if known_review_gate_action:
         return known_review_gate_action
+    if (
+        known_assisted_review_reason
+        and check_state in {"success", "unknown"}
+        and mergeable_state in {"clean", "unknown", None}
+    ):
+        return "wait for maintainer review"
 
     if check_state in {"success", "unknown"} and mergeable_state == "clean":
         return "request review"
@@ -292,6 +310,7 @@ def collect_pull_request_metrics(spec: str, now: Optional[dt.datetime] = None) -
     checks = summarize_commit_checks(repo, head_sha) if head_sha else {"state": "unknown"}
     known_external_failure_reason = classify_known_external_failure(spec, checks)
     known_review_gate = KNOWN_REVIEW_GATES.get(spec) or {}
+    known_assisted_review = KNOWN_ASSISTED_REVIEW_REQUESTS.get(spec) or {}
     updated_at = pull_request.get("updated_at")
     return {
         "pr": f"{repo}#{pr_number}",
@@ -314,11 +333,13 @@ def collect_pull_request_metrics(spec: str, now: Optional[dt.datetime] = None) -
         "checks": checks,
         "known_external_failure_reason": known_external_failure_reason,
         "known_review_gate_reason": known_review_gate.get("reason"),
+        "known_assisted_review_reason": known_assisted_review.get("reason"),
         "next_action": recommend_integration_action(
             pull_request,
             checks,
             known_external_failure_reason,
             known_review_gate.get("action"),
+            known_assisted_review.get("reason"),
         ),
     }
 
@@ -559,6 +580,16 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
             lines.append(
                 f"- [{integration['pr']}]({integration.get('html_url')}): "
                 f"{integration['known_review_gate_reason']}"
+            )
+    assisted_review_integrations = [
+        integration for integration in metrics["integrations"] if integration.get("known_assisted_review_reason")
+    ]
+    if assisted_review_integrations:
+        lines.extend(["", "## Assisted review waits", ""])
+        for integration in assisted_review_integrations:
+            lines.append(
+                f"- [{integration['pr']}]({integration.get('html_url')}): "
+                f"{integration['known_assisted_review_reason']}"
             )
     lines.extend(["", "## Failed or pending checks", ""])
     for integration in metrics["integrations"]:

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -454,36 +454,74 @@ def test_collect_integration_metrics_recommends_review_for_clean_success_pr(monk
     module = load_growth_metrics_module()
 
     def fake_fetch_json(url, headers=None):
-        if url == "https://api.github.com/repos/infiniflow/ragflow/pulls/16473":
+        if url == "https://api.github.com/repos/mahseema/awesome-ai-tools/pulls/1689":
             return {
-                "number": 16473,
-                "title": "feat(stt): add FunASR / SenseVoice provider",
+                "number": 1689,
+                "title": "Add FunASR",
                 "state": "open",
                 "draft": False,
                 "mergeable": True,
                 "mergeable_state": "clean",
-                "html_url": "https://github.com/infiniflow/ragflow/pull/16473",
-                "updated_at": "2026-06-30T03:16:39Z",
-                "head": {"sha": "818a295", "ref": "funasr/ragflow-15526-conflict-fix"},
+                "html_url": "https://github.com/mahseema/awesome-ai-tools/pull/1689",
+                "updated_at": "2026-06-30T06:44:34Z",
+                "head": {"sha": "9a19b5e", "ref": "add-funasr"},
                 "base": {"ref": "main"},
                 "user": {"login": "LauraGPT"},
             }
-        if url == "https://api.github.com/repos/infiniflow/ragflow/commits/818a295/status":
+        if url == "https://api.github.com/repos/mahseema/awesome-ai-tools/commits/9a19b5e/status":
             return {"state": "success", "statuses": []}
-        if url == "https://api.github.com/repos/infiniflow/ragflow/commits/818a295/check-runs?per_page=100":
+        if url == "https://api.github.com/repos/mahseema/awesome-ai-tools/commits/9a19b5e/check-runs?per_page=100":
             return {
                 "total_count": 1,
                 "check_runs": [
-                    {"name": "CodeRabbit", "status": "completed", "conclusion": "success"},
+                    {"name": "validate", "status": "completed", "conclusion": "success"},
                 ],
             }
         raise AssertionError(f"unexpected URL: {url}")
 
     monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
 
-    metrics = module.collect_integration_metrics(["infiniflow/ragflow#16473"])
+    metrics = module.collect_integration_metrics(["mahseema/awesome-ai-tools#1689"])
 
     assert metrics["integrations"][0]["next_action"] == "request review"
+
+
+def test_collect_integration_metrics_marks_known_assisted_review_request(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/lukasmasuch/best-of-ml-python/pulls/455":
+            return {
+                "number": 455,
+                "title": "Add FunASR",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "html_url": "https://github.com/lukasmasuch/best-of-ml-python/pull/455",
+                "updated_at": "2026-06-30T09:16:59Z",
+                "head": {"sha": "48f3070", "ref": "add-funasr"},
+                "base": {"ref": "main"},
+                "user": {"login": "LauraGPT"},
+            }
+        if url == "https://api.github.com/repos/lukasmasuch/best-of-ml-python/commits/48f3070/status":
+            return {"state": "success", "statuses": []}
+        if url == "https://api.github.com/repos/lukasmasuch/best-of-ml-python/commits/48f3070/check-runs?per_page=100":
+            return {
+                "total_count": 1,
+                "check_runs": [
+                    {"name": "tests", "status": "completed", "conclusion": "success"},
+                ],
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["lukasmasuch/best-of-ml-python#455"])
+
+    integration = metrics["integrations"][0]
+    assert integration["known_assisted_review_reason"] == "review evidence already posted; avoid duplicate pings"
+    assert integration["next_action"] == "wait for maintainer review"
 
 
 def test_collect_integration_metrics_applies_known_review_gate(monkeypatch):
@@ -943,6 +981,36 @@ def test_format_integration_markdown_lists_known_review_gates():
     assert (
         "- [punkpeye/awesome-mcp-servers#7153](https://github.com/punkpeye/awesome-mcp-servers/pull/7153): "
         "Glama listing and score badge required before review"
+    ) in output
+
+
+def test_format_integration_markdown_lists_assisted_review_waits():
+    module = load_growth_metrics_module()
+    metrics = {
+        "collected_at_utc": "2026-07-02T00:00:00+00:00",
+        "integrations": [
+            {
+                "pr": "lukasmasuch/best-of-ml-python#455",
+                "html_url": "https://github.com/lukasmasuch/best-of-ml-python/pull/455",
+                "state": "open",
+                "mergeable_state": "clean",
+                "repo_stars": 23_652,
+                "repo_forks": 3_800,
+                "updated_at": "2026-06-30T09:16:59Z",
+                "updated_age_days": 0,
+                "next_action": "wait for maintainer review",
+                "known_assisted_review_reason": "review evidence already posted; avoid duplicate pings",
+                "checks": {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
+            }
+        ],
+    }
+
+    output = module.format_integration_markdown(metrics)
+
+    assert "## Assisted review waits" in output
+    assert (
+        "- [lukasmasuch/best-of-ml-python#455](https://github.com/lukasmasuch/best-of-ml-python/pull/455): "
+        "review evidence already posted; avoid duplicate pings"
     ) in output
 
 


### PR DESCRIPTION
## Summary
- Track external integration PRs where review evidence was already posted so snapshots do not keep recommending duplicate review-request comments.
- Add an Assisted review waits section to the integration markdown report.
- Keep unassisted clean PRs on the request review path.

## Validation
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check HEAD^ HEAD
- python scripts/collect_growth_metrics.py --integrations --format markdown | sed -n '/## Assisted review waits/,+8p'