### PR TITLE
docs: quote current FunASR install commands

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -44,7 +44,7 @@ Install vLLM first, choosing a version compatible with your NVIDIA driver's CUDA
 pip install "vllm==0.19.1"   # adjust to your driver CUDA; see note below
 
 # 2) Then FunASR and the rest.
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 
 cd /path/to/FunASR && pip install -e .
 ```

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -45,7 +45,7 @@
 pip install "vllm==0.19.1"   # 按你的驱动 CUDA 调整;见下方说明
 
 # 2) 再装 FunASR 与其余依赖。
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
 cd /path/to/FunASR && pip install -e .

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -45,7 +45,7 @@
 pip install "vllm==0.19.1"   # 按你的驱动 CUDA 调整;见下方说明
 
 # 2) 再装 FunASR 与其余依赖。
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
 cd /path/to/FunASR && pip install -e .

--- a/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md
+++ b/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 ```
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 ```
 
 ## Data Prepare

--- a/examples/industrial_data_pretraining/fun_asr_nano/docs/fintune_zh.md
+++ b/examples/industrial_data_pretraining/fun_asr_nano/docs/fintune_zh.md
@@ -5,7 +5,7 @@
 ## 安装训练环境
 
 ```
-pip install funasr>=1.3.0
+pip install "funasr>=1.3.19"
 ```
 
 ## 数据准备

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+DOCS_WITH_CURRENT_FUNASR_INSTALL = [
+    "docs/vllm_guide.md",
+    "docs/vllm_guide_zh.md",
+    "docs/vllm_guide_zh_v2.md",
+    "examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md",
+    "examples/industrial_data_pretraining/fun_asr_nano/docs/fintune_zh.md",
+]
+
+
+def test_current_funasr_install_commands_are_quoted():
+    for relpath in DOCS_WITH_CURRENT_FUNASR_INSTALL:
+        text = (ROOT / relpath).read_text()
+        assert '"funasr>=1.3.19"' in text
+        assert "funasr>=1.3.0" not in text
+        assert not re.search(r"pip install funasr>=", text)


### PR DESCRIPTION
## Summary
- update FunASR-Nano vLLM and finetune docs from funasr>=1.3.0 to funasr>=1.3.19
- quote pip specifiers as "funasr>=1.3.19" so shells do not treat > as redirection
- add a focused docs regression test for these install commands

## Validation
- python3 -m pytest tests/test_docs_funasr_install_commands.py -q
- python3 -m py_compile tests/test_docs_funasr_install_commands.py
- PyPI JSON confirms funasr 1.3.19 exists
- git diff --check