### PR TITLE
Mark discovery integration review waits

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -76,6 +76,12 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "lukasmasuch/best-of-ml-python#455": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
+    "mahseema/awesome-ai-tools#1689": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "ai4s-research/awesome-ai-for-science#69": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
     "tmoroney/auto-subs#629": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -454,23 +454,23 @@ def test_collect_integration_metrics_recommends_review_for_clean_success_pr(monk
     module = load_growth_metrics_module()
 
     def fake_fetch_json(url, headers=None):
-        if url == "https://api.github.com/repos/mahseema/awesome-ai-tools/pulls/1689":
+        if url == "https://api.github.com/repos/example/clean-pr/pulls/42":
             return {
-                "number": 1689,
+                "number": 42,
                 "title": "Add FunASR",
                 "state": "open",
                 "draft": False,
                 "mergeable": True,
                 "mergeable_state": "clean",
-                "html_url": "https://github.com/mahseema/awesome-ai-tools/pull/1689",
+                "html_url": "https://github.com/example/clean-pr/pull/42",
                 "updated_at": "2026-06-30T06:44:34Z",
                 "head": {"sha": "9a19b5e", "ref": "add-funasr"},
                 "base": {"ref": "main"},
                 "user": {"login": "LauraGPT"},
             }
-        if url == "https://api.github.com/repos/mahseema/awesome-ai-tools/commits/9a19b5e/status":
+        if url == "https://api.github.com/repos/example/clean-pr/commits/9a19b5e/status":
             return {"state": "success", "statuses": []}
-        if url == "https://api.github.com/repos/mahseema/awesome-ai-tools/commits/9a19b5e/check-runs?per_page=100":
+        if url == "https://api.github.com/repos/example/clean-pr/commits/9a19b5e/check-runs?per_page=100":
             return {
                 "total_count": 1,
                 "check_runs": [
@@ -481,9 +481,20 @@ def test_collect_integration_metrics_recommends_review_for_clean_success_pr(monk
 
     monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
 
-    metrics = module.collect_integration_metrics(["mahseema/awesome-ai-tools#1689"])
+    metrics = module.collect_integration_metrics(["example/clean-pr#42"])
 
     assert metrics["integrations"][0]["next_action"] == "request review"
+
+
+def test_known_assisted_review_requests_include_validated_discovery_prs():
+    module = load_growth_metrics_module()
+
+    expected_prs = {
+        "mahseema/awesome-ai-tools#1689",
+        "ai4s-research/awesome-ai-for-science#69",
+    }
+
+    assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))
 
 
 def test_collect_integration_metrics_marks_known_assisted_review_request(monkeypatch):


### PR DESCRIPTION
## Summary
- Mark the already-validated FunClip/FunASR discovery-list PRs as assisted review waits.
- Keep untracked clean PRs on the request-review path.
- Add a regression test so these two PRs do not reappear as duplicate review-request work.

## Evidence
- mahseema/awesome-ai-tools#1689 already has a validation comment: https://github.com/mahseema/awesome-ai-tools/pull/1689#issuecomment-4840630727
- ai4s-research/awesome-ai-for-science#69 already has a validation comment: https://github.com/ai4s-research/awesome-ai-for-science/pull/69#issuecomment-4840609892

## Validation
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check HEAD^ HEAD
- python scripts/collect_growth_metrics.py --integrations --format json | jq -r '.integrations[] | select(.pr=="mahseema/awesome-ai-tools#1689" or .pr=="ai4s-research/awesome-ai-for-science#69") | [.pr, .checks.state, (.mergeable_state // .mergeable), .next_action, (.known_assisted_review_reason // "")] | @tsv'