### PR TITLE
Track TEN review bot permission gate

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -68,6 +68,10 @@ KNOWN_REVIEW_GATES = {
     "punkpeye/awesome-mcp-servers#7153": {
         "action": "submit Glama",
         "reason": "Glama listing and score badge required before review",
+    },
+    "TEN-framework/ten-framework#2191": {
+        "action": "wait for maintainer review",
+        "reason": "Claude review action requires maintainer permissions for fork PRs",
     }
 }
 KNOWN_ASSISTED_REVIEW_REQUESTS = {
@@ -313,6 +317,10 @@ def recommend_integration_action(
     ).lower()
     if "cla" in pending_names:
         return "resolve CLA"
+    if known_review_gate_action and (
+        "claude-review" in failed_names or "review bot" in failed_names
+    ):
+        return known_review_gate_action
     if "claude-review" in failed_names or "review bot" in failed_names:
         return "review bot gate"
     if "vercel" in failed_names and "vercel.com/git/authorize" in failed_urls:

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -689,7 +689,10 @@ def test_collect_integration_metrics_classifies_review_bot_failure(monkeypatch):
     metrics = module.collect_integration_metrics(["TEN-framework/ten-framework#2191"])
 
     integration = metrics["integrations"][0]
-    assert integration["next_action"] == "review bot gate"
+    assert integration["known_review_gate_reason"] == (
+        "Claude review action requires maintainer permissions for fork PRs"
+    )
+    assert integration["next_action"] == "wait for maintainer review"
     assert integration["checks"]["failed_check_runs"][0]["name"] == "claude-review"
 
 


### PR DESCRIPTION
## Summary
- mark TEN-framework/ten-framework#2191 as a known review gate caused by the Claude review action requiring maintainer permissions for fork PRs
- let known review-gate actions override the generic review-bot gate recommendation
- update the tracker regression test for this permission-gated external integration PR

## Verification
- python -m pytest tests/test_collect_growth_metrics.py::test_collect_integration_metrics_classifies_review_bot_failure -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py && git diff --check
- python scripts/collect_growth_metrics.py --integrations --integration-prs TEN-framework/ten-framework#2191 --format json | jq -r '.integrations[0] | [.pr,.checks.state,.known_review_gate_reason,.next_action] | @tsv'

External evidence:
- TEN-framework/ten-framework#2191 already has a comment with the failing action log excerpt showing only read permission for the fork PR actor.