### PR TITLE
docs(llama.cpp): fix default GGUF quickstart

### DIFF
--- a/.github/workflows/test-llamacpp-downloader.yml
+++ b/.github/workflows/test-llamacpp-downloader.yml
@@ -1,0 +1,31 @@
+name: Test llama.cpp downloader
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'README_zh.md'
+      - 'runtime/llama.cpp/download-funasr-model.sh'
+      - 'runtime/llama.cpp/tests/test_download_funasr_model.sh'
+      - '.github/workflows/test-llamacpp-downloader.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'README.md'
+      - 'README_zh.md'
+      - 'runtime/llama.cpp/download-funasr-model.sh'
+      - 'runtime/llama.cpp/tests/test_download_funasr_model.sh'
+      - '.github/workflows/test-llamacpp-downloader.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run downloader and README contract tests
+        run: bash runtime/llama.cpp/tests/test_download_funasr_model.sh

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ bash download-funasr-model.sh sensevoice ./gguf        # or: paraformer | nano
 # Windows PowerShell: run from the extracted archive root (with the `hf` CLI installed)
 hf download FunAudioLLM/SenseVoiceSmall-GGUF sensevoice-small-q8.gguf --local-dir .\gguf
 hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf
-.\pkg\llama-funasr-sensevoice.exe -m .\gguf\sensevoice-small-q8.gguf --vad .\gguf\fsmn-vad.gguf -a audio.wav
+.\llama-funasr-sensevoice.exe -m .\gguf\sensevoice-small-q8.gguf --vad .\gguf\fsmn-vad.gguf -a audio.wav
 ```
 
 **Prebuilt binaries:** [Releases](https://github.com/modelscope/FunASR/releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF models:** [Hugging Face](https://huggingface.co/FunAudioLLM) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)

--- a/README.md
+++ b/README.md
@@ -246,13 +246,20 @@ docker pull registry.cn-hangzhou.aliyuncs.com/funasr_repo/funasr:funasr-runtime-
 Run **SenseVoice / Paraformer / Fun-ASR-Nano** as a **single self-contained binary** on CPU and edge devices — this is to FunASR what [whisper.cpp](https://github.com/ggml-org/whisper.cpp) is to Whisper, but with **~3× lower CER than whisper.cpp on Chinese**. Built-in FSMN-VAD, no Python at runtime.
 
 ```bash
-# 1) Grab a prebuilt binary from Releases (Linux / macOS / Windows), then:
+# Linux / macOS: run from the extracted release directory
 bash download-funasr-model.sh sensevoice ./gguf        # or: paraformer | nano
-llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+./llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
 # → 欢迎大家来体验达摩院推出的语音识别模型
 ```
 
-**Prebuilt binaries:** [Releases](../../releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF models:** [Hugging Face](https://huggingface.co/FunAudioLLM) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)
+```powershell
+# Windows PowerShell: run from the extracted archive root (with the `hf` CLI installed)
+hf download FunAudioLLM/SenseVoiceSmall-GGUF sensevoice-small-q8.gguf --local-dir .\gguf
+hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf
+.\pkg\llama-funasr-sensevoice.exe -m .\gguf\sensevoice-small-q8.gguf --vad .\gguf\fsmn-vad.gguf -a audio.wav
+```
+
+**Prebuilt binaries:** [Releases](https://github.com/modelscope/FunASR/releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF models:** [Hugging Face](https://huggingface.co/FunAudioLLM) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 [OpenAI API example →](./examples/openai_api/) · [Gradio demo →](./examples/openai_api/GRADIO.md) · [Client recipes →](./examples/openai_api/CLIENTS.md) · [JavaScript/TypeScript recipes →](./examples/openai_api/JAVASCRIPT.md) · [Kubernetes template →](./examples/openai_api/kubernetes/) · [Workflow recipes →](./examples/openai_api/WORKFLOWS.md) · [Postman collection →](./examples/openai_api/POSTMAN.md) · [OpenAPI spec →](./examples/openai_api/OPENAPI.md) · [Security guide →](./examples/openai_api/SECURITY.md) · [Deployment matrix →](./docs/deployment_matrix.md) · [Deployment docs →](./runtime/readme.md) · [Agent integration →](https://modelscope.github.io/FunASR/agent.html)
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Run **SenseVoice / Paraformer / Fun-ASR-Nano** as a **single self-contained bina
 ```bash
 # 1) Grab a prebuilt binary from Releases (Linux / macOS / Windows), then:
 bash download-funasr-model.sh sensevoice ./gguf        # or: paraformer | nano
-llama-funasr-sensevoice -m ./gguf/SenseVoiceSmall-f16.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
 # → 欢迎大家来体验达摩院推出的语音识别模型
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -279,13 +279,20 @@ docker pull registry.cn-hangzhou.aliyuncs.com/funasr_repo/funasr:funasr-runtime-
 在 CPU 和边缘设备上用单个自包含二进制运行 **SenseVoice / Paraformer / Fun-ASR-Nano**，无需 Python 运行环境，并内置 FSMN-VAD。
 
 ```bash
-# 1) 从 Releases 下载 Linux / macOS / Windows 预编译包，然后执行：
+# Linux / macOS：在解压后的发布目录中执行
 bash download-funasr-model.sh sensevoice ./gguf        # 也可使用 paraformer 或 nano
-llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+./llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
 # -> 欢迎大家来体验达摩院推出的语音识别模型
 ```
 
-**预编译二进制：** [Releases](../../releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF 模型：** [Hugging Face](https://huggingface.co/FunAudioLLM) · **文档与评测：** [runtime/llama.cpp/](./runtime/llama.cpp/)
+```powershell
+# Windows PowerShell：在解压根目录执行（需已安装 `hf` CLI）
+hf download FunAudioLLM/SenseVoiceSmall-GGUF sensevoice-small-q8.gguf --local-dir .\gguf
+hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf
+.\pkg\llama-funasr-sensevoice.exe -m .\gguf\sensevoice-small-q8.gguf --vad .\gguf\fsmn-vad.gguf -a audio.wav
+```
+
+**预编译二进制：** [Releases](https://github.com/modelscope/FunASR/releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF 模型：** [Hugging Face](https://huggingface.co/FunAudioLLM) · **文档与评测：** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 [OpenAI API 示例 →](./examples/openai_api/README_zh.md) · [Gradio Demo →](./examples/openai_api/GRADIO_zh.md) · [客户端配方 →](./examples/openai_api/CLIENTS.md) · [JavaScript/TypeScript 配方 →](./examples/openai_api/JAVASCRIPT_zh.md) · [Kubernetes 模板 →](./examples/openai_api/kubernetes/README_zh.md) · [工作流配方 →](./examples/openai_api/WORKFLOWS_zh.md) · [Postman 集合 →](./examples/openai_api/POSTMAN_zh.md) · [OpenAPI 规范 →](./examples/openai_api/OPENAPI_zh.md) · [安全指南 →](./examples/openai_api/SECURITY_zh.md) · [部署选型 →](./docs/deployment_matrix_zh.md) · [部署文档 →](./runtime/readme_cn.md) · [Agent 集成 →](https://modelscope.github.io/FunASR/agent.html)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -289,7 +289,7 @@ bash download-funasr-model.sh sensevoice ./gguf        # 也可使用 paraformer
 # Windows PowerShell：在解压根目录执行（需已安装 `hf` CLI）
 hf download FunAudioLLM/SenseVoiceSmall-GGUF sensevoice-small-q8.gguf --local-dir .\gguf
 hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf
-.\pkg\llama-funasr-sensevoice.exe -m .\gguf\sensevoice-small-q8.gguf --vad .\gguf\fsmn-vad.gguf -a audio.wav
+.\llama-funasr-sensevoice.exe -m .\gguf\sensevoice-small-q8.gguf --vad .\gguf\fsmn-vad.gguf -a audio.wav
 ```
 
 **预编译二进制：** [Releases](https://github.com/modelscope/FunASR/releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF 模型：** [Hugging Face](https://huggingface.co/FunAudioLLM) · **文档与评测：** [runtime/llama.cpp/](./runtime/llama.cpp/)

--- a/README_zh.md
+++ b/README_zh.md
@@ -274,7 +274,18 @@ curl http://localhost:8000/v1/audio/transcriptions \
 docker pull registry.cn-hangzhou.aliyuncs.com/funasr_repo/funasr:funasr-runtime-sdk-online-cpu-0.1.12
 ```
 
-> **CPU / 边缘部署(无需 GPU、无需 Python):** 用 **llama.cpp / GGUF** 跑 Fun-ASR-Nano / SenseVoice / Paraformer —— 单个自包含二进制,对标 whisper.cpp。详见 [runtime/llama.cpp/](./runtime/llama.cpp/)。
+### CPU / 边缘部署 - llama.cpp / GGUF（无需 GPU、无需 Python）
+
+在 CPU 和边缘设备上用单个自包含二进制运行 **SenseVoice / Paraformer / Fun-ASR-Nano**，无需 Python 运行环境，并内置 FSMN-VAD。
+
+```bash
+# 1) 从 Releases 下载 Linux / macOS / Windows 预编译包，然后执行：
+bash download-funasr-model.sh sensevoice ./gguf        # 也可使用 paraformer 或 nano
+llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+# -> 欢迎大家来体验达摩院推出的语音识别模型
+```
+
+**预编译二进制：** [Releases](../../releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF 模型：** [Hugging Face](https://huggingface.co/FunAudioLLM) · **文档与评测：** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 [OpenAI API 示例 →](./examples/openai_api/README_zh.md) · [Gradio Demo →](./examples/openai_api/GRADIO_zh.md) · [客户端配方 →](./examples/openai_api/CLIENTS.md) · [JavaScript/TypeScript 配方 →](./examples/openai_api/JAVASCRIPT_zh.md) · [Kubernetes 模板 →](./examples/openai_api/kubernetes/README_zh.md) · [工作流配方 →](./examples/openai_api/WORKFLOWS_zh.md) · [Postman 集合 →](./examples/openai_api/POSTMAN_zh.md) · [OpenAPI 规范 →](./examples/openai_api/OPENAPI_zh.md) · [安全指南 →](./examples/openai_api/SECURITY_zh.md) · [部署选型 →](./docs/deployment_matrix_zh.md) · [部署文档 →](./runtime/readme_cn.md) · [Agent 集成 →](https://modelscope.github.io/FunASR/agent.html)
 

--- a/runtime/llama.cpp/tests/test_download_funasr_model.sh
+++ b/runtime/llama.cpp/tests/test_download_funasr_model.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+REPO_ROOT=$(cd "$ROOT/../.." && pwd)
 SCRIPT="$ROOT/download-funasr-model.sh"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
@@ -105,5 +106,24 @@ if HF_SKIP_CREATE=1 bash "$SCRIPT" sensevoice "$TMP/out" >"$TMP/stdout" 2>"$TMP/
   exit 1
 fi
 grep -F "no GGUF files found in $TMP/out" "$TMP/stderr" >/dev/null
+
+assert_readme_quickstart() {
+  local readme=$1
+  if ! grep -F "bash download-funasr-model.sh sensevoice ./gguf" "$readme" >/dev/null; then
+    printf 'missing default SenseVoice download command in %s\n' "$readme" >&2
+    exit 1
+  fi
+  if ! grep -F "llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav" "$readme" >/dev/null; then
+    printf 'README command does not run the default sensevoice-small-q8.gguf in %s\n' "$readme" >&2
+    exit 1
+  fi
+  if grep -F "SenseVoiceSmall-f16.gguf" "$readme" >/dev/null; then
+    printf 'stale SenseVoice filename in %s\n' "$readme" >&2
+    exit 1
+  fi
+}
+
+assert_readme_quickstart "$REPO_ROOT/README.md"
+assert_readme_quickstart "$REPO_ROOT/README_zh.md"
 
 echo "download-funasr-model contract tests passed"

--- a/runtime/llama.cpp/tests/test_download_funasr_model.sh
+++ b/runtime/llama.cpp/tests/test_download_funasr_model.sh
@@ -63,6 +63,8 @@ bash "$SCRIPT" sensevoice "$TMP/out" >/dev/null
 assert_log "download FunAudioLLM/SenseVoiceSmall-GGUF sensevoice-small-q8.gguf --local-dir $TMP/out"
 assert_log "download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir $TMP/out"
 assert_no_log "--include *.gguf"
+DEFAULT_SENSEVOICE_MODEL=$(awk '$1 == "download" && $2 == "FunAudioLLM/SenseVoiceSmall-GGUF" { print $3; exit }' "$HF_LOG")
+[[ -n "$DEFAULT_SENSEVOICE_MODEL" ]]
 
 reset_case
 bash "$SCRIPT" paraformer "$TMP/out" f16 >/dev/null
@@ -109,21 +111,49 @@ grep -F "no GGUF files found in $TMP/out" "$TMP/stderr" >/dev/null
 
 assert_readme_quickstart() {
   local readme=$1
-  if ! grep -F "bash download-funasr-model.sh sensevoice ./gguf" "$readme" >/dev/null; then
+  local section_prefix=$2
+  local section
+  local quickstart
+
+  if ! section=$(awk -v prefix="$section_prefix" '
+    !found && index($0, prefix) == 1 { found = 1 }
+    found && /^---$/ { exit }
+    found { print }
+    END { if (!found) exit 1 }
+  ' "$readme"); then
+    printf 'missing CPU/edge section in %s\n' "$readme" >&2
+    exit 1
+  fi
+
+  if ! quickstart=$(printf '%s\n' "$section" | awk '
+    !seen && /^```bash$/ { seen = 1; in_block = 1; next }
+    in_block && /^```$/ { complete = 1; exit }
+    in_block { print }
+    END { if (!seen || !complete) exit 1 }
+  '); then
+    printf 'missing Bash quickstart block in %s\n' "$readme" >&2
+    exit 1
+  fi
+
+  if ! grep -F "bash download-funasr-model.sh sensevoice ./gguf" <<<"$quickstart" >/dev/null; then
     printf 'missing default SenseVoice download command in %s\n' "$readme" >&2
     exit 1
   fi
-  if ! grep -F "llama-funasr-sensevoice -m ./gguf/sensevoice-small-q8.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav" "$readme" >/dev/null; then
+  if ! grep -F "./llama-funasr-sensevoice -m ./gguf/$DEFAULT_SENSEVOICE_MODEL --vad ./gguf/fsmn-vad.gguf -a audio.wav" <<<"$quickstart" >/dev/null; then
     printf 'README command does not run the default sensevoice-small-q8.gguf in %s\n' "$readme" >&2
     exit 1
   fi
-  if grep -F "SenseVoiceSmall-f16.gguf" "$readme" >/dev/null; then
-    printf 'stale SenseVoice filename in %s\n' "$readme" >&2
+  if ! grep -F ".\\pkg\\llama-funasr-sensevoice.exe -m .\\gguf\\$DEFAULT_SENSEVOICE_MODEL --vad .\\gguf\\fsmn-vad.gguf -a audio.wav" <<<"$section" >/dev/null; then
+    printf 'missing Windows PowerShell quickstart in %s\n' "$readme" >&2
+    exit 1
+  fi
+  if ! grep -F '[Releases](https://github.com/modelscope/FunASR/releases)' <<<"$section" >/dev/null; then
+    printf 'non-portable Releases link in %s\n' "$readme" >&2
     exit 1
   fi
 }
 
-assert_readme_quickstart "$REPO_ROOT/README.md"
-assert_readme_quickstart "$REPO_ROOT/README_zh.md"
+assert_readme_quickstart "$REPO_ROOT/README.md" '### CPU / Edge'
+assert_readme_quickstart "$REPO_ROOT/README_zh.md" '### CPU / 边缘部署'
 
 echo "download-funasr-model contract tests passed"

--- a/runtime/llama.cpp/tests/test_download_funasr_model.sh
+++ b/runtime/llama.cpp/tests/test_download_funasr_model.sh
@@ -146,23 +146,23 @@ assert_readme_quickstart() {
     exit 1
   fi
 
-  if ! grep -F "bash download-funasr-model.sh sensevoice ./gguf" <<<"$quickstart" >/dev/null; then
+  if ! grep -Eq '^bash download-funasr-model\.sh sensevoice \./gguf([[:space:]]+#.*)?$' <<<"$quickstart"; then
     printf 'missing default SenseVoice download command in %s\n' "$readme" >&2
     exit 1
   fi
-  if ! grep -F "./llama-funasr-sensevoice -m ./gguf/$DEFAULT_SENSEVOICE_MODEL --vad ./gguf/fsmn-vad.gguf -a audio.wav" <<<"$quickstart" >/dev/null; then
+  if ! grep -Fx "./llama-funasr-sensevoice -m ./gguf/$DEFAULT_SENSEVOICE_MODEL --vad ./gguf/fsmn-vad.gguf -a audio.wav" <<<"$quickstart" >/dev/null; then
     printf 'README command does not run the default sensevoice-small-q8.gguf in %s\n' "$readme" >&2
     exit 1
   fi
-  if ! grep -F "hf download FunAudioLLM/SenseVoiceSmall-GGUF $DEFAULT_SENSEVOICE_MODEL --local-dir .\\gguf" <<<"$powershell" >/dev/null; then
+  if ! grep -Fx "hf download FunAudioLLM/SenseVoiceSmall-GGUF $DEFAULT_SENSEVOICE_MODEL --local-dir .\\gguf" <<<"$powershell" >/dev/null; then
     printf 'missing Windows SenseVoice download command in %s\n' "$readme" >&2
     exit 1
   fi
-  if ! grep -F 'hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf' <<<"$powershell" >/dev/null; then
+  if ! grep -Fx 'hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf' <<<"$powershell" >/dev/null; then
     printf 'missing Windows FSMN-VAD download command in %s\n' "$readme" >&2
     exit 1
   fi
-  if ! grep -F ".\\llama-funasr-sensevoice.exe -m .\\gguf\\$DEFAULT_SENSEVOICE_MODEL --vad .\\gguf\\fsmn-vad.gguf -a audio.wav" <<<"$powershell" >/dev/null; then
+  if ! grep -Fx ".\\llama-funasr-sensevoice.exe -m .\\gguf\\$DEFAULT_SENSEVOICE_MODEL --vad .\\gguf\\fsmn-vad.gguf -a audio.wav" <<<"$powershell" >/dev/null; then
     printf 'missing Windows PowerShell quickstart in %s\n' "$readme" >&2
     exit 1
   fi

--- a/runtime/llama.cpp/tests/test_download_funasr_model.sh
+++ b/runtime/llama.cpp/tests/test_download_funasr_model.sh
@@ -114,6 +114,7 @@ assert_readme_quickstart() {
   local section_prefix=$2
   local section
   local quickstart
+  local powershell
 
   if ! section=$(awk -v prefix="$section_prefix" '
     !found && index($0, prefix) == 1 { found = 1 }
@@ -135,6 +136,16 @@ assert_readme_quickstart() {
     exit 1
   fi
 
+  if ! powershell=$(printf '%s\n' "$section" | awk '
+    !seen && /^```powershell$/ { seen = 1; in_block = 1; next }
+    in_block && /^```$/ { complete = 1; exit }
+    in_block { print }
+    END { if (!seen || !complete) exit 1 }
+  '); then
+    printf 'missing PowerShell quickstart block in %s\n' "$readme" >&2
+    exit 1
+  fi
+
   if ! grep -F "bash download-funasr-model.sh sensevoice ./gguf" <<<"$quickstart" >/dev/null; then
     printf 'missing default SenseVoice download command in %s\n' "$readme" >&2
     exit 1
@@ -143,7 +154,15 @@ assert_readme_quickstart() {
     printf 'README command does not run the default sensevoice-small-q8.gguf in %s\n' "$readme" >&2
     exit 1
   fi
-  if ! grep -F ".\\pkg\\llama-funasr-sensevoice.exe -m .\\gguf\\$DEFAULT_SENSEVOICE_MODEL --vad .\\gguf\\fsmn-vad.gguf -a audio.wav" <<<"$section" >/dev/null; then
+  if ! grep -F "hf download FunAudioLLM/SenseVoiceSmall-GGUF $DEFAULT_SENSEVOICE_MODEL --local-dir .\\gguf" <<<"$powershell" >/dev/null; then
+    printf 'missing Windows SenseVoice download command in %s\n' "$readme" >&2
+    exit 1
+  fi
+  if ! grep -F 'hf download FunAudioLLM/fsmn-vad-GGUF fsmn-vad.gguf --local-dir .\gguf' <<<"$powershell" >/dev/null; then
+    printf 'missing Windows FSMN-VAD download command in %s\n' "$readme" >&2
+    exit 1
+  fi
+  if ! grep -F ".\\llama-funasr-sensevoice.exe -m .\\gguf\\$DEFAULT_SENSEVOICE_MODEL --vad .\\gguf\\fsmn-vad.gguf -a audio.wav" <<<"$powershell" >/dev/null; then
     printf 'missing Windows PowerShell quickstart in %s\n' "$readme" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary

- align both root README quickstarts with the default `sensevoice-small-q8.gguf` downloaded by the helper
- make the packaged commands executable as copied: `./llama-funasr-sensevoice` on Linux/macOS and `.\llama-funasr-sensevoice.exe` from the Windows ZIP root
- add a scoped downloader/README contract test and a lightweight PR/push workflow that runs it
- use an absolute Releases URL so the quickstart remains valid outside GitHub

## Root cause

The downloader defaults to the practical Q8 SenseVoice artifact, while the English root README invoked the old, differently cased `SenseVoiceSmall-f16.gguf` filename. The release archives also do not install their binaries into `PATH`, so the Unix command needed `./`; the Chinese root README had only a pointer rather than an equivalent copy-paste flow.

The existing downloader contract was not connected to CI and searched whole README files. It now extracts the CPU/edge Bash and PowerShell fences, derives the expected SenseVoice filename from the downloader's observed request, and requires complete runnable command lines for both platforms.

## Validation

- reproduced the stale-filename and missing-executable-path failures before the fixes
- mutation-tested that commands outside the CPU/edge fence, missing Windows downloads, and commented-out commands are rejected
- `bash runtime/llama.cpp/tests/test_download_funasr_model.sh`
- `bash -n runtime/llama.cpp/tests/test_download_funasr_model.sh runtime/llama.cpp/download-funasr-model.sh`
- `git diff --check`
- [GitHub Actions contract job](https://github.com/modelscope/FunASR/actions/runs/29392054836/job/87277478477)
- verified the v0.1.6 Linux x64 and Windows x64 assets against their published SHA-256 digests; archive listings place both platform binaries at the documented roots
- executed `./llama-funasr-sensevoice --help` from the extracted Linux x64 release
- verified the Releases, funasr.com quickstart, and Hugging Face links return HTTP 200
