### PR TITLE
docs: update remaining FunASR repository links

### DIFF
--- a/runtime/html5/readme.md
+++ b/runtime/html5/readme.md
@@ -43,7 +43,7 @@ cd funasr/runtime/python/websocket
 python funasr_wss_server.py --port 10095
 ```
 
-For detailed parameter configuration and analysis, please click [here](https://github.com/alibaba-damo-academy/FunASR/tree/main/runtime/python/websocket).
+For detailed parameter configuration and analysis, please click [here](https://github.com/modelscope/FunASR/tree/main/runtime/python/websocket).
 
 #### Html5 Service (Optional)
 
@@ -69,13 +69,13 @@ Since there are many dependencies for C++, it is recommended to deploy it using 
 curl -O https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/shell/funasr-runtime-deploy-offline-cpu-zh.sh;
 sudo bash funasr-runtime-deploy-offline-cpu-zh.sh install --workspace /root/funasr-runtime-resources
 ```
-For detailed parameter configuration and analysis, please click [here](https://github.com/alibaba-damo-academy/FunASR/blob/main/runtime/docs/SDK_tutorial_zh.md).
+For detailed parameter configuration and analysis, please click [here](https://github.com/modelscope/FunASR/blob/main/runtime/docs/SDK_tutorial_zh.md).
 
 ## Client Testing
 
 ### Method 1
 
-Directly connect to the html client, manually download the client ([click here](https://github.com/alibaba-damo-academy/FunASR/tree/main/runtime/html5/static)) to the local computer, and open the index.html webpage, enter the wss address and port number to use.
+Directly connect to the html client, manually download the client ([click here](https://github.com/modelscope/FunASR/tree/main/runtime/html5/static)) to the local computer, and open the index.html webpage, enter the wss address and port number to use.
 
 ### Method 2
 
@@ -89,5 +89,5 @@ Enter the wss address and port number to use.
 
 
 ## Acknowledge
-1. This project is maintained by [FunASR community](https://github.com/alibaba-damo-academy/FunASR).
+1. This project is maintained by [FunASR community](https://github.com/modelscope/FunASR).
 2. We acknowledge [AiHealthx](http://www.aihealthx.com/) for contributing the html5 demo.

--- a/runtime/html5/readme_zh.md
+++ b/runtime/html5/readme_zh.md
@@ -67,14 +67,14 @@ python h5Server.py --host 0.0.0.0 --port 1337
 curl -O https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/shell/funasr-runtime-deploy-offline-cpu-zh.sh;
 sudo bash funasr-runtime-deploy-offline-cpu-zh.sh install --workspace /root/funasr-runtime-resources
 ```
-详细参数配置与解析（[点击此处](https://github.com/alibaba-damo-academy/FunASR/blob/main/runtime/docs/SDK_tutorial_zh.md)）
+详细参数配置与解析（[点击此处](https://github.com/modelscope/FunASR/blob/main/runtime/docs/SDK_tutorial_zh.md)）
 
 
 ## 客户端测试
 
 ### 方式一
 
-html客户端直连，手动下载客户端（[点击此处](https://github.com/alibaba-damo-academy/FunASR/tree/main/runtime/html5/static)）至本地，打开`index.html`网页，输入wss地址与端口号即可使用
+html客户端直连，手动下载客户端（[点击此处](https://github.com/modelscope/FunASR/tree/main/runtime/html5/static)）至本地，打开`index.html`网页，输入wss地址与端口号即可使用
 
 ### 方式二
 
@@ -89,5 +89,5 @@ https://127.0.0.1:1337/static/index.html
 
 
 ## Acknowledge
-1. This project is maintained by [FunASR community](https://github.com/alibaba-damo-academy/FunASR).
+1. This project is maintained by [FunASR community](https://github.com/modelscope/FunASR).
 2. We acknowledge [AiHealthx](http://www.aihealthx.com/) for contributing the html5 demo.

--- a/runtime/html5/static/index.html
+++ b/runtime/html5/static/index.html
@@ -14,7 +14,7 @@
 		 
 
         <h1>FunASR Demo</h1>
-						<h3>这里是FunASR开源项目体验demo，集成了VAD、ASR与标点等工业级别的模型，支持长音频离线文件转写，实时语音识别等，开源项目地址：https://github.com/alibaba-damo-academy/FunASR</h3>
+						<h3>这里是FunASR开源项目体验demo，集成了VAD、ASR与标点等工业级别的模型，支持长音频离线文件转写，实时语音识别等，开源项目地址：https://github.com/modelscope/FunASR</h3>
 
 		<div class="div_class_topArea">
 

--- a/runtime/http/readme.md
+++ b/runtime/http/readme.md
@@ -32,7 +32,7 @@ apt-get install libssl-dev #ubuntu
 
 ### Build runtime
 ```shell
-git clone https://github.com/alibaba-damo-academy/FunASR.git && cd FunASR/runtime/http
+git clone https://github.com/modelscope/FunASR.git && cd FunASR/runtime/http
 mkdir build && cd build
 cmake  -DCMAKE_BUILD_TYPE=release .. -DONNXRUNTIME_DIR=/path/to/onnxruntime-linux-x64-1.14.0 -DFFMPEG_DIR=/path/to/ffmpeg-master-latest-linux64-gpl-shared
 make -j 4

--- a/runtime/http/readme_zh.md
+++ b/runtime/http/readme_zh.md
@@ -32,7 +32,7 @@ apt-get install libssl-dev #ubuntu
 ### 编译 runtime
 
 ```shell
-git clone https://github.com/alibaba-damo-academy/FunASR.git && cd FunASR/runtime/http
+git clone https://github.com/modelscope/FunASR.git && cd FunASR/runtime/http
 mkdir build && cd build
 cmake  -DCMAKE_BUILD_TYPE=release .. -DONNXRUNTIME_DIR=/path/to/onnxruntime-linux-x64-1.14.0 -DFFMPEG_DIR=/path/to/ffmpeg-master-latest-linux64-gpl-shared
 make -j 4

--- a/runtime/java/readme.md
+++ b/runtime/java/readme.md
@@ -60,7 +60,7 @@ result json, example like:
 
 
 ## Acknowledge
-1. This project is maintained by [FunASR community](https://github.com/alibaba-damo-academy/FunASR).
+1. This project is maintained by [FunASR community](https://github.com/modelscope/FunASR).
 2. We acknowledge [zhaoming](https://github.com/zhaomingwork/FunASR/tree/java-ws-client-support/funasr/runtime/java) for contributing the java websocket client example.
 
 

--- a/runtime/onnxruntime/readme.md
+++ b/runtime/onnxruntime/readme.md
@@ -1,4 +1,4 @@
-# Please ref to [websocket service](https://github.com/alibaba-damo-academy/FunASR/tree/main/runtime/websocket)
+# Please ref to [websocket service](https://github.com/modelscope/FunASR/tree/main/runtime/websocket)
 
 # If you want to compile the file yourself, you can follow the steps below.
 ## Building for Linux/Unix
@@ -27,7 +27,7 @@ apt-get install libssl-dev #ubuntu
 
 ### Build runtime
 ```shell
-git clone https://github.com/alibaba-damo-academy/FunASR.git && cd FunASR/runtime/onnxruntime
+git clone https://github.com/modelscope/FunASR.git && cd FunASR/runtime/onnxruntime
 mkdir build && cd build
 cmake  -DCMAKE_BUILD_TYPE=release .. -DONNXRUNTIME_DIR=/path/to/onnxruntime-linux-x64-1.14.0 -DFFMPEG_DIR=/path/to/ffmpeg-master-latest-linux64-gpl-shared
 make -j 4
@@ -47,7 +47,7 @@ Download and unzip to d:/ffmpeg-master-latest-win64-gpl-shared
 
 ### Build runtime
 ```
-git clone https://github.com/alibaba-damo-academy/FunASR.git
+git clone https://github.com/modelscope/FunASR.git
 cd FunASR/runtime/onnxruntime
 mkdir build
 cd build

--- a/runtime/websocket/readme.md
+++ b/runtime/websocket/readme.md
@@ -29,7 +29,7 @@ apt-get install libssl-dev #ubuntu
 
 ### Build runtime
 ```shell
-git clone https://github.com/alibaba-damo-academy/FunASR.git && cd FunASR/runtime/websocket
+git clone https://github.com/modelscope/FunASR.git && cd FunASR/runtime/websocket
 mkdir build && cd build
 cmake  -DCMAKE_BUILD_TYPE=release .. -DONNXRUNTIME_DIR=/path/to/onnxruntime-linux-x64-1.14.0 -DFFMPEG_DIR=/path/to/ffmpeg-master-latest-linux64-gpl-shared
 make -j 4
@@ -54,7 +54,7 @@ Download to d:\openssl-1.1.1w
 
 ### Build runtime
 ```
-git clone https://github.com/alibaba-damo-academy/FunASR.git 
+git clone https://github.com/modelscope/FunASR.git
 cd FunASR/runtime/websocket
 mkdir build
 cd build

--- a/runtime/websocket/readme_zh.md
+++ b/runtime/websocket/readme_zh.md
@@ -30,7 +30,7 @@ apt-get install libssl-dev #ubuntu
 ### 编译 runtime
 
 ```shell
-git clone https://github.com/alibaba-damo-academy/FunASR.git && cd FunASR/runtime/websocket
+git clone https://github.com/modelscope/FunASR.git && cd FunASR/runtime/websocket
 mkdir build && cd build
 cmake  -DCMAKE_BUILD_TYPE=release .. -DONNXRUNTIME_DIR=/path/to/onnxruntime-linux-x64-1.14.0 -DFFMPEG_DIR=/path/to/ffmpeg-master-latest-linux64-gpl-shared
 make -j 4
@@ -55,7 +55,7 @@ https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/dep_libs/openssl-1.1.
 
 ### 编译 runtime
 ```
-git clone https://github.com/alibaba-damo-academy/FunASR.git 
+git clone https://github.com/modelscope/FunASR.git
 cd FunASR/runtime/websocket
 mkdir build
 cd build

--- a/web-pages/public/static/offline/index.html
+++ b/web-pages/public/static/offline/index.html
@@ -14,7 +14,7 @@
 		 
 
         <h1>FunASR Demo</h1>
-						<h3>这里是FunASR开源项目体验demo，集成了VAD、ASR与标点等工业级别的模型，支持长音频离线文件转写，实时语音识别等，开源项目地址：https://github.com/alibaba-damo-academy/FunASR</h3>
+						<h3>这里是FunASR开源项目体验demo，集成了VAD、ASR与标点等工业级别的模型，支持长音频离线文件转写，实时语音识别等，开源项目地址：https://github.com/modelscope/FunASR</h3>
 
 		<div class="div_class_topArea">
 

--- a/web-pages/public/static/online/index.html
+++ b/web-pages/public/static/online/index.html
@@ -14,7 +14,7 @@
 		 
 
         <h1>FunASR Demo</h1>
-						<h3>这里是FunASR开源项目体验demo，集成了VAD、ASR与标点等工业级别的模型，支持长音频离线文件转写，实时语音识别等，开源项目地址：https://github.com/alibaba-damo-academy/FunASR</h3>
+						<h3>这里是FunASR开源项目体验demo，集成了VAD、ASR与标点等工业级别的模型，支持长音频离线文件转写，实时语音识别等，开源项目地址：https://github.com/modelscope/FunASR</h3>
 
 		<div class="div_class_topArea">
 


### PR DESCRIPTION
## Summary
- update the remaining CRLF Markdown/HTML docs from `alibaba-damo-academy/FunASR` to `modelscope/FunASR`
- cover runtime websocket/html5/http/java/onnxruntime docs plus static web demo pages
- preserve CRLF line endings while touching only the repository URL lines

## Validation
- all changed files kept the same CRLF/LF/CR line-ending counts before and after the URL replacement
- `git -c core.whitespace=blank-at-eof,space-before-tab,cr-at-eol diff --check`
- tracked Markdown/HTML scan confirms no remaining `https://github.com/alibaba-damo-academy/FunASR` links
- changed-line audit confirms the diff is limited to old/new FunASR GitHub URL lines
