### PR TITLE
docs: add community projects showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ llama-funasr-sensevoice -m ./gguf/SenseVoiceSmall-f16.gguf --vad ./gguf/fsmn-vad
 | 📖 [Documentation](https://modelscope.github.io/FunASR/) | 🐛 [Issues](https://github.com/modelscope/FunASR/issues) |
 | 💬 [Discussions](https://github.com/modelscope/FunASR/discussions) | 🤗 [HuggingFace](https://huggingface.co/funasr) |
 | 🤝 [Contributing](./CONTRIBUTING.md) | 🌐 [funasr.com](https://www.funasr.com) |
+| 🧩 [Community projects](./docs/community_projects.md) | 💡 [Use-case showcase](./docs/use_case_showcase.md) |
 
 ## Star History
 

--- a/docs/community_projects.md
+++ b/docs/community_projects.md
@@ -1,0 +1,40 @@
+# FunASR Community Projects
+
+This page collects maintained community integrations and experiments around FunASR models. These projects are useful for users exploring deployment paths beyond the official Python runtime, but they are not official FunASR implementations unless explicitly noted.
+
+## VAD runtimes
+
+| Project | What it provides | Notes |
+|---|---|---|
+| [vad-burn](https://github.com/di-osc/vad-burn) | FSMN VAD inference in pure Rust with Python bindings. It supports offline VAD, streaming VAD, CPU-only inference, and automatic download of the default `iic/speech_fsmn_vad_zh-cn-16k-common-pytorch` model from ModelScope. | Community project from [#3106](https://github.com/modelscope/FunASR/issues/3106). Useful for Rust services, CLI tools, desktop apps, or Python pipelines that need FSMN VAD without depending on the original Python runtime. |
+
+`vad-burn` reports the following benchmark on `assets/vad_example.wav` (16 kHz mono PCM, 70.47 seconds) on a MacBook Pro M1 with the Burn Flex CPU backend:
+
+| Mode | Avg time | RTF | Speedup |
+|---|---:|---:|---:|
+| FSMN VAD offline | 73.631 ms | 0.001045 | 957.08x |
+| FSMN VAD streaming, 600 ms chunks | 198.425 ms | 0.002816 | 355.15x |
+
+Minimal Python usage from the project:
+
+```python
+from vad_burn import FsmnVadModel, VadOptions
+
+vad = FsmnVadModel.from_modelscope()
+segments = vad.detect(samples, 16000, VadOptions())
+
+stream = vad.new_stream(VadOptions())
+for chunk in chunks:
+    segments = stream.push(chunk, 16000)
+final_segments = stream.finish()
+```
+
+## Add your project
+
+If you maintain a FunASR integration, open a [showcase issue](https://github.com/modelscope/FunASR/issues/new?template=showcase.md) with:
+
+- repository link and maintenance status
+- supported FunASR model or runtime path
+- install and minimal usage instructions
+- benchmark or validation details when available
+- a note about whether the project is official, community-maintained, or experimental

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,6 +113,7 @@ Overview
    ./cli.md
    ./use_case_showcase.md
    ./use_case_showcase_zh.md
+   ./community_projects.md
    ./reference/application.md
 
 .. toctree::


### PR DESCRIPTION
## Summary

Add a small community projects page and link it from the README Community section.

The first entry is `di-osc/vad-burn`, shared in #3106: a community FSMN VAD runtime implemented in Rust with Python bindings.

## Why

Community runtimes make it easier for users to embed FunASR models outside the official Python path. This gives maintained third-party projects a visible but clearly scoped place in the docs.

## Notes

The page explicitly says these projects are community integrations, not official FunASR implementations unless noted.

## Validation

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
readme = Path('README.md').read_text()
idx = Path('docs/index.rst').read_text()
community = Path('docs/community_projects.md').read_text()
assert './docs/community_projects.md' in readme
assert './community_projects.md' in idx
assert 'vad-burn' in community
assert 'not official FunASR implementations' in community
assert Path('docs/use_case_showcase.md').exists()
print('docs checks passed')
PY
```
