### PR TITLE
Add realtime WebSocket session stats logging

### DIFF
--- a/funasr/bin/realtime_ws.py
+++ b/funasr/bin/realtime_ws.py
@@ -313,6 +313,16 @@ class HybridSpeakerTracker:
         self.all_embeddings.clear()
         self.last_speaker_id = 0
 
+    def session_stats(self):
+        return {
+            "speaker_history_chunks": len(self.all_chunks),
+            "speaker_history_embeddings": len(self.all_embeddings),
+            "speaker_history_limit": self.all_chunks.maxlen,
+            "speaker_centers": len(self.speaker_centers),
+            "speaker_center_limit": self.max_speakers,
+            "last_speaker_id": self.last_speaker_id,
+        }
+
 
 class RealtimeASRSession:
     """Manages a single streaming ASR session."""
@@ -601,6 +611,22 @@ class RealtimeASRSession:
                 "partial_start_ms": partial_start,
                 "duration_ms": duration_ms, "is_final": False}
 
+    def session_stats(self):
+        stats = {
+            "duration_ms": int(self.total_samples * 1000 / self.sample_rate),
+            "total_samples": self.total_samples,
+            "audio_buffer_samples": len(self.audio_buffer),
+            "audio_buffer_start_ms": int(
+                self.audio_buffer_start_sample * 1000 / self.sample_rate
+            ),
+            "locked_sentences": len(self.locked_sentences),
+            "partial_active": self.vad.current_speech_start is not None,
+            "last_decode_ms": int(self.last_decode_samples * 1000 / self.sample_rate),
+        }
+        if self.spk_tracker:
+            stats.update(self.spk_tracker.session_stats())
+        return stats
+
     def reset(self):
         self.audio_buffer = np.array([], dtype=np.float32)
         self.audio_buffer_start_sample = 0
@@ -686,6 +712,25 @@ async def run_session_work(args, operation, *operation_args, **operation_kwargs)
         return await asyncio.to_thread(operation, *operation_args, **operation_kwargs)
 
 
+def log_session_stats(session):
+    stats = session.session_stats()
+    logger.info(
+        "Session stats: duration_ms=%d audio_buffer_samples=%d "
+        "audio_buffer_start_ms=%d locked_sentences=%d partial_active=%s "
+        "speaker_history_chunks=%s speaker_history_embeddings=%s "
+        "speaker_centers=%s",
+        stats["duration_ms"],
+        stats["audio_buffer_samples"],
+        stats["audio_buffer_start_ms"],
+        stats["locked_sentences"],
+        stats["partial_active"],
+        stats.get("speaker_history_chunks", "-"),
+        stats.get("speaker_history_embeddings", "-"),
+        stats.get("speaker_centers", "-"),
+    )
+    return stats
+
+
 async def handle_client(websocket, args):
     vllm_engine, asr_kwargs, vad_model, spk_model = load_models(args)
     endpoint_mode = getattr(args, "endpoint_mode", "server")
@@ -706,6 +751,8 @@ async def handle_client(websocket, args):
 
     decode_interval = args.decode_interval
     last_decode_time = 0
+    stats_interval = getattr(args, "log_session_stats_interval", 0.0)
+    last_stats_time = time.time()
 
     try:
         async for message in websocket:
@@ -782,6 +829,13 @@ async def handle_client(websocket, args):
             elif isinstance(message, bytes) and session.is_active:
                 await run_session_work(args, session.add_audio, message)
                 now = time.time()
+                if (
+                    stats_interval
+                    and stats_interval > 0
+                    and now - last_stats_time >= stats_interval
+                ):
+                    log_session_stats(session)
+                    last_stats_time = now
                 if now - last_decode_time >= decode_interval and session.should_decode():
                     result = await run_session_work(args, session.decode, is_final=False)
                     await websocket.send(json.dumps(result))
@@ -868,6 +922,8 @@ def build_arg_parser():
                         help="WebSocket close handshake timeout in seconds.")
     parser.add_argument("--ws-max-size", type=int, default=10 * 1024 * 1024,
                         help="Maximum incoming WebSocket message size in bytes.")
+    parser.add_argument("--log-session-stats-interval", type=float, default=0.0,
+                        help="Log bounded long-session state every N seconds; <=0 disables.")
     return parser
 
 

--- a/tests/test_realtime_ws_service.py
+++ b/tests/test_realtime_ws_service.py
@@ -61,6 +61,7 @@ def test_cli_defaults_disable_speaker_and_bound_partial_window():
     assert args.enable_spk is False
     assert args.partial_window_sec == 15.0
     assert args.endpoint_mode == "server"
+    assert args.log_session_stats_interval == 0.0
 
 
 def test_cli_accepts_client_endpoint_mode():
@@ -112,6 +113,16 @@ def test_websocket_keepalive_kwargs_can_disable_ping():
     kwargs = module.build_websocket_serve_kwargs(args)
     assert kwargs["ping_interval"] is None
     assert kwargs["ping_timeout"] is None
+
+
+def test_cli_accepts_session_stats_interval():
+    module = load_service_module()
+
+    args = module.build_arg_parser().parse_args(
+        ["--log-session-stats-interval", "30"]
+    )
+
+    assert args.log_session_stats_interval == 30.0
 
 
 def test_create_speaker_tracker_skips_spk_when_disabled():
@@ -459,6 +470,31 @@ def test_two_hour_session_keeps_audio_bounded_and_duration_absolute():
     assert session._build_response(is_final=False)["duration_ms"] == 2 * 60 * 60 * 1000
 
 
