### PR TITLE
fix: align randperm index device in paraformer streaming sampler

### DIFF
--- a/funasr/models/paraformer_streaming/model.py
+++ b/funasr/models/paraformer_streaming/model.py
@@ -377,8 +377,11 @@ class ParaformerStreaming(Paraformer):
                     ((seq_lens[li] - same_num[li].sum()).float()) * self.sampling_ratio
                 ).long()
                 if target_num > 0:
+                    index = torch.randperm(
+                        seq_lens[li].item(), device=input_mask.device
+                    )[: target_num.item()]
                     input_mask[li].scatter_(
-                        dim=0, index=torch.randperm(seq_lens[li])[:target_num].cuda(), value=0
+                        dim=0, index=index, value=0
                     )
             input_mask = input_mask.eq(1)
             input_mask = input_mask.masked_fill(~nonpad_positions, False)


### PR DESCRIPTION
## Summary

This PR fixes a device mismatch issue in the ParaformerStreaming sampler during multi-GPU DDP training.

In `funasr/models/paraformer_streaming/model.py`, the sampling index for `scatter_` was generated using `torch.randperm(...).cuda()`. In multi-GPU training, `input_mask` is created on the local rank device, while `.cuda()` may place the index tensor on the default CUDA device. This can cause device mismatch errors such as tensors being on `cuda:1` and `cuda:0`.

The fix ensures that the sampled index is created on the same device as `input_mask`.

## Type of change

- [x] Bug fix
- [ ] Documentation
- [ ] Example or demo
- [ ] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

- [x] Code compiles
- [ ] Full test suite not run

## User impact

This fixes multi-GPU DDP training failures for ParaformerStreaming caused by scatter index tensors being placed on a different CUDA device from `input_mask`.

## Notes for reviewers

The non-streaming Paraformer implementation already aligns the randperm index with `input_mask.device`. This PR applies the same device-safe behavior to the streaming Paraformer implementation without changing the sampling logic.