### PR TITLE
Track LlamaIndex FunASR review wait

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -76,6 +76,9 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "run-llama/llama_index#21958": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
+    "run-llama/llama_index#21996": {
+        "reason": "FunASR dependency gate addressed; avoid duplicate pings",
+    },
     "mudler/LocalAI#10090": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -502,6 +502,7 @@ def test_known_assisted_review_requests_include_validated_review_gate_prs():
 
     expected_prs = {
         "run-llama/llama_index#21958",
+        "run-llama/llama_index#21996",
         "mudler/LocalAI#10090",
         "ray-project/ray#64053",
         "agno-agi/agno#8501",


### PR DESCRIPTION
## Summary
- Mark run-llama/llama_index#21996 as an assisted review wait after the FunASR dependency gate was addressed.
- Keep the integration tracker from repeatedly recommending duplicate review-gate follow-up for that high-exposure LlamaIndex PR.
- Add regression coverage so #21996 remains in the assisted-review set.

## Evidence
- run-llama/llama_index#21996 removed `funasr>=1.3.0` from the shared `llama-index-readers-file` dependencies while preserving the lazy import path.

## Validation
- python -m pytest tests/test_collect_growth_metrics.py::test_known_assisted_review_requests_include_validated_review_gate_prs -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs run-llama/llama_index#21996 --format json | jq -r '.integrations[0] | [.pr, .checks.state, (.mergeable_state // .mergeable), .next_action, .known_assisted_review_reason] | @tsv'