### PR TITLE
docs: add GPT-SoVITS community integration

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -275,6 +275,7 @@ docker pull registry.cn-hangzhou.aliyuncs.com/funasr_repo/funasr:funasr-runtime-
 | 📖 [文档](https://modelscope.github.io/FunASR/zh/) | 🐛 [问题反馈](https://github.com/modelscope/FunASR/issues) |
 | 💬 [讨论](https://github.com/modelscope/FunASR/discussions) | 🤗 [HuggingFace](https://huggingface.co/funasr) |
 | 🤝 [贡献指南](./CONTRIBUTING.md) | 📈 [20k 增长计划](./docs/community_growth_20k.md) |
+| 🧩 [社区项目](./docs/community_projects.md) | 💡 [使用案例](./docs/use_case_showcase.md) |
 
 ## Star 趋势
 

--- a/docs/community_projects.md
+++ b/docs/community_projects.md
@@ -2,6 +2,18 @@
 
 This page collects maintained community integrations and experiments around FunASR models. These projects are useful for users exploring deployment paths beyond the official Python runtime, but they are not official FunASR implementations unless explicitly noted.
 
+## Applications and workflows
+
+| Project | What it provides | Notes |
+|---|---|---|
+| [GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS) | Voice-dataset preparation and WebUI transcription with Fun-ASR-Nano, SenseVoice, and classic FunASR models. | The default CLI path uses Fun-ASR-Nano for Chinese, English, Japanese, Korean, and automatic language detection; Cantonese uses classic UniASR. Models download on first use. See the upstream [runtime fallback](https://github.com/RVC-Boss/GPT-SoVITS/pull/2801) and [backend documentation](https://github.com/RVC-Boss/GPT-SoVITS/pull/2803). |
+
+Run dataset transcription from a GPT-SoVITS checkout:
+
+```bash
+python tools/asr/funasr_asr.py -i <input> -o <output> -l zh
+```
+
 ## VAD runtimes
 
 | Project | What it provides | Notes |


### PR DESCRIPTION
## Summary

- add the merged GPT-SoVITS integration to the maintained community-projects page
- document the real Fun-ASR-Nano, SenseVoice, and classic FunASR routing exposed upstream
- include the working dataset transcription command
- expose community projects and use-case showcases from the Chinese README

## Verification

- confirmed RVC-Boss/GPT-SoVITS #2801 and #2803 are merged
- checked current GPT-SoVITS main for backend defaults, supported languages, SenseVoice, and Cantonese UniASR routing
- verified both local README links exist
- git diff --check
