### PR TITLE
fix(cli): route Paraformer hotwords correctly

### DIFF
--- a/funasr/cli.py
+++ b/funasr/cli.py
@@ -139,7 +139,13 @@ def main():
         if args.language:
             gen_kw["language"] = args.language
         if args.hotwords:
-            gen_kw["hotwords"] = args.hotwords.split(",")
+            hotwords = [
+                word.strip() for word in args.hotwords.split(",") if word.strip()
+            ]
+            if args.model == "paraformer":
+                gen_kw["hotword"] = " ".join(hotwords)
+            else:
+                gen_kw["hotwords"] = hotwords
 
         result = model.generate(**gen_kw)
         elapsed = time.time() - t0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ class DummyAutoModel:
         self.instances.append(self)
 
     def generate(self, **kwargs):
+        self.generate_kwargs = kwargs
         return [{"text": "hello"}]
 
 
@@ -39,3 +40,32 @@ def test_cli_passes_hub_to_auto_model(tmp_path):
     assert DummyAutoModel.instances[0].kwargs["hub"] == "hf"
     assert stdout.getvalue().strip() == "hello"
 
+
+def test_cli_routes_multiple_hotwords_to_paraformer_hotword(tmp_path):
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"not a real wav")
+    fake_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+
+    DummyAutoModel.instances = []
+    argv = [
+        "funasr",
+        "--model",
+        "paraformer",
+        "--hotwords",
+        "FunASR, ModelScope",
+        str(audio_path),
+    ]
+
+    with (
+        patch.object(sys, "argv", argv),
+        patch.dict(sys.modules, {"torch": fake_torch}),
+        patch("funasr.AutoModel", DummyAutoModel),
+        redirect_stdout(io.StringIO()),
+    ):
+        cli.main()
+
+    generate_kwargs = DummyAutoModel.instances[0].generate_kwargs
+    assert generate_kwargs["hotword"] == "FunASR ModelScope"
+    assert "hotwords" not in generate_kwargs


### PR DESCRIPTION
## Summary

- route comma-separated `--hotwords` to Paraformer's singular `hotword` runtime argument
- trim surrounding whitespace and discard empty comma-separated entries
- add a CLI regression test covering multiple Paraformer hotwords

## Root cause

The `paraformer` CLI alias resolves to the SeACo Paraformer model, whose inference path reads `kwargs.get("hotword")`. The CLI always emitted `hotwords=[...]`, so the accepted flag was silently ignored for the documented Paraformer command.

## Verification

- `python3 -m pytest -q tests/test_cli.py tests/test_postprocess_hotwords.py` - 12 passed, 1 skipped
- `ruff check funasr/cli.py tests/test_cli.py`
- `python3 -m compileall -q funasr/cli.py tests/test_cli.py`
- `git diff --check`

A broader run including `tests/test_auto_model.py` had 16 passes, 1 skip, and one environment-only failure because this host lacks `modelscope`/`rapidfuzz`, preventing unrelated model auto-registration.