### PR TITLE
Split manual Glama handoff from active queue

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -126,9 +126,13 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
 }
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}
+MANUAL_HANDOFF_ACTIONS = {
+    "submit Glama",
+}
 PASSIVE_INTEGRATION_ACTIONS = {
     "archive",
     "finish draft",
+    *MANUAL_HANDOFF_ACTIONS,
     "preview auth gate",
     "resolve CLA",
     "wait for checks",
@@ -654,6 +658,24 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
             lines.append(
                 f"- [{integration['pr']}]({integration.get('html_url')}): "
                 f"{integration.get('next_action') or 'inspect'}"
+            )
+    manual_handoff_integrations = sorted(
+        (
+            integration
+            for integration in metrics["integrations"]
+            if integration.get("state") == "open"
+            and (integration.get("next_action") or "inspect") in MANUAL_HANDOFF_ACTIONS
+        ),
+        key=lambda integration: int(integration.get("repo_stars") or 0),
+        reverse=True,
+    )
+    if manual_handoff_integrations:
+        lines.extend(["", "## Manual handoff gates", ""])
+        for integration in manual_handoff_integrations:
+            reason = integration.get("known_review_gate_reason") or "manual action required"
+            lines.append(
+                f"- [{integration['pr']}]({integration.get('html_url')}): "
+                f"{integration.get('next_action') or 'inspect'}; {reason}"
             )
     review_gate_integrations = [
         integration for integration in metrics["integrations"] if integration.get("known_review_gate_reason")

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -1070,6 +1070,51 @@ def test_format_integration_markdown_lists_active_operator_queue():
     assert "activepieces/activepieces#13985" not in active_queue
 
 
+def test_format_integration_markdown_lists_manual_handoff_gates():
+    module = load_growth_metrics_module()
+    metrics = {
+        "collected_at_utc": "2026-07-02T00:00:00+00:00",
+        "integrations": [
+            {
+                "pr": "punkpeye/awesome-mcp-servers#7153",
+                "html_url": "https://github.com/punkpeye/awesome-mcp-servers/pull/7153",
+                "state": "open",
+                "mergeable_state": "clean",
+                "repo_stars": 90_000,
+                "repo_forks": 12_000,
+                "updated_at": "2026-06-16T04:21:55Z",
+                "updated_age_days": 16,
+                "next_action": "submit Glama",
+                "known_review_gate_reason": "Glama listing and score badge required before review",
+                "checks": {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
+            },
+            {
+                "pr": "huggingface/optimum-intel#1801",
+                "html_url": "https://github.com/huggingface/optimum-intel/pull/1801",
+                "state": "open",
+                "mergeable_state": "unstable",
+                "repo_stars": 600,
+                "repo_forks": 240,
+                "updated_at": "2026-06-30T04:20:02Z",
+                "updated_age_days": 0,
+                "next_action": "review gate",
+                "checks": {"state": "unknown", "failed_check_runs": [], "pending_check_runs": []},
+            },
+        ],
+    }
+
+    output = module.format_integration_markdown(metrics)
+
+    active_queue = output.split("## Active operator queue", 1)[1].split("## Manual handoff gates", 1)[0]
+    manual_gates = output.split("## Manual handoff gates", 1)[1].split("## Manual review gates", 1)[0]
+    assert "punkpeye/awesome-mcp-servers#7153" not in active_queue
+    assert (
+        "- [punkpeye/awesome-mcp-servers#7153](https://github.com/punkpeye/awesome-mcp-servers/pull/7153): "
+        "submit Glama; Glama listing and score badge required before review"
+    ) in manual_gates
+    assert "huggingface/optimum-intel#1801" not in manual_gates
+
+
 def test_format_integration_markdown_lists_known_review_gates():
     module = load_growth_metrics_module()
     metrics = {


### PR DESCRIPTION
## Summary
- move manual Glama submission out of the Active operator queue
- add a Manual handoff gates section for account/site tasks such as the Glama listing and score badge requirement
- keep the active queue focused on PRs the maintainer/operator can actually inspect, fix, or validate from GitHub

## Verification
- python -m pytest tests/test_collect_growth_metrics.py::test_format_integration_markdown_lists_manual_handoff_gates tests/test_collect_growth_metrics.py::test_format_integration_markdown_lists_active_operator_queue -q
- python -m pytest tests/test_collect_growth_metrics.py -q
- python -m py_compile scripts/collect_growth_metrics.py && git diff --check
- GITHUB_TOKEN="$GITHUB_TOKEN" python scripts/collect_growth_metrics.py --integrations --format markdown | sed -n '/## Active operator queue/,/## Manual review gates/p'

Evidence checked:
- punkpeye/awesome-mcp-servers#7153 maintainer comments require submitting the server at Glama and adding a score badge after evaluation
- https://glama.ai/mcp/servers/modelscope/FunASR currently redirects without a listed server page