### PR TITLE
Track high-star discovery PRs

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
 DEFAULT_REPO = "modelscope/FunASR"
@@ -55,6 +56,22 @@ DEFAULT_INTEGRATION_PRS = [
     "tensorchord/Awesome-LLMOps#533",
     "rafska/awesome-local-llm#118",
     "mahseema/awesome-ai-tools#1689",
+    "vinta/awesome-python#3246",
+    "fighting41love/funNLP#478",
+    "josephmisiti/awesome-machine-learning#1339",
+    "RVC-Boss/GPT-SoVITS#2801",
+    "jobbole/awesome-python-cn#141",
+    "ChristosChristofidis/awesome-deep-learning#317",
+    "Hannibal046/Awesome-LLM#623",
+    "AiHubCN/Awesome-Chinese-LLM#103",
+    "pluja/awesome-privacy#836",
+    "BradyFU/Awesome-Multimodal-Large-Language-Models#280",
+    "mahmoud/awesome-python-applications#227",
+    "bharathgs/Awesome-pytorch-list#164",
+    "owainlewis/awesome-artificial-intelligence#243",
+    "steven2358/awesome-generative-ai#821",
+    "WangRongsheng/awesome-LLM-resources#162",
+    "crownpku/Awesome-Chinese-NLP#32",
 ]
 FAILED_CHECK_CONCLUSIONS = {"action_required", "cancelled", "failure", "startup_failure", "timed_out"}
 AGGREGATE_FAILURE_CHECK_NAMES = {"pr-ci / PR CI status"}
@@ -163,6 +180,54 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "speaches-ai/speaches#658": {
         "reason": "lightweight validation evidence posted; no repo checks exposed",
     },
+    "vinta/awesome-python#3246": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "fighting41love/funNLP#478": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "josephmisiti/awesome-machine-learning#1339": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "RVC-Boss/GPT-SoVITS#2801": {
+        "reason": "Fun-ASR-Nano compatibility fix already opened with reproduction context; avoid duplicate pings",
+    },
+    "jobbole/awesome-python-cn#141": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "ChristosChristofidis/awesome-deep-learning#317": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "Hannibal046/Awesome-LLM#623": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "AiHubCN/Awesome-Chinese-LLM#103": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "pluja/awesome-privacy#836": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "BradyFU/Awesome-Multimodal-Large-Language-Models#280": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "mahmoud/awesome-python-applications#227": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "bharathgs/Awesome-pytorch-list#164": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "owainlewis/awesome-artificial-intelligence#243": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "steven2358/awesome-generative-ai#821": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "WangRongsheng/awesome-LLM-resources#162": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
+    "crownpku/Awesome-Chinese-NLP#32": {
+        "reason": "high-star discovery-list PR already opened with project evidence; avoid duplicate pings",
+    },
 }
 REPORTER_WAITING_LABELS = {"needs feedback"}
 CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}
@@ -203,6 +268,12 @@ def github_headers() -> Dict[str, str]:
         "User-Agent": "funasr-growth-metrics",
     }
     token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        token_path = Path.home() / ".config" / "funasr-ops" / "github_token"
+        try:
+            token = token_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            token = None
     if not token:
         try:
             completed = subprocess.run(

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -25,6 +25,7 @@ def test_default_integration_prs_include_sglang_omni_fun_asr():
 def test_github_headers_falls_back_to_gh_auth_token(monkeypatch):
     module = load_growth_metrics_module()
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("HOME", "/tmp/funasr-growth-metrics-no-token-home")
 
     def fake_run(args, **kwargs):
         assert args == ["gh", "auth", "token"]
@@ -35,6 +36,24 @@ def test_github_headers_falls_back_to_gh_auth_token(monkeypatch):
     headers = module.github_headers()
 
     assert headers["Authorization"] == "Bearer cli-token"
+
+
+def test_github_headers_reads_funasr_ops_token_file(monkeypatch, tmp_path):
+    module = load_growth_metrics_module()
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    token_path = tmp_path / ".config" / "funasr-ops" / "github_token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("file-token\n")
+
+    def fake_run(args, **kwargs):
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    headers = module.github_headers()
+
+    assert headers["Authorization"] == "Bearer file-token"
 
 
 def test_default_integration_prs_include_high_visibility_external_queue():
@@ -88,6 +107,56 @@ def test_default_integration_prs_include_voice_agent_and_ml_discovery_lanes():
     }
 
     assert expected_prs.issubset(set(module.DEFAULT_INTEGRATION_PRS))
