### PR TITLE
Track speaches FunASR review wait

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -115,6 +115,9 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "huggingface/speech-to-speech#319": {
         "reason": "ruff blocker fixed and validation posted; no repo checks exposed",
     },
+    "speaches-ai/speaches#658": {
+        "reason": "lightweight validation evidence posted; no repo checks exposed",
+    },
 }
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -511,6 +511,7 @@ def test_known_assisted_review_requests_include_validated_review_gate_prs():
         "GetStream/Vision-Agents#606",
         "Uberi/speech_recognition#903",
         "huggingface/speech-to-speech#319",
+        "speaches-ai/speaches#658",
     }
 
     assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))


### PR DESCRIPTION
## Summary
- mark speaches-ai/speaches#658 as waiting for maintainer review after lightweight validation evidence was posted
- extend the growth tracker regression list for this assisted review wait

## Verification
- python -m pytest tests/test_collect_growth_metrics.py::test_known_assisted_review_requests_include_validated_review_gate_prs -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py
- git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs speaches-ai/speaches#658 --format json | jq -r '.integrations[0] | [.pr,.state,.mergeable,.mergeable_state,.checks.state,.known_assisted_review_reason,.next_action] | @tsv'

External PR evidence:
- https://github.com/speaches-ai/speaches/pull/658#issuecomment-4842855907