### PR TITLE
Track LiveKit FunASR review wait

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -73,6 +73,9 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "infiniflow/ragflow#16473": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
+    "livekit/agents#6176": {
+        "reason": "review feedback addressed and checks are green; avoid duplicate pings",
+    },
     "run-llama/llama_index#21958": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -501,6 +501,7 @@ def test_known_assisted_review_requests_include_validated_review_gate_prs():
     module = load_growth_metrics_module()
 
     expected_prs = {
+        "livekit/agents#6176",
         "run-llama/llama_index#21958",
         "run-llama/llama_index#21996",
         "mudler/LocalAI#10090",


### PR DESCRIPTION
## Summary
- Mark livekit/agents#6176 as an assisted review wait after review feedback was addressed and checks turned green.
- Prevent the growth tracker from repeatedly surfacing the LiveKit PR as an unresolved review gate.
- Extend the assisted-review regression coverage to include the LiveKit integration.

## Evidence
- livekit/agents#6176 head `348c46f` has ruff, unit-tests, type-check, blockguard, CLA, and Devin Review all green.

## Validation
- python -m pytest tests/test_collect_growth_metrics.py::test_known_assisted_review_requests_include_validated_review_gate_prs -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs livekit/agents#6176 run-llama/llama_index#21996 --format json | jq -r '.integrations[] | [.pr, .checks.state, (.mergeable_state // .mergeable), .next_action, .known_assisted_review_reason] | @tsv'