### PR TITLE
Release funasr-onnx 0.4.2 without Torch runtime dependency

### DIFF
--- a/.github/workflows/test-funasr-onnx-package.yml
+++ b/.github/workflows/test-funasr-onnx-package.yml
@@ -31,9 +31,9 @@ jobs:
           - "3.12"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload release candidate
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: funasr-onnx-0.4.2
           path: dist/funasr-onnx/*

--- a/.github/workflows/test-funasr-onnx-package.yml
+++ b/.github/workflows/test-funasr-onnx-package.yml
@@ -1,0 +1,85 @@
+name: Validate funasr-onnx package
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/test-funasr-onnx-package.yml"
+      - "runtime/python/onnxruntime/**"
+      - "tests/test_funasr_onnx_release.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/test-funasr-onnx-package.yml"
+      - "runtime/python/onnxruntime/**"
+      - "tests/test_funasr_onnx_release.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package-smoke:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Check release contract
+        run: python tests/test_funasr_onnx_release.py
+
+      - name: Build wheel and source distribution
+        run: python -m build runtime/python/onnxruntime --outdir dist/funasr-onnx
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/funasr-onnx/*
+
+      - name: Install built wheel
+        run: python -m pip install --force-reinstall dist/funasr-onnx/*.whl
+
+      - name: Verify clean ONNX install
+        run: |
+          python -m pip check
+          python - <<'PY'
+          import importlib.util
+          from importlib.metadata import requires, version
+
+          assert version("funasr-onnx") == "0.4.2"
+          assert importlib.util.find_spec("torch") is None
+
+          requirements = requires("funasr-onnx") or []
+          normalized = {item.lower().replace("_", "-") for item in requirements}
+          assert any(item.startswith("jieba") for item in normalized)
+          assert not any(item.startswith("torch") for item in normalized)
+
+          from funasr_onnx import CT_Transformer, Fsmn_vad, Paraformer, SenseVoiceSmall
+
+          assert all(
+              entrypoint is not None
+              for entrypoint in (Paraformer, Fsmn_vad, CT_Transformer, SenseVoiceSmall)
+          )
+          PY
+
+      - name: Upload release candidate
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: funasr-onnx-0.4.2
+          path: dist/funasr-onnx/*
+          if-no-files-found: error

--- a/runtime/python/onnxruntime/setup.py
+++ b/runtime/python/onnxruntime/setup.py
@@ -13,7 +13,7 @@ def get_readme():
 
 
 MODULE_NAME = "funasr_onnx"
-VERSION_NUM = "0.4.1"
+VERSION_NUM = "0.4.2"
 
 setuptools.setup(
     name=MODULE_NAME,

--- a/tests/test_funasr_onnx_release.py
+++ b/tests/test_funasr_onnx_release.py
@@ -1,0 +1,75 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = ROOT / "runtime" / "python" / "onnxruntime"
+SETUP_PATH = PACKAGE_ROOT / "setup.py"
+EXPECTED_VERSION = "0.4.2"
+
+
+def read_setup_tree():
+    return ast.parse(SETUP_PATH.read_text(encoding="utf-8"), filename=str(SETUP_PATH))
+
+
+def assigned_literal(tree, name):
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} is not assigned in {SETUP_PATH}")
+
+
+def setup_keyword_literal(tree, name):
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "setup":
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == name:
+                return ast.literal_eval(keyword.value)
+    raise AssertionError(f"setuptools.setup() has no {name!r} keyword")
+
+
+class FunASROnnxReleaseContractTest(unittest.TestCase):
+    def test_release_version_is_0_4_2(self):
+        self.assertEqual(assigned_literal(read_setup_tree(), "VERSION_NUM"), EXPECTED_VERSION)
+
+    def test_runtime_dependencies_keep_onnx_install_torch_free(self):
+        requirements = setup_keyword_literal(read_setup_tree(), "install_requires")
+        names = {
+            requirement.split(";", 1)[0]
+            .split("[", 1)[0]
+            .split("=", 1)[0]
+            .split("<", 1)[0]
+            .split(">", 1)[0]
+            .strip()
+            .lower()
+            .replace("_", "-")
+            for requirement in requirements
+        }
+        self.assertIn("jieba", names)
+        self.assertNotIn("torch", names)
+
+    def test_package_source_has_no_torch_imports(self):
+        offenders = []
+        package_dir = PACKAGE_ROOT / "funasr_onnx"
+        for source_path in sorted(package_dir.rglob("*.py")):
+            tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    modules = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    modules = [node.module or ""]
+                else:
+                    continue
+                if any(module == "torch" or module.startswith("torch.") for module in modules):
+                    offenders.append(f"{source_path.relative_to(ROOT)}:{node.lineno}")
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_funasr_onnx_release.py
+++ b/tests/test_funasr_onnx_release.py
@@ -1,5 +1,6 @@
 import ast
 from pathlib import Path
+import re
 import unittest
 
 
@@ -7,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = ROOT / "runtime" / "python" / "onnxruntime"
 SETUP_PATH = PACKAGE_ROOT / "setup.py"
 EXPECTED_VERSION = "0.4.2"
+REQUIREMENT_NAME_PATTERN = re.compile(r"^\s*([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)")
 
 
 def read_setup_tree():
@@ -34,25 +36,33 @@ def setup_keyword_literal(tree, name):
     raise AssertionError(f"setuptools.setup() has no {name!r} keyword")
 
 
+def normalized_requirement_name(requirement):
+    match = REQUIREMENT_NAME_PATTERN.match(requirement)
+    if match is None:
+        raise AssertionError(f"Unable to parse requirement name from {requirement!r}")
+    return re.sub(r"[-_.]+", "-", match.group(1)).lower()
+
+
 class FunASROnnxReleaseContractTest(unittest.TestCase):
     def test_release_version_is_0_4_2(self):
         self.assertEqual(assigned_literal(read_setup_tree(), "VERSION_NUM"), EXPECTED_VERSION)
 
     def test_runtime_dependencies_keep_onnx_install_torch_free(self):
         requirements = setup_keyword_literal(read_setup_tree(), "install_requires")
-        names = {
-            requirement.split(";", 1)[0]
-            .split("[", 1)[0]
-            .split("=", 1)[0]
-            .split("<", 1)[0]
-            .split(">", 1)[0]
-            .strip()
-            .lower()
-            .replace("_", "-")
-            for requirement in requirements
-        }
+        names = {normalized_requirement_name(requirement) for requirement in requirements}
         self.assertIn("jieba", names)
         self.assertNotIn("torch", names)
+
+    def test_requirement_name_parser_handles_pep508_forms(self):
+        cases = {
+            "torch!=2.0": "torch",
+            "Torch_CUDA~=2.0": "torch-cuda",
+            'torch[distributed]>=2.0; python_version >= "3.11"': "torch",
+            "torch @ https://example.invalid/torch.whl": "torch",
+        }
+        for requirement, expected in cases.items():
+            with self.subTest(requirement=requirement):
+                self.assertEqual(normalized_requirement_name(requirement), expected)
 
     def test_package_source_has_no_torch_imports(self):
         offenders = []


### PR DESCRIPTION
## Summary

- bump `funasr-onnx` from `0.4.1` to the immutable `0.4.2` release candidate;
- add a release-contract test that requires `jieba`, rejects Torch as a runtime dependency, and rejects Torch imports in the ONNX package source;
- add Python 3.11/3.12 CI that builds the wheel and sdist, runs `twine check`, installs the wheel in a clean environment, runs `pip check`, imports all four public entry points, and uploads the release candidate artifact.

## Why

The source fixes for #2604 are already on `main`: SenseVoice post-processing is NumPy-only and the missing `jieba` dependency is declared. PyPI still serves `funasr-onnx==0.4.1`, however, so users continue to receive the old Torch-importing wheel. Re-uploading the existing version is not safe; this PR creates a new version and makes the release contract reproducible.

This PR does **not** close #2604 by itself. Keep the issue open until `0.4.2` is uploaded to PyPI and the downloaded PyPI wheel passes the same smoke test.

## Verification

- release contract: 4 tests passed;
- `python -m build`: wheel and sdist built successfully;
- `twine check`: both distributions passed;
- fresh Python 3.11.15 and 3.12.3 environments: 34 packages compatible, `funasr-onnx==0.4.2`, Torch absent, `jieba` present, and `Paraformer`, `Fsmn_vad`, `CT_Transformer`, `SenseVoiceSmall` all import successfully;
- real CPU inference from the newly built wheel, with Torch absent, using the official quantized SenseVoice ONNX model:
  - input: 16 kHz mono, 5.55 seconds;
  - output: `<|zh|><|NEUTRAL|><|Speech|><|withitn|>欢迎大家来体验达摩院推出的语音识别模型。`;
- Black, compileall, workflow semantic checks, and `git diff --check` passed.

Local release-candidate checksums:

```text
42243d2d5f91b679220206bdc4424861127bb7814693fae38ce4026f4e10cbca  funasr_onnx-0.4.2-py3-none-any.whl
c13e1d6b832c902afc6716a07d9ed70ec33394102a34bb8c0f3bb87ccfe65435  funasr_onnx-0.4.2.tar.gz
```

## Post-merge release gate

A maintainer still needs to upload the final artifacts with the project PyPI credential. After upload, download `funasr-onnx==0.4.2` from PyPI into fresh Python 3.11 and 3.12 environments and repeat the no-Torch dependency/import smoke before closing #2604.