### PR TITLE
fix: handle Unicode punctuation post-processing

### DIFF
--- a/fun_text_processing/text_normalization/data_loader_utils.py
+++ b/fun_text_processing/text_normalization/data_loader_utils.py
@@ -284,7 +284,7 @@ def post_process_punct(input: str, normalized_text: str, add_unicode_punct: bool
     Args:
         input: input text (original input to the NN, before normalization or tokenization)
         normalized_text: output text (output of the TN NN model)
-        add_unicode_punct: set to True to handle unicode punctuation marks as well as default string.punctuation (increases post processing time)
+        add_unicode_punct: set to True to handle unicode punctuation marks as well as default string.punctuation
     """
     # in the post-processing WFST graph "``" are repalced with '"" quotes (otherwise single quotes "`" won't be handled correctly)
     # this function fixes spaces around them based on input sequence, so here we're making the same double quote replacement
@@ -296,12 +296,11 @@ def post_process_punct(input: str, normalized_text: str, add_unicode_punct: bool
     punct_marks = [x for x in string.punctuation if x in input]
 
     if add_unicode_punct:
-        punct_unicode = [
-            chr(i)
-            for i in range(sys.maxunicode)
-            if category(chr(i)).startswith("P") and chr(i) not in punct_default and chr(i) in input
-        ]
-        punct_marks = punct_marks.extend(punct_unicode)
+        punct_marks.extend(
+            char
+            for char in dict.fromkeys(input)
+            if char not in string.punctuation and category(char).startswith("P")
+        )
 
     for punct in punct_marks:
         try:

--- a/tests/test_text_normalization_punctuation.py
+++ b/tests/test_text_normalization_punctuation.py
@@ -1,0 +1,16 @@
+from fun_text_processing.text_normalization.data_loader_utils import post_process_punct
+
+
+def test_post_process_punct_preserves_ascii_punctuation_spacing():
+    assert post_process_punct("test' example", "test 'example") == "test' example"
+
+
+def test_post_process_punct_handles_unicode_punctuation():
+    assert (
+        post_process_punct(
+            "\u4f60\u597d\uff0c\u4e16\u754c\uff01",
+            "\u4f60\u597d \uff0c \u4e16\u754c \uff01",
+            add_unicode_punct=True,
+        )
+        == "\u4f60\u597d\uff0c\u4e16\u754c\uff01"
+    )


### PR DESCRIPTION
## Summary

Fix Unicode punctuation post-processing reported in [Discussion #2451](https://github.com/modelscope/FunASR/discussions/2451).

When add_unicode_punct=True, the existing path referenced both undefined sys and punct_default, then assigned the None return value from list.extend() back to punct_marks. As a result, the option could not process any Unicode punctuation.

This change:

- collects only Unicode punctuation characters that actually occur in the input;
- preserves each character once in input order;
- leaves the default ASCII punctuation path unchanged; and
- avoids scanning the full Unicode code-point range on every call.

## Validation

- Red-before-green regression: the new Unicode case failed with NameError: sys is not defined on origin/main.
- python -m pytest tests/test_text_normalization_punctuation.py -q --tb=short -> 2 passed.
- The same test under the FunASR CPU integration environment -> 2 passed.
- ruff check --ignore E722 on the changed source and test -> passed. E722 is a pre-existing bare except in this function; the two pre-existing F821 errors are fixed.
- ruff format --check tests/test_text_normalization_punctuation.py -> passed.
- python -m compileall and git diff --check -> passed.

The legacy tests/test_punctuation_pipeline.py cannot be collected in the available environments because its unrelated ModelScope dependency chain is incomplete (modelscope, then addict).