### PR TITLE
fix: initialize ggml timer in funasr nano cli

### DIFF
--- a/runtime/llama.cpp/fun-asr-nano/funasr-cli/funasr-cli.cpp
+++ b/runtime/llama.cpp/fun-asr-nano/funasr-cli/funasr-cli.cpp
@@ -184,6 +184,7 @@ int main(int argc,char**argv){
 
     std::vector<float> wav;
     if(!funasr_load_audio_16k_mono(wav_path.c_str(),wav)){fprintf(stderr,"failed to read audio\n");return 1;}
+    ggml_time_init(); // Required before ggml_time_us() on Windows.
     int64_t t0=ggml_time_us();
 
     enc_model em; if(!load_enc(enc_path.c_str(),em))return 1;


### PR DESCRIPTION
## Summary

#3209 修复方案，注意只验证了Windows下的2个二进制文件，并未验证其他平台

Fix a Windows crash in the Fun-ASR-Nano llama.cpp CLI by initializing the ggml timer before the first call to `ggml_time_us()`.

On Windows, `ggml_time_us()` depends on `ggml_time_init()` to initialize the performance counter frequency. Without this initialization, `llama-funasr-cli.exe` can crash with an integer divide-by-zero exception (`0xC0000094`) before transcription starts.

This change adds:

```cpp
ggml_time_init();
```

before the first `ggml_time_us()` call in:

```text
runtime/llama.cpp/fun-asr-nano/funasr-cli/funasr-cli.cpp
```

This should be safe for non-Windows platforms because `ggml_time_init()` is a no-op there, and on Windows it uses one-time initialization internally.

## Type of change

- [x] Bug fix
- [ ] Documentation
- [ ] Example or demo
- [x] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

- [ ] `python -m compileall funasr examples tests`
- [ ] Docs or links checked
- [x] Runtime/deployment command tested

Validation performed only on Windows 11 x64, and only for the built `llama-funasr-cli.exe` program.

Not tested:

- Linux binary
- macOS binary
- Other runtime binaries such as `llama-funasr-sensevoice`, `llama-funasr-paraformer`, `llama-funasr-vad`, `llama-funasr-encoder`, or `llama-funasr-embd`
- Python package tests
- Full FunASR test suite

### Crash reproduced before the fix

Official `runtime-llamacpp-v0.1.4` Windows binaries crashed with:

```text
-1073741676
```

This is `0xC0000094`, integer divide-by-zero.

Reproduced with:

- `funasr-llamacpp-windows-x64.zip`
- `funasr-llamacpp-windows-x64-avx2.zip`
- Q4KM Nano model
- Q8 Nano model
- PowerShell
- `cmd.exe`

WinDbg showed:

```text
(6774.5c70): Integer divide-by-zero - code c0000094 (first chance)
llama_funasr_cli+0x261b84:
00007ff7`2c3d1b84 48f73dfdd51300  idiv    rax,qword ptr [llama_funasr_cli+0x39f188 (00007ff7`2c50f188)] ds:00007ff7`2c50f188=0000000000000000
```

This matches the Windows implementation of `ggml_time_us()`, where the timer frequency is used as a divisor.

### Tested command after the fix

```powershell
.\llama-funasr-cli.exe `
  --enc C:\path\to\funasr-encoder-f16.gguf `
  -m C:\path\to\qwen3-0.6b-q4km.gguf `
  --vad C:\path\to\fsmn-vad.gguf `
  -a C:\path\to\standard.wav
```

### GitHub Actions artifact validation

I built patched Windows artifacts from my fork and tested the generated `llama-funasr-cli.exe` files locally on Windows 11 x64.

`windows-x64` artifact:

```text
short 10s audio:
  exit code: 0
  time: ~7.48s

5-6 minute audio:
  exit code: 0
  time: ~273.46s
  VAD segments: 80
```

`windows-x64-avx2` artifact:

```text
short 10s audio:
  exit code: 0
  time: ~1.10s

5-6 minute audio:
  exit code: 0
  time: ~23.01s
  VAD segments: 80
```

Both artifacts produced valid Chinese transcription output. The same 5-6 minute audio produced the same output length in both tested builds.

## User impact

This fixes Fun-ASR-Nano GGUF inference on Windows for users running the llama.cpp runtime binary `llama-funasr-cli.exe`.

Without this fix, the Windows CLI can crash immediately before transcription starts. With this fix, Fun-ASR-Nano can run on CPU with VAD using the Windows x64 and x64-avx2 runtime builds.

## Notes for reviewers

- The fix is intentionally minimal: one call to `ggml_time_init()` before the first `ggml_time_us()`.
- `ggml.h` documents `ggml_time_init()` as something that should be called once at the beginning of the program.
- On Windows, `ggml_time_init()` initializes the performance counter frequency used by `ggml_time_us()`.
- On non-Windows platforms, `ggml_time_init()` is currently a no-op, so the change should not alter behavior there.
- I only tested the built `llama-funasr-cli.exe` on Windows 11 x64. Other platforms and other runtime binaries were not tested by me.