+
+
+def test_default_integration_prs_include_high_star_awesome_discovery_lanes():
+    module = load_growth_metrics_module()
+
+    expected_prs = {
+        "vinta/awesome-python#3246",
+        "fighting41love/funNLP#478",
+        "josephmisiti/awesome-machine-learning#1339",
+        "RVC-Boss/GPT-SoVITS#2801",
+        "jobbole/awesome-python-cn#141",
+        "ChristosChristofidis/awesome-deep-learning#317",
+        "Hannibal046/Awesome-LLM#623",
+        "AiHubCN/Awesome-Chinese-LLM#103",
+        "pluja/awesome-privacy#836",
+        "BradyFU/Awesome-Multimodal-Large-Language-Models#280",
+        "mahmoud/awesome-python-applications#227",
+        "bharathgs/Awesome-pytorch-list#164",
+        "owainlewis/awesome-artificial-intelligence#243",
+        "steven2358/awesome-generative-ai#821",
+        "WangRongsheng/awesome-LLM-resources#162",
+        "crownpku/Awesome-Chinese-NLP#32",
+    }
+
+    assert expected_prs.issubset(set(module.DEFAULT_INTEGRATION_PRS))
+
+
+def test_high_star_awesome_discovery_lanes_wait_for_maintainer_review():
+    module = load_growth_metrics_module()
+
+    expected_prs = {
+        "vinta/awesome-python#3246",
+        "fighting41love/funNLP#478",
+        "josephmisiti/awesome-machine-learning#1339",
+        "RVC-Boss/GPT-SoVITS#2801",
+        "jobbole/awesome-python-cn#141",
+        "ChristosChristofidis/awesome-deep-learning#317",
+        "Hannibal046/Awesome-LLM#623",
+        "AiHubCN/Awesome-Chinese-LLM#103",
+        "pluja/awesome-privacy#836",
+        "BradyFU/Awesome-Multimodal-Large-Language-Models#280",
+        "mahmoud/awesome-python-applications#227",
+        "bharathgs/Awesome-pytorch-list#164",
+        "owainlewis/awesome-artificial-intelligence#243",
+        "steven2358/awesome-generative-ai#821",
+        "WangRongsheng/awesome-LLM-resources#162",
+        "crownpku/Awesome-Chinese-NLP#32",
+    }
+
+    assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))
 
 
 def test_default_integration_prs_include_mcp_discovery_lanes():
@@ -640,7 +709,7 @@ def test_collect_integration_metrics_surfaces_pending_cla_status(monkeypatch):
     metrics = module.collect_integration_metrics(["activepieces/activepieces#13985"])
 
     integration = metrics["integrations"][0]
-    assert integration["next_action"] == "resolve CLA"
+    assert integration["next_action"] == "wait for author CLA"
     assert integration["checks"]["pending_check_runs"] == [
         {
             "name": "license/cla",
@@ -734,7 +803,7 @@ def test_collect_integration_metrics_classifies_vercel_authorization_gate(monkey
     metrics = module.collect_integration_metrics(["mem0ai/mem0#5571"])
 
     integration = metrics["integrations"][0]
-    assert integration["next_action"] == "preview auth gate"
+    assert integration["next_action"] == "wait for preview authorization"
     assert integration["checks"]["failed_check_runs"] == [
         {
             "name": "Vercel",
@@ -850,7 +919,7 @@ def test_collect_integration_metrics_treats_empty_pending_status_as_review_gate(
     integration = metrics["integrations"][0]
     assert integration["checks"]["state"] == "unknown"
     assert integration["checks"]["pending_check_runs"] == []
-    assert integration["next_action"] == "review gate"
+    assert integration["next_action"] == "wait for contributor conflict resolution"
 
 
 def test_format_integration_markdown_includes_update_age_and_next_action():


### PR DESCRIPTION
## Summary
- read the FunASR ops token file as a GitHub API fallback when `GITHUB_TOKEN` and `gh` are unavailable
- add 16 high-star LauraGPT discovery/integration PRs to the growth tracker
- mark the new discovery PRs as assisted review requests so patrols wait for maintainers instead of duplicate-pinging
- align growth-metrics tests with the current manual-gate classifications

## Validation
- `python3 -m pytest tests/test_collect_growth_metrics.py -q`
- `python3 -m py_compile scripts/collect_growth_metrics.py`
- `git diff --check`
- `python3 scripts/collect_growth_metrics.py --integrations --format json` with 42 tracked PRs, 16 new tracked PRs, and empty active operator list
