### PR TITLE
docs: add voiceai discovery listing

### DIFF
--- a/docs/community_projects.md
+++ b/docs/community_projects.md
@@ -45,6 +45,7 @@ These integrations are community-maintained. Their release cadence, hardware sup
 |---|---|---|
 | [awesome-python](https://github.com/vinta/awesome-python) | SenseVoice is listed in the Speech Recognition section of one of the largest Python resource directories, making it easier for Python developers to discover local multilingual ASR. | [Project README](https://github.com/vinta/awesome-python#readme) and merged [#3246](https://github.com/vinta/awesome-python/pull/3246). |
 | [speech-trident](https://github.com/ga642381/speech-trident) | SenseVoice is listed among speech/audio language models in a curated speech LLM, representation learning, and codec model directory. | [Project README](https://github.com/ga642381/speech-trident#readme) and merged [#31](https://github.com/ga642381/speech-trident/pull/31). |
+| [voiceai](https://github.com/mahimairaja/voiceai) | A voice-AI agent resource map that lists FunASR and SenseVoice in its Speech-to-text (STT / ASR) section, pointing agent builders toward self-hosted local ASR and multilingual speech understanding options. | [English README](https://github.com/mahimairaja/voiceai#readme), [Chinese README](https://github.com/mahimairaja/voiceai/blob/main/README_zh.md), and merged [#16](https://github.com/mahimairaja/voiceai/pull/16). |
 
 ## Before adopting an integration
 

--- a/docs/community_projects_zh.md
+++ b/docs/community_projects_zh.md
@@ -45,6 +45,7 @@
 |---|---|---|
 | [awesome-python](https://github.com/vinta/awesome-python) | SenseVoice 已收录到大型 Python 资源目录的 Speech Recognition 部分，方便 Python 开发者发现本地多语种 ASR。 | [项目 README](https://github.com/vinta/awesome-python#readme) 和已合并 [#3246](https://github.com/vinta/awesome-python/pull/3246)。 |
 | [speech-trident](https://github.com/ga642381/speech-trident) | SenseVoice 已收录到 speech/audio language models 目录，面向语音 LLM、representation learning 和 codec model 读者。 | [项目 README](https://github.com/ga642381/speech-trident#readme) 和已合并 [#31](https://github.com/ga642381/speech-trident/pull/31)。 |
+| [voiceai](https://github.com/mahimairaja/voiceai) | 面向 Voice AI agent builder 的资源地图，在 Speech-to-text (STT / ASR) 部分同时收录 FunASR 和 SenseVoice，帮助开发者发现自托管本地 ASR 与多语种语音理解选项。 | [英文 README](https://github.com/mahimairaja/voiceai#readme)、[中文 README](https://github.com/mahimairaja/voiceai/blob/main/README_zh.md) 和已合并 [#16](https://github.com/mahimairaja/voiceai/pull/16)。 |
 
 ## 采用社区集成前
 


### PR DESCRIPTION
## Summary
- add voiceai to the official FunASR community discovery lists
- document that voiceai lists both FunASR and SenseVoice in its Speech-to-text (STT / ASR) section
- link the English README, Chinese README, and merged upstream PR #16

## Validation
- rg -n "voiceai|Voice AI agent|FunASR and SenseVoice" docs/community_projects.md docs/community_projects_zh.md
- rg -n "FunASR|SenseVoice|Speech-to-text|语音转文字" /cpfs_speech/user/zhifu.gzf/codebase/voiceai/README.md /cpfs_speech/user/zhifu.gzf/codebase/voiceai/README_zh.md
- git diff --check
- curl link checks for voiceai README, Chinese README, and PR #16 returned 200