### PR TITLE
Fix Java offline client connection cleanup

### DIFF
--- a/runtime/java/FunasrWsClient.java
+++ b/runtime/java/FunasrWsClient.java
@@ -225,7 +225,10 @@ public class FunasrWsClient extends WebSocketClient {
       close();
     }
 	 
-    if (iseof && mode.equals("offline") && jsonObject.containsKey("is_final") && jsonObject.get("is_final").equals("false")) {
+    if (iseof
+        && mode.equals("offline")
+        && jsonObject.containsKey("is_final")
+        && Boolean.TRUE.equals(jsonObject.get("is_final"))) {
       close();
     }
   }

--- a/runtime/java/Makefile
+++ b/runtime/java/Makefile
@@ -8,6 +8,7 @@ WEBSOCKET_DIR:= ./
 WEBSOCKET_FILES = \
 	$(WEBSOCKET_DIR)/FunasrWsClient.java \
  
+TEST_FILES = $(WEBSOCKET_DIR)/tests/FunasrWsClientTest.java
 
 
 LIB_BUILD_DIR = ./lib
@@ -31,7 +32,7 @@ vpath %.java src
 	
 rebuild: clean all
 	
-.PHONY:  clean run downjar
+.PHONY:  clean run downjar test
 
 downjar:
 	wget https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar -P ./lib/
@@ -60,6 +61,11 @@ runclient:
 
 buildwebsocket: $(WEBSOCKET_FILES:.java=.class)
 	
+
+test: buildwebsocket
+				$(JAVAC) -cp $(BUILD_DIR):lib/slf4j-simple-1.7.25.jar:lib/slf4j-api-1.7.25.jar:lib/Java-WebSocket-1.5.3.jar:lib/json-simple-1.1.1.jar:lib/argparse4j-0.9.0.jar -d $(BUILD_DIR) -encoding UTF-8 $(TEST_FILES)
+				java -ea -cp $(BUILD_DIR):lib/slf4j-simple-1.7.25.jar:lib/slf4j-api-1.7.25.jar:lib/Java-WebSocket-1.5.3.jar:lib/json-simple-1.1.1.jar:lib/argparse4j-0.9.0.jar $(RUNJFLAGS) websocket.FunasrWsClientTest
+
 
 %.class: %.java
 

--- a/runtime/java/tests/FunasrWsClientTest.java
+++ b/runtime/java/tests/FunasrWsClientTest.java
@@ -1,0 +1,69 @@
+package websocket;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+public final class FunasrWsClientTest {
+  private static final class RecordingClient extends FunasrWsClient {
+    private boolean closeCalled;
+
+    RecordingClient() throws Exception {
+      super(new URI("ws://127.0.0.1:1"));
+    }
+
+    @Override
+    public void close() {
+      closeCalled = true;
+    }
+  }
+
+  private static void assertCloseDecision(
+      boolean expected, boolean eof, String mode, String message, String description)
+      throws Exception {
+    RecordingClient client = new RecordingClient();
+    FunasrWsClient.mode = mode;
+
+    Field eofField = FunasrWsClient.class.getDeclaredField("iseof");
+    eofField.setAccessible(true);
+    eofField.setBoolean(client, eof);
+
+    client.onMessage(message);
+    if (client.closeCalled != expected) {
+      throw new AssertionError(
+          description + ": expected close=" + expected + ", actual=" + client.closeCalled);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    assertCloseDecision(
+        false,
+        true,
+        "offline",
+        "{\"text\":\"partial\",\"is_final\":false}",
+        "non-final offline response");
+    assertCloseDecision(
+        false,
+        false,
+        "offline",
+        "{\"text\":\"done\",\"is_final\":true}",
+        "final response before EOF");
+    assertCloseDecision(
+        false,
+        true,
+        "online",
+        "{\"text\":\"done\",\"is_final\":true}",
+        "final online response");
+    assertCloseDecision(
+        true,
+        true,
+        "offline",
+        "{\"text\":\"legacy done\"}",
+        "legacy offline response without is_final");
+    assertCloseDecision(
+        true,
+        true,
+        "offline",
+        "{\"text\":\"done\",\"is_final\":true}",
+        "final offline response");
+  }
+}

--- a/runtime/java/tests/FunasrWsClientTest.java
+++ b/runtime/java/tests/FunasrWsClientTest.java
@@ -1,6 +1,5 @@
 package websocket;
 
-import java.lang.reflect.Field;
 import java.net.URI;
 
 public final class FunasrWsClientTest {
@@ -15,17 +14,19 @@ public final class FunasrWsClientTest {
     public void close() {
       closeCalled = true;
     }
+
+    @Override
+    public void send(String text) {}
   }
 
   private static void assertCloseDecision(
-      boolean expected, boolean eof, String mode, String message, String description)
+      boolean expected, boolean eof, String clientMode, String message, String description)
       throws Exception {
     RecordingClient client = new RecordingClient();
-    FunasrWsClient.mode = mode;
-
-    Field eofField = FunasrWsClient.class.getDeclaredField("iseof");
-    eofField.setAccessible(true);
-    eofField.setBoolean(client, eof);
+    FunasrWsClient.mode = clientMode;
+    if (eof) {
+      client.sendEof();
+    }
 
     client.onMessage(message);
     if (client.closeCalled != expected) {
@@ -63,7 +64,7 @@ public final class FunasrWsClientTest {
         true,
         true,
         "offline",
-        "{\"text\":\"done\",\"is_final\":true}",
+        "{\"mode\":\"2pass-offline\",\"text\":\"done\",\"is_final\":true}",
         "final offline response");
   }
 }


### PR DESCRIPTION
## Summary

- close the official Java offline WebSocket client when the server sends the boolean `is_final: true`
- preserve compatibility with older offline payloads that do not include `is_final`
- add a Java regression test for final, non-final, pre-EOF, online, and legacy responses

Fixes #2792

## Type of change

- [x] Bug fix
- [ ] Documentation
- [ ] Example or demo
- [x] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

- [ ] `python -m compileall funasr examples tests`
- [ ] Docs or links checked
- [x] Runtime/deployment command tested

```bash
export PATH=/path/to/jdk-11/bin:$PATH
cd runtime/java
make downjar
make test
```

Validated with Temurin Java 11.0.31. The regression test first failed on the previous implementation because a parsed JSON boolean did not equal the string `"false"`; all five close-decision scenarios pass with this change.

## User impact

Offline batch users of the official Java client no longer leave completed WebSocket connections open. This lets the 2-pass server observe the close event and release the per-connection decoder state during its cleanup loop instead of retaining memory across a batch.

## Notes for reviewers

The 2-pass server emits intermediate results with `is_final: false` and the terminal result with `is_final: true`. This change only corrects the Java client's type and polarity check; the existing no-field fallback remains for compatibility with older servers.
