### PR TITLE
fix(server): segment text-only OpenAI transcription responses

### DIFF
--- a/funasr/bin/_server_app.py
+++ b/funasr/bin/_server_app.py
@@ -26,6 +26,67 @@ except ImportError:
 logger = logging.getLogger("funasr.server")
 
 
+def _split_text_for_openai_segments(text: str, max_chars: int = 80):
+    """Split unsegmented ASR text into readable OpenAI-compatible cues."""
+    text = text.strip()
+    if not text:
+        return []
+
+    words = text.split()
+    if not words:
+        return [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
+
+    parts = []
+    current = []
+    current_len = 0
+    for word in words:
+        next_len = len(word) if not current else current_len + 1 + len(word)
+        if current and next_len > max_chars:
+            parts.append(" ".join(current))
+            current = []
+            current_len = 0
+
+        current.append(word)
+        current_len = len(word) if current_len == 0 else current_len + 1 + len(word)
+        if word[-1:] in ".!?;:" and current_len >= max_chars // 2:
+            parts.append(" ".join(current))
+            current = []
+            current_len = 0
+
+    if current:
+        parts.append(" ".join(current))
+
+    if any(len(part) > max_chars for part in parts):
+        return [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
+
+    return parts
+
+
+def build_openai_fallback_segments(text: str, duration: float, max_chars: int = 80):
+    """Build coarse timestamped segments when a backend returns text only."""
+    parts = _split_text_for_openai_segments(text, max_chars=max_chars)
+    if not parts:
+        return []
+    if len(parts) == 1 or duration <= 0:
+        return [{"start": 0.0, "end": max(float(duration), 0.0), "text": parts[0]}]
+
+    total_chars = sum(len(part) for part in parts)
+    if total_chars <= 0:
+        return [{"start": 0.0, "end": float(duration), "text": text.strip()}]
+
+    segments = []
+    consumed = 0
+    previous_end = 0.0
+    for i, part in enumerate(parts):
+        consumed += len(part)
+        end = float(duration) if i == len(parts) - 1 else float(duration) * consumed / total_chars
+        end = max(end, previous_end)
+        segments.append({"start": round(previous_end, 3), "end": round(end, 3), "text": part})
+        previous_end = end
+
+    return segments
+
+
 def prepare_audio_for_inference(audio_data, sr, target_sr=16000):
     """Return mono float32 audio at target_sr for ASR inference."""
     audio_data = np.asarray(audio_data)
@@ -174,6 +235,10 @@ def create_app(device: str = "cuda", preload_model: str = "auto") -> FastAPI:
     def _process_fallback(model_name, audio_path, language=None):
         """Process with non-LLM model (SenseVoice/Paraformer)."""
         model = _load_fallback(model_name)
+        try:
+            duration = float(sf.info(audio_path).duration)
+        except Exception:
+            duration = 0.0
         kwargs = {"input": audio_path, "batch_size": 1}
         if language:
             kwargs["language"] = language
@@ -188,7 +253,9 @@ def create_app(device: str = "cuda", preload_model: str = "auto") -> FastAPI:
                     "text": re.sub(r'<\|[^|]*\|>', '', s.get("text", "")).strip(),
                     "speaker": s.get("spk"),
                 })
-        return {"text": text, "segments": segments}
+        if not segments and text:
+            segments = build_openai_fallback_segments(text, duration)
+        return {"text": text, "segments": segments, "duration": duration}
 
     # Pre-load
     if preload_model == "fun-asr-nano":

--- a/tests/test_server_app_openai_segments.py
+++ b/tests/test_server_app_openai_segments.py
@@ -1,0 +1,58 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVICE_PATH = REPO_ROOT / "funasr" / "bin" / "_server_app.py"
+
+
+def load_server_app(monkeypatch):
+    fastapi_stub = types.ModuleType("fastapi")
+    fastapi_stub.FastAPI = object
+    fastapi_stub.UploadFile = object
+    fastapi_stub.File = lambda *args, **kwargs: None
+    fastapi_stub.Form = lambda *args, **kwargs: None
+    fastapi_stub.HTTPException = Exception
+
+    responses_stub = types.ModuleType("fastapi.responses")
+    responses_stub.JSONResponse = lambda content=None: content
+
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_stub)
+    monkeypatch.setitem(sys.modules, "fastapi.responses", responses_stub)
+
+    module_name = "funasr_server_app_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, SERVICE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fallback_segments_split_long_fun_asr_server_text(monkeypatch):
+    module = load_server_app(monkeypatch)
+    text = (
+        "i believe that this nation should commit itself to achieving the goal before this decade is out "
+        "of landing a man on the moon and returning him safely to the earth "
+        "no single space project in this period will be more impressive to mankind "
+        "or more important for the long range exploration of space"
+    )
+
+    segments = module.build_openai_fallback_segments(text, duration=21.0)
+
+    assert len(segments) > 1
+    assert segments[0]["start"] == 0.0
+    assert segments[-1]["end"] == 21.0
+    assert all(segment["end"] >= segment["start"] for segment in segments)
+    assert all(len(segment["text"]) <= 80 for segment in segments)
+    assert " ".join(segment["text"] for segment in segments) == text
+
+
+def test_fallback_segments_keep_short_text_single_cue(monkeypatch):
+    module = load_server_app(monkeypatch)
+
+    assert module.build_openai_fallback_segments("hello", duration=1.25) == [
+        {"start": 0.0, "end": 1.25, "text": "hello"}
+    ]


### PR DESCRIPTION
## Summary

Fixes the OpenAI-compatible `/v1/audio/transcriptions` fallback path for non-vLLM models such as `sensevoice` / `paraformer` when the underlying `AutoModel.generate()` result returns text but no `sentence_info`.

Before this patch, `response_format=verbose_json` returned `segments: []` even when `text` was populated, which causes OpenAI-compatible clients that rely on `segments` for subtitles to render one large cue or lose timing entirely.

This patch:

- records fallback audio duration via `soundfile.info()`
- preserves model-provided `sentence_info` when available
- builds coarse OpenAI-style segments from long text-only results when `sentence_info` is missing
- keeps short text-only responses as one cue
- adds lightweight tests for the Kennedy-style long-text / empty-segments response shape

## Validation

```text
python3 -m pytest tests/test_server_app_openai_segments.py tests/test_fun_asr_nano_openai_response.py -q
# 4 passed

python3 -m py_compile funasr/bin/_server_app.py tests/test_server_app_openai_segments.py

git diff --check
```
