### PR TITLE
Track Vision-Agents FunASR review wait

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -106,6 +106,9 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "pipecat-ai/pipecat#4844": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
+    "GetStream/Vision-Agents#606": {
+        "reason": "review feedback addressed and checks are green; avoid duplicate pings",
+    },
 }
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -508,6 +508,7 @@ def test_known_assisted_review_requests_include_validated_review_gate_prs():
         "ray-project/ray#64053",
         "agno-agi/agno#8501",
         "pipecat-ai/pipecat#4844",
+        "GetStream/Vision-Agents#606",
     }
 
     assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))


### PR DESCRIPTION
## Summary
- mark GetStream/Vision-Agents#606 as an assisted review wait after resolved/outdated review threads and green checks
- extend the growth tracker regression list so this status does not regress

## Verification
- python -m pytest tests/test_collect_growth_metrics.py::test_known_assisted_review_requests_include_validated_review_gate_prs -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs GetStream/Vision-Agents#606 --format json | jq -r '.integrations[0] | [.pr,.state,.mergeable,.mergeable_state,.checks.state,.known_assisted_review_reason,.next_action] | @tsv'