### PR TITLE
Record Fun-ASR-vLLM sampling win

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -234,6 +234,7 @@ Completed external wins:
 | `xinnan-tech/xiaozhi-esp32-server#3255` configurable FunASR language | Improves a high-star ESP32 voice-agent backend by letting users pin SenseVoice/FunASR language for short utterances | Merged on 2026-06-30 after adding the multi-module management-console database migration requested by maintainers. |
 | `tmoroney/auto-subs#629` SenseVoice engine for subtitle workflows | Adds SenseVoice to an on-device subtitle generation app used by video editors and creators | Merged on 2026-06-30 after adding the declarative model manifest, SenseVoice/Canary/Cohere engines, real CTC timestamps, native translation routing, and robustness fixes. |
 | `pipecat-ai/pipecat#4844` FunASR local STT service | Puts SenseVoice/FunASR into realtime voice agent pipelines used by builders comparing local STT backends | Merged on 2026-07-02 after adding the local STT service, optional dependency handling, docs, and validation coverage. |
+| `yuekaizhang/Fun-ASR-vllm#20` deterministic vLLM sampling for ASR | Improves a community Fun-ASR-vLLM inference path by making ASR generation deterministic enough for repeatable evaluation and demos | Merged on 2026-07-07 after switching the vLLM sampling path to deterministic decoding for ASR. Follow-up `#21` continues the prompt-embedding dtype cleanup. |
 
 Operating rules:
 


### PR DESCRIPTION
## Summary
- Add `yuekaizhang/Fun-ASR-vllm#20` to the completed external wins table.
- Keep the newer `#21` prompt-embedding dtype PR as the active follow-up while recording that deterministic vLLM sampling for ASR already merged on 2026-07-07.

## Validation
- completed wins table sanity check: `completed_rows=4`, `funasr_vllm20_rows=1`, `bad_rows=[]`
- `git diff --check`