### PR TITLE
Track audio integration review waits

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -109,6 +109,12 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "GetStream/Vision-Agents#606": {
         "reason": "review feedback addressed and checks are green; avoid duplicate pings",
     },
+    "Uberi/speech_recognition#903": {
+        "reason": "review evidence already posted; no repo checks exposed",
+    },
+    "huggingface/speech-to-speech#319": {
+        "reason": "ruff blocker fixed and validation posted; no repo checks exposed",
+    },
 }
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -509,6 +509,8 @@ def test_known_assisted_review_requests_include_validated_review_gate_prs():
         "agno-agi/agno#8501",
         "pipecat-ai/pipecat#4844",
         "GetStream/Vision-Agents#606",
+        "Uberi/speech_recognition#903",
+        "huggingface/speech-to-speech#319",
     }
 
     assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))


### PR DESCRIPTION
## Summary
- mark Uberi/speech_recognition#903 as waiting for maintainer review after validation evidence was posted and no repo checks are exposed
- mark huggingface/speech-to-speech#319 as waiting for maintainer review after the ruff blocker was fixed on the PR branch and validation was posted
- extend the growth tracker regression list for these assisted review waits

## Verification
- python -m pytest tests/test_collect_growth_metrics.py::test_known_assisted_review_requests_include_validated_review_gate_prs -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs Uberi/speech_recognition#903 huggingface/speech-to-speech#319 --format json | jq -r '.integrations[] | [.pr,.state,.mergeable,.mergeable_state,.checks.state,.known_assisted_review_reason,.next_action] | @tsv'