### PR TITLE
docs: add discovery list community entries

### DIFF
--- a/docs/community_projects.md
+++ b/docs/community_projects.md
@@ -35,6 +35,13 @@ These integrations are community-maintained. Their release cadence, hardware sup
 | [Fun-ASR-vLLM](https://github.com/yuekaizhang/Fun-ASR-vllm) | Community vLLM inference for Fun-ASR-Nano and Fun-ASR-MLT-Nano, including batch evaluation and NVIDIA Triton deployment. | [Setup and benchmarks](https://github.com/yuekaizhang/Fun-ASR-vllm#readme) and the deterministic ASR decoding fix in merged [#20](https://github.com/yuekaizhang/Fun-ASR-vllm/pull/20). |
 | [vad-burn](https://github.com/di-osc/vad-burn) | FSMN VAD inference in pure Rust with Python bindings, including offline, streaming, and CPU-only modes. | [Project README](https://github.com/di-osc/vad-burn#readme) and the FunASR showcase in [#3106](https://github.com/modelscope/FunASR/issues/3106). |
 
+## Discovery lists
+
+| Project | What is integrated | Start here |
+|---|---|---|
+| [awesome-python](https://github.com/vinta/awesome-python) | SenseVoice is listed in the Speech Recognition section of one of the largest Python resource directories, making it easier for Python developers to discover local multilingual ASR. | [Project README](https://github.com/vinta/awesome-python#readme) and merged [#3246](https://github.com/vinta/awesome-python/pull/3246). |
+| [speech-trident](https://github.com/ga642381/speech-trident) | SenseVoice is listed among speech/audio language models in a curated speech LLM, representation learning, and codec model directory. | [Project README](https://github.com/ga642381/speech-trident#readme) and merged [#31](https://github.com/ga642381/speech-trident/pull/31). |
+
 ## Before adopting an integration
 
 - Follow the upstream project's installation and release notes; do not assume its dependency versions match FunASR `main`.

--- a/docs/community_projects_zh.md
+++ b/docs/community_projects_zh.md
@@ -35,6 +35,13 @@
 | [Fun-ASR-vLLM](https://github.com/yuekaizhang/Fun-ASR-vllm) | 面向 Fun-ASR-Nano 和 Fun-ASR-MLT-Nano 的社区 vLLM 推理实现，包含批量评测和 NVIDIA Triton 部署。 | [安装与 Benchmark](https://github.com/yuekaizhang/Fun-ASR-vllm#readme) 和已合并 [#20](https://github.com/yuekaizhang/Fun-ASR-vllm/pull/20) 中的确定性 ASR 解码修复。 |
 | [vad-burn](https://github.com/di-osc/vad-burn) | 纯 Rust FSMN VAD 推理与 Python binding，支持离线、流式和纯 CPU 模式。 | [项目 README](https://github.com/di-osc/vad-burn#readme) 和 FunASR showcase [#3106](https://github.com/modelscope/FunASR/issues/3106)。 |
 
+## 发现入口
+
+| 项目 | 已集成能力 | 从这里开始 |
+|---|---|---|
+| [awesome-python](https://github.com/vinta/awesome-python) | SenseVoice 已收录到大型 Python 资源目录的 Speech Recognition 部分，方便 Python 开发者发现本地多语种 ASR。 | [项目 README](https://github.com/vinta/awesome-python#readme) 和已合并 [#3246](https://github.com/vinta/awesome-python/pull/3246)。 |
+| [speech-trident](https://github.com/ga642381/speech-trident) | SenseVoice 已收录到 speech/audio language models 目录，面向语音 LLM、representation learning 和 codec model 读者。 | [项目 README](https://github.com/ga642381/speech-trident#readme) 和已合并 [#31](https://github.com/ga642381/speech-trident/pull/31)。 |
+
 ## 采用社区集成前
 
 - 按上游项目的安装和发布说明操作，不要假设其依赖版本与 FunASR `main` 完全一致。


### PR DESCRIPTION
## Summary
- add a Discovery lists section to the English and Chinese community integration pages
- include merged SenseVoice entries in awesome-python and speech-trident

## Verification
- checked exactly one awesome-python and one speech-trident row in each community page
- checked all upstream discovery-list links return HTTP 200
- git diff --check