+def test_session_stats_report_bounded_long_session_state():
+    module = load_service_module()
+    sample_rate = 10
+    session = module.RealtimeASRSession(
+        vllm_engine=DummyEngine(),
+        asr_kwargs={},
+        vad=SilentVad(),
+        sample_rate=sample_rate,
+        chunk_ms=1000,
+        audio_lookback_sec=5,
+    )
+    for _ in range(20):
+        session.add_audio(np.zeros(sample_rate, dtype=np.int16).tobytes())
+    session.locked_sentences = [{"text": "done", "start": 0, "end": 1000}]
+
+    stats = session.session_stats()
+
+    assert stats["duration_ms"] == 20000
+    assert stats["total_samples"] == 200
+    assert stats["audio_buffer_samples"] <= 50
+    assert stats["audio_buffer_start_ms"] == 15000
+    assert stats["locked_sentences"] == 1
+    assert stats["partial_active"] is False
+
+
 def test_completed_segment_uses_absolute_offsets_after_audio_compaction():
     module = load_service_module()
     sample_rate = 16000
@@ -647,7 +683,9 @@ def test_handler_keeps_event_loop_responsive_during_session_work(monkeypatch):
         async def send(self, message):
             self.sent.append(message)
 
-    monkeypatch.setattr(module, "load_models", lambda args: (object(), {}, object(), None))
+    monkeypatch.setattr(
+        module, "load_models", lambda args: (object(), {}, object(), None)
+    )
     monkeypatch.setattr(module, "DynamicStreamingVAD", lambda model: object())
     monkeypatch.setattr(module, "create_speaker_tracker", lambda model, args: None)
     monkeypatch.setattr(module, "RealtimeASRSession", BlockingSession)
@@ -680,3 +718,89 @@ def test_handler_keeps_event_loop_responsive_during_session_work(monkeypatch):
     assert gaps
     assert max(gaps) < 0.08
     assert BlockingSession.max_active_workers == 1
+
+
+def test_handler_logs_session_stats_on_configured_interval(monkeypatch):
+    module = load_service_module()
+    logged = []
+
+    class StatsSession:
+        def __init__(self, *args, **kwargs):
+            self.is_active = False
+            self.audio_buffer = np.zeros(1, dtype=np.float32)
+            self.total_samples = 0
+            self.audio_buffer_start_sample = 0
+
+        def reset(self):
+            pass
+
+        def add_audio(self, message):
+            self.total_samples += 1
+
+        def should_decode(self):
+            return False
+
+        def session_stats(self):
+            return {
+                "duration_ms": self.total_samples,
+                "audio_buffer_samples": 1,
+                "audio_buffer_start_ms": 0,
+                "locked_sentences": 0,
+                "partial_active": False,
+                "speaker_history_chunks": 0,
+                "speaker_history_embeddings": 0,
+                "speaker_centers": 0,
+            }
+
+    class FakeWebSocket:
+        remote_address = ("127.0.0.1", 12345)
+
+        def __init__(self):
+            self.messages = iter(["START", b"a", b"b", "STOP"])
+            self.sent = []
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.messages)
+            except StopIteration as error:
+                raise StopAsyncIteration from error
+
+        async def send(self, message):
+            self.sent.append(json.loads(message))
+
+    clock = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(module, "load_models", lambda args: (object(), {}, object(), None))
+    monkeypatch.setattr(module, "DynamicStreamingVAD", lambda model: object())
+    monkeypatch.setattr(module, "create_speaker_tracker", lambda model, args: None)
+    monkeypatch.setattr(module, "RealtimeASRSession", StatsSession)
+    monkeypatch.setattr(
+        module,
+        "log_session_stats",
+        lambda session: logged.append(session.session_stats()),
+    )
+    monkeypatch.setattr(module.time, "time", lambda: next(clock, 2.0))
+    args = types.SimpleNamespace(
+        device="cpu",
+        decode_interval=60.0,
+        partial_window_sec=15.0,
+        endpoint_mode="server",
+        log_session_stats_interval=1.0,
+    )
+
+    asyncio.run(module.handle_client(FakeWebSocket(), args))
+
+    assert logged == [
+        {
+            "duration_ms": 2,
+            "audio_buffer_samples": 1,
+            "audio_buffer_start_ms": 0,
+            "locked_sentences": 0,
+            "partial_active": False,
+            "speaker_history_chunks": 0,
+            "speaker_history_embeddings": 0,
+            "speaker_centers": 0,
+        }
+    ]


### PR DESCRIPTION
## Summary

Adds an opt-in realtime WebSocket diagnostic log for long-running sessions, especially the speaker-enabled disconnect/RTF regression tracked in #3101.

- adds `--log-session-stats-interval N` (default `0`, disabled)
- reports bounded session state: duration, retained audio samples/start offset, locked sentence count, partial-active state, speaker history chunks/embeddings, and speaker center count
- exposes `session_stats()` on the realtime session and speaker tracker so tests can verify the counters without loading real models

This does not change default runtime behavior. It gives users a concrete command-line switch for the next #3101 reproduction so we can tell whether state remains bounded when RTF grows.

## Validation

- `PYTHONPATH=. python -m pytest tests/test_realtime_ws_service.py -q` -> 23 passed
- `python -m compileall -q funasr/bin/realtime_ws.py tests/test_realtime_ws_service.py examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py`
- `git diff --check`

Ruff was not available in this ind-gpu8 Python environment (`No module named ruff`).

Closes no issue; supports #3101 diagnostics.