### PR TITLE
Mark assisted review gate integrations

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -73,6 +73,18 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "infiniflow/ragflow#16473": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
+    "run-llama/llama_index#21958": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "mudler/LocalAI#10090": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "ray-project/ray#64053": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "agno-agi/agno#8501": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
     "lukasmasuch/best-of-ml-python#455": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
@@ -83,6 +95,9 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
     "tmoroney/auto-subs#629": {
+        "reason": "review evidence already posted; avoid duplicate pings",
+    },
+    "pipecat-ai/pipecat#4844": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
 }
@@ -293,7 +308,7 @@ def recommend_integration_action(
     if (
         known_assisted_review_reason
         and check_state in {"success", "unknown"}
-        and mergeable_state in {"clean", "unknown", None}
+        and mergeable_state in {"blocked", "clean", "unknown", "unstable", None}
     ):
         return "wait for maintainer review"
 

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -497,6 +497,20 @@ def test_known_assisted_review_requests_include_validated_discovery_prs():
     assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))
 
 
+def test_known_assisted_review_requests_include_validated_review_gate_prs():
+    module = load_growth_metrics_module()
+
+    expected_prs = {
+        "run-llama/llama_index#21958",
+        "mudler/LocalAI#10090",
+        "ray-project/ray#64053",
+        "agno-agi/agno#8501",
+        "pipecat-ai/pipecat#4844",
+    }
+
+    assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))
+
+
 def test_collect_integration_metrics_marks_known_assisted_review_request(monkeypatch):
     module = load_growth_metrics_module()
 
@@ -728,6 +742,18 @@ def test_recommend_integration_action_treats_blocked_unknown_checks_as_review_ga
     )
 
     assert action == "review gate"
+
+
+def test_recommend_integration_action_waits_for_maintainer_after_assisted_blocked_review_gate():
+    module = load_growth_metrics_module()
+
+    action = module.recommend_integration_action(
+        {"state": "open", "draft": False, "mergeable_state": "blocked"},
+        {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
+        known_assisted_review_reason="review evidence already posted; avoid duplicate pings",
+    )
+
+    assert action == "wait for maintainer review"
 
 
 def test_recommend_integration_action_treats_clean_unknown_checks_as_request_review():
@@ -1221,4 +1247,5 @@ def test_main_outputs_integrations_json(monkeypatch):
     assert integration["repo_stars"] == 36_000
     assert integration["repo_forks"] == 6_800
     assert integration["checks"]["state"] == "success"
-    assert integration["next_action"] == "request review"
+    assert integration["next_action"] == "wait for maintainer review"
+    assert integration["known_assisted_review_reason"] == "review evidence already posted; avoid duplicate pings"


### PR DESCRIPTION
## Summary
- Mark high-exposure external PRs that already have FunASR-side validation as waiting for maintainer review instead of generic review gates.
- Extend the assisted-review action to blocked/unstable PRs when checks are not failing or pending.
- Keep untracked blocked PRs on the review-gate path so real unhandled gates still surface.

## Validation
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check HEAD^ HEAD
- python scripts/collect_growth_metrics.py --integrations --format json | jq -r '.integrations[] | select(.next_action=="review gate" or .next_action=="wait for maintainer review") | [.pr, .repo_stars, .checks.state, (.mergeable_state // .mergeable), .next_action, (.known_assisted_review_reason // "")] | @tsv'