### PR TITLE
docs: surface GGUF runtime on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@ print(res[0]["sentence_info"])</pre>
             <h2 class="section-title">What's New</h2>
             <p class="section-subtitle">The public docs now track the latest README and main-branch capabilities.</p>
             <div class="grid-3">
+                <div class="card"><h3>llama.cpp / GGUF Runtime</h3><p>runtime-llamacpp-v0.1.8 adds a Linux Vulkan package for SenseVoiceSmall GGUF. Run the self-contained binary with <code>--backend vulkan</code> on supported GPUs.</p><p><a href="deployment-matrix.html#runtime-llamacpp-v0.1.8">Choose the GGUF runtime</a></p></div>
                 <div class="card"><h3>vLLM Inference Engine</h3><p>2-3x faster LLM decoding for Fun-ASR-Nano, with tensor parallel batch inference and real-time WebSocket service.</p><p><a href="vllm.html">Read the vLLM guide</a></p></div>
                 <div class="card"><h3>Agent Infrastructure</h3><p><code>funasr-server</code> exposes OpenAI-compatible transcription APIs; MCP and voice-input examples connect local ASR to AI tools.</p><p><a href="agent.html">Set up Agent integration</a></p></div>
                 <div class="card"><h3>Benchmark Report</h3><p>Long-form benchmark results cover SenseVoice, Paraformer, Fun-ASR-Nano, GLM-ASR, and Whisper variants on GPU and CPU.</p><p><a href="benchmark.html">View benchmark</a></p></div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -93,6 +93,7 @@ print(res[0]["sentence_info"])</pre>
             <h2 class="section-title">最新动态</h2>
             <p class="section-subtitle">网站文档已对齐 README 和 main 分支最新能力。</p>
             <div class="grid-3">
+                <div class="card"><h3>llama.cpp / GGUF 运行时</h3><p>runtime-llamacpp-v0.1.8 新增 SenseVoiceSmall GGUF 的 Linux Vulkan 包。支持 Vulkan 的 GPU 可用自包含二进制和 <code>--backend vulkan</code> 运行。</p><p><a href="deployment-matrix.html#runtime-llamacpp-v0.1.8">选择 GGUF 运行时</a></p></div>
                 <div class="card"><h3>vLLM 推理引擎</h3><p>Fun-ASR-Nano LLM 解码加速 2-3 倍，支持 tensor parallel 批量推理和实时 WebSocket 服务。</p><p><a href="vllm.html">阅读 vLLM 文档</a></p></div>
                 <div class="card"><h3>Agent 基础设施</h3><p><code>funasr-server</code> 提供 OpenAI 兼容转写 API；MCP 和语音输入示例可把本地 ASR 接入 AI 工具。</p><p><a href="agent.html">配置 Agent 集成</a></p></div>
                 <div class="card"><h3>性能评测</h3><p>长音频评测覆盖 SenseVoice、Paraformer、Fun-ASR-Nano、GLM-ASR 和 Whisper 变体，包含 GPU/CPU 结果。</p><p><a href="benchmark.html">查看评测</a></p></div>


### PR DESCRIPTION
## Summary
- add an English homepage card for runtime-llamacpp-v0.1.8 and the Linux Vulkan GGUF runtime
- add the matching Chinese homepage card
- link both cards to the deployment matrix runtime anchor

## Validation
- homepage runtime card text assertions
- HTML link parser assertions
- git diff --check