### PR TITLE
docs: add Glama maintainer metadata

### DIFF
--- a/examples/mcp_server/README.md
+++ b/examples/mcp_server/README.md
@@ -25,7 +25,8 @@ docker run --rm -i \
 
 When submitting this server to MCP directories such as Glama, use this folder as
 the Docker build context so the container entrypoint runs `funasr_mcp.py`.
-The `glama.json` file in this directory declares the MCP server command and
+The repository root `glama.json` declares GitHub maintainer ownership for Glama,
+while the `glama.json` file in this directory declares the container command and
 metadata for directory scanners.
 
 ### Official MCP Registry checklist

--- a/glama.json
+++ b/glama.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://glama.ai/api/mcp/v1/schemas/glama.json",
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["LauraGPT"],
   "name": "funasr",
   "display_name": "FunASR MCP Server",
   "description": "Local speech recognition MCP server powered by FunASR and SenseVoice. It exposes a transcribe_audio tool for privacy-friendly audio transcription from local files.",


### PR DESCRIPTION
## Summary

- switch the repository-level Glama manifest to the current official server schema;
- declare the GitHub maintainer required by that schema;
- clarify the distinct roles of the root and MCP example manifests.

## Validation

- the live Glama schema returned HTTP 200 and lists `maintainers` as required;
- `jsonschema.validate` passed for the root manifest;
- both Glama JSON files parse successfully;
- `git diff --check origin/main...HEAD` passed.