### PR TITLE
fix: accept float32 dtype in realtime websocket server

### DIFF
--- a/examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py
+++ b/examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py
@@ -585,7 +585,7 @@ def build_arg_parser():
     parser.add_argument("--spk-model", type=str, default="iic/speech_eres2netv2_sv_zh-cn_16k-common")
     parser.add_argument("--hotword-file", type=str, default="热词列表")
     parser.add_argument("--language", type=str, default=None, help="Language hint (e.g. 中文, English, 日本語)")
-    parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16", "fp32"])
+    parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16", "fp32", "float32"])
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
     parser.add_argument("--max-model-len", type=int, default=2048)

--- a/examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py
+++ b/examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py
@@ -585,7 +585,12 @@ def build_arg_parser():
     parser.add_argument("--spk-model", type=str, default="iic/speech_eres2netv2_sv_zh-cn_16k-common")
     parser.add_argument("--hotword-file", type=str, default="热词列表")
     parser.add_argument("--language", type=str, default=None, help="Language hint (e.g. 中文, English, 日本語)")
-    parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16", "fp32", "float32"])
+    parser.add_argument(
+        "--dtype",
+        type=lambda value: "fp32" if value == "float32" else value,
+        default="bf16",
+        choices=["bf16", "fp16", "fp32", "float32"],
+    )
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
     parser.add_argument("--max-model-len", type=int, default=2048)

--- a/tests/test_realtime_ws_service.py
+++ b/tests/test_realtime_ws_service.py
@@ -41,7 +41,7 @@ def test_cli_accepts_float32_dtype_alias():
 
     args = module.build_arg_parser().parse_args(["--dtype", "float32"])
 
-    assert args.dtype == "float32"
+    assert args.dtype == "fp32"
 
 
 def test_websocket_keepalive_kwargs_are_configurable():

--- a/tests/test_realtime_ws_service.py
+++ b/tests/test_realtime_ws_service.py
@@ -36,6 +36,14 @@ def test_cli_defaults_disable_speaker_and_bound_partial_window():
     assert args.partial_window_sec == 15.0
 
 
+def test_cli_accepts_float32_dtype_alias():
+    module = load_service_module()
+
+    args = module.build_arg_parser().parse_args(["--dtype", "float32"])
+
+    assert args.dtype == "float32"
+
+
 def test_websocket_keepalive_kwargs_are_configurable():
     module = load_service_module()
 


### PR DESCRIPTION
## Summary
- accept `float32` as a valid `--dtype` value for the Fun-ASR-Nano realtime WebSocket server
- add a parser regression test covering the `float32` CLI alias

Fixes #3202.

## Test
- `python3 -m pytest tests/test_realtime_ws_service.py -q`
