### PR TITLE
Fix Fun-ASR-Nano stereo audio preprocessing

### DIFF
--- a/examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py
+++ b/examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py
@@ -67,6 +67,21 @@ _spk_model = None
 _args = None
 
 
+def prepare_audio_for_inference(audio_data, sr, target_sr=16000):
+    """Return mono float32 audio at target_sr for ASR inference."""
+    audio_data = np.asarray(audio_data)
+    if audio_data.ndim > 1:
+        channel_axis = -1 if audio_data.shape[-1] <= audio_data.shape[0] else 0
+        audio_data = audio_data.mean(axis=channel_axis)
+
+    if sr != target_sr:
+        import librosa
+        audio_data = librosa.resample(audio_data, orig_sr=sr, target_sr=target_sr)
+        sr = target_sr
+
+    return audio_data.astype(np.float32), sr
+
+
 def load_engine(args):
     global _engine, _vad_model, _spk_model, _args
     _args = args
@@ -90,14 +105,7 @@ def load_engine(args):
 def process_audio(audio_data, sr=16000, language=None, hotwords=None, 
                   use_vad=True, use_spk=False, use_timestamp=True):
     """Core processing: VAD segment → vLLM ASR → timestamps → SPK."""
-    if sr != 16000:
-        import librosa
-        audio_data = librosa.resample(audio_data, orig_sr=sr, target_sr=16000)
-        sr = 16000
-
-    if audio_data.ndim > 1:
-        audio_data = audio_data[:, 0]
-    audio_data = audio_data.astype(np.float32)
+    audio_data, sr = prepare_audio_for_inference(audio_data, sr)
 
     # VAD segmentation
     if use_vad and len(audio_data) > sr * 1:

--- a/funasr/bin/_server_app.py
+++ b/funasr/bin/_server_app.py
@@ -26,6 +26,20 @@ except ImportError:
 logger = logging.getLogger("funasr.server")
 
 
+def prepare_audio_for_inference(audio_data, sr, target_sr=16000):
+    """Return mono float32 audio at target_sr for ASR inference."""
+    audio_data = np.asarray(audio_data)
+    if audio_data.ndim > 1:
+        channel_axis = -1 if audio_data.shape[-1] <= audio_data.shape[0] else 0
+        audio_data = audio_data.mean(axis=channel_axis)
+
+    if sr != target_sr:
+        import librosa
+        audio_data = librosa.resample(audio_data, orig_sr=sr, target_sr=target_sr)
+        sr = target_sr
+
+    return audio_data.astype(np.float32), sr
+
 def create_app(device: str = "cuda", preload_model: str = "auto") -> FastAPI:
     if preload_model == "auto":
         preload_model = "fun-asr-nano" if device.startswith("cuda") else "sensevoice"
@@ -107,13 +121,7 @@ def create_app(device: str = "cuda", preload_model: str = "auto") -> FastAPI:
 
     def _process_vllm(audio_data, sr, language=None, hotwords=None, use_spk=False):
         """Process audio with vLLM engine (Fun-ASR-Nano)."""
-        if sr != 16000:
-            import librosa
-            audio_data = librosa.resample(audio_data, orig_sr=sr, target_sr=16000)
-            sr = 16000
-        if audio_data.ndim > 1:
-            audio_data = audio_data[:, 0]
-        audio_data = audio_data.astype(np.float32)
+        audio_data, sr = prepare_audio_for_inference(audio_data, sr)
 
         # VAD
         vad_res = app.state.vad_model.generate(input=audio_data, fs=sr)

--- a/tests/test_fun_asr_nano_openai_response.py
+++ b/tests/test_fun_asr_nano_openai_response.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+import numpy as np
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SERVICE_PATH = (
@@ -108,3 +110,44 @@ def test_openai_verbose_json_keeps_segment_speaker(monkeypatch):
     )
 
     assert response["segments"][0]["speaker"] == "SPK0"
+
+
+def test_process_audio_downmixes_stereo_before_resampling(monkeypatch):
+    module = load_service_module(monkeypatch)
+    captured = {}
+
+    librosa_stub = types.ModuleType("librosa")
+
+    def fake_resample(audio, orig_sr, target_sr):
+        assert audio.ndim == 1
+        captured["resample_input"] = audio.copy()
+        assert orig_sr == 8000
+        assert target_sr == 16000
+        return np.repeat(audio, 2)
+
+    librosa_stub.resample = fake_resample
+    monkeypatch.setitem(sys.modules, "librosa", librosa_stub)
+
+    class EngineStub:
+        def generate(self, inputs, **kwargs):
+            captured["engine_input"] = inputs[0]
+            return [{"text": "ok"}]
+
+    module._engine = EngineStub()
+    stereo_audio = np.column_stack(
+        [np.zeros(8000, dtype=np.float32), np.ones(8000, dtype=np.float32)]
+    )
+
+    result = module.process_audio(
+        stereo_audio,
+        sr=8000,
+        use_vad=False,
+        use_spk=False,
+        use_timestamp=False,
+    )
+
+    assert np.allclose(captured["resample_input"], 0.5)
+    assert captured["engine_input"].shape == (16000,)
+    assert np.allclose(captured["engine_input"], 0.5)
+    assert result["duration"] == 1.0
+    assert result["text"] == "ok"


### PR DESCRIPTION
## Summary

Fixes #3102.

The Fun-ASR-Nano vLLM server handled stereo audio in the wrong order: it resampled before reducing channels. `soundfile.read()` returns stereo input as `(samples, channels)`, and `librosa.resample()` defaults to the last axis, so 8kHz stereo audio could be resampled along the channel axis and then truncated to the first channel. This produced incorrect duration and could drop content.

This PR now prepares audio by:

1. converting multi-channel input to mono by averaging channels
2. resampling mono audio to 16kHz
3. casting to `float32`

The same preprocessing is used by both the example vLLM server and packaged `funasr-server` vLLM path.

## Testing

```bash
python -m pytest tests/test_fun_asr_nano_openai_response.py -q
python -m pytest tests/test_fun_asr_nano_openai_response.py tests/test_fun_asr_nano_repetition_penalty.py tests/test_realtime_ws_service.py -q
python -m py_compile examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py funasr/bin/_server_app.py tests/test_fun_asr_nano_openai_response.py
git diff --check
```
