### PR TITLE
fix(tokenizer): treat special-token strings as text to prevent batch crashes (#3110)

### DIFF
--- a/funasr/models/sense_voice/whisper_lib/tokenizer.py
+++ b/funasr/models/sense_voice/whisper_lib/tokenizer.py
@@ -194,11 +194,24 @@ class Tokenizer:
 
     def encode(self, text, **kwargs):
         """Encode.
-        
+
             Args:
                 text: Text tensor or string input.
                 **kwargs: Additional keyword arguments.
-            """
+
+        ``tiktoken`` rejects any text containing a special-token string
+        (e.g. ``<|no|>``, ``<|zh|>``, ``<|nospeech|>``) by default
+        (``disallowed_special="all"``). ASR models such as Fun-ASR-Nano
+        occasionally emit such special-token strings as part of their
+        transcription text; re-encoding that text for downstream tasks
+        (forced alignment, loss computation, ...) then crashes the whole
+        batch with a single bad sample (see issue #3110).
+
+        Treat special-token strings as ordinary text unless the caller
+        explicitly opts into a stricter policy. Callers that already pass
+        ``allowed_special`` / ``disallowed_special`` are left untouched.
+        """
+        kwargs.setdefault("disallowed_special", ())
         return self.encoding.encode(text, **kwargs)
 
     def decode(self, token_ids: List[int], **kwargs) -> str:

--- a/tests/test_sensevoice_tokenizer_special_tokens.py
+++ b/tests/test_sensevoice_tokenizer_special_tokens.py
@@ -1,0 +1,110 @@
+"""Unit tests for SenseVoice Tokenizer handling of special-token strings.
+
+Regression guard for issue #3110: ASR models such as Fun-ASR-Nano occasionally
+emit special-token strings (e.g. ``<|no|>``, a language tag) as part of the
+transcription text. Re-encoding that text via ``tiktoken.Encoding.encode``
+crashes by default (``disallowed_special="all"``), which takes down the whole
+batch on a single bad sample during forced alignment / loss computation.
+``Tokenizer.encode`` now treats special-token strings as ordinary text unless
+the caller explicitly opts into a stricter policy.
+
+These tests build a minimal in-memory tiktoken encoding, so they run without
+the Fun-ASR-Nano ``multilingual.tiktoken`` vocab (which ships with the model,
+not this repo) and without a GPU or model download.
+"""
+
+import unittest
+
+import tiktoken
+
+from funasr.models.sense_voice.whisper_lib.tokenizer import Tokenizer
+
+
+def _build_test_encoding() -> tiktoken.Encoding:
+    """A minimal byte-level BPE encoding with the specials Tokenizer needs.
+
+    Every single byte is its own token, so arbitrary text can be encoded
+    without the model's multilingual.tiktoken vocab file.
+    """
+    mergeable_ranks = {bytes([b]): b for b in range(256)}
+    n_vocab = len(mergeable_ranks)
+
+    # Specials required by Tokenizer.__post_init__ (startoftranscript/translate/
+    # transcribe) plus a few language tags. "<|no|>" is the Norwegian tag that
+    # triggered #3110.
+    required_specials = [
+        "<|startoftranscript|>",
+        "<|no|>",
+        "<|zh|>",
+        "<|en|>",
+        "<|translate|>",
+        "<|transcribe|>",
+        "<|startoflm|>",
+        "<|startofprev|>",
+        "<|nospeech|>",
+        "<|notimestamps|>",
+        "<|0.00|>",
+    ]
+    special_tokens = {}
+    for tok in required_specials:
+        special_tokens[tok] = n_vocab
+        n_vocab += 1
+
+    return tiktoken.Encoding(
+        name="test-encoding",
+        pat_str=(
+            r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| """
+            r"""?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"""
+        ),
+        mergeable_ranks=mergeable_ranks,
+        special_tokens=special_tokens,
+    )
+
+
+def _build_test_tokenizer() -> Tokenizer:
+    return Tokenizer(encoding=_build_test_encoding(), num_languages=1)
+
+
+class TestTokenizerEncodeSpecialTokens(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer = _build_test_tokenizer()
+        self.no_id = self.tokenizer.special_tokens["<|no|>"]
+
+    def test_plain_text_encodes(self):
+        ids = self.tokenizer.encode("hello world")
+        self.assertIsInstance(ids, list)
+        self.assertTrue(ids)
+
+    def test_language_tag_in_text_does_not_raise(self):
+        # The exact failure from issue #3110: ASR output containing "<|no|>"
+        # used to crash with "disallowed special token '<|no|>'".
+        ids = self.tokenizer.encode("hello <|no|> world")
+        self.assertIsInstance(ids, list)
+        self.assertTrue(ids)
+
+    def test_nospeech_tag_in_text_does_not_raise(self):
+        ids = self.tokenizer.encode("<|nospeech|> something")
+        self.assertIsInstance(ids, list)
+        self.assertTrue(ids)
+
+    def test_language_tag_alone_does_not_raise(self):
+        ids = self.tokenizer.encode("<|no|>")
+        self.assertIsInstance(ids, list)
+        self.assertTrue(ids)
+
+    def test_caller_disallowed_special_is_respected(self):
+        # A caller that explicitly wants the strict behaviour must still get
+        # it (setdefault must not override an explicit kwargs).
+        with self.assertRaises(ValueError):
+            self.tokenizer.encode("<|no|>", disallowed_special="all")
+
+    def test_allowed_special_all_keeps_special_token_ids(self):
+        # funasr/models/sense_voice/whisper_lib/decoding.py calls
+        # tokenizer.encode(prompt, allowed_special="all"); the special token
+        # must still be encoded as its token id, not as raw bytes.
+        ids = self.tokenizer.encode("<|no|>", allowed_special="all")
+        self.assertEqual(ids, [self.no_id])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When transcribing long audio in a batch with `FunAudioLLM/Fun-ASR-Nano-2512` (+ `vad_model=fsmn-vad`, `spk_model=campplus`), a single sample can crash with `Encountered text corresponding to disallowed special token '<|no|>'.` and abort the entire batch, even though every other sample transcribes fine (stable RTF). Closes #3110.

**Root cause.** The model occasionally emits a special-token string (e.g. `<|no|>`, the Norwegian language tag) as part of its transcription text. That text is then re-encoded for forced alignment / loss computation:

```python
# funasr/models/fun_asr_nano/model.py:928
target_ids = torch.tensor(self.ctc_tokenizer.encode(result["text"]), dtype=torch.int64)
```

`self.ctc_tokenizer` resolves to `SenseVoiceTokenizer` (`funasr/tokenizer/whisper_tokenizer.py:30`) → `funasr/models/sense_voice/whisper_lib/tokenizer.py::Tokenizer`, whose `encode` forwards straight to `tiktoken.Encoding.encode`:

```python
def encode(self, text, **kwargs):
    return self.encoding.encode(text, **kwargs)
```

tiktoken defaults to `disallowed_special="all"`, so any text containing a special-token string raises `ValueError`, taking down the whole batch. `model.py:921` already strips `<|nospeech|>` from the CTC text — which confirms ASR output can leak special-token strings — but the allow-list isn't exhaustive (language tags like `<|no|>` slip through).

**Fix.** Default `disallowed_special=()` in `Tokenizer.encode` so special-token strings are treated as ordinary text unless a caller explicitly opts into stricter behaviour:

```python
def encode(self, text, **kwargs):
    kwargs.setdefault("disallowed_special", ())
    return self.encoding.encode(text, **kwargs)
```

## Type of change

- [x] Bug fix
- [ ] Documentation
- [ ] Example or demo
- [ ] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

- [x] `python -m compileall funasr examples tests`
- [x] Docs or links checked
- [ ] Runtime/deployment command tested

`python -m compileall -q funasr examples tests` exits 0 (only two pre-existing `SyntaxWarning`s in `examples/industrial_data_pretraining/fun_asr_nano/tools/format5res.py`, untouched by this PR).

Adds `tests/test_sensevoice_tokenizer_special_tokens.py`. It builds a minimal in-memory `tiktoken.Encoding` (byte-level BPE + the specials `Tokenizer.__post_init__` needs), so it runs without the `multilingual.tiktoken` vocab (ships with the model, not this repo), without a GPU and without a model download:

- plain text encodes
- text containing `<|no|>` / `<|nospeech|>` no longer raises (regression for #3110)
- explicit `disallowed_special="all"` still raises (back-compat)
- `allowed_special="all"` still returns the special-token id (back-compat for `decoding.py`)

Local exercise of the fix against the minimal encoding (`importlib`-loaded `tokenizer.py` to bypass the heavy `funasr` package import chain on a machine without `torch`/`kaldiio`):

```
1. raw tiktoken encode("<|no|>")                        -> raises (reproduces #3110)
2. Tokenizer.encode("hello <|no|> world")               -> OK, 18 ids (fixed)
3. Tokenizer.encode("<|no|>", disallowed_special="all") -> still raises (back-compat)
4. Tokenizer.encode("<|no|>", allowed_special="all")   -> [257] == <|no|> id (back-compat)
```

## User impact

Production deployers running Fun-ASR-Nano (and any model reusing the SenseVoice `Tokenizer`) on batch / streaming ASR pipelines. Today a single bad sample aborts the whole batch; after this PR that sample is transcribed with the stray token treated as text and the batch completes. Researchers using `ctc_tokenizer.encode` for forced alignment / loss hit the same crash.

## Notes for reviewers

**Why the tokenizer, not the call sites.** There are multiple call sites that re-encode ASR output — `fun_asr_nano/model.py:443, 495, 923, 928`, `inference_vllm.py:668`, `inference_vllm_pipeline.py:348`. Patching the tokenizer covers all of them in one place, and also protects SenseVoice and any future model that reuses this `Tokenizer`.

**Backward compatibility.** `setdefault` keeps the change fully backward compatible:

- Callers that pass `disallowed_special=...` are untouched.
- `decoding.py`'s `tokenizer.encode(prompt, allowed_special="all")` still encodes special tokens as their token ids (verified in case 4 above).
- The internal `non_speech_tokens` cached_property calls `self.encoding.encode(...)` directly (not `self.encode`), so it's unaffected.

**Scope.** One-line behavioural default in `Tokenizer.encode` + regression tests. No model weights, no config, no public API change.
