### PR TITLE
docs: require FunASR 1.3.23 for Nano guides

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -44,7 +44,7 @@ Install vLLM first, choosing a version compatible with your NVIDIA driver's CUDA
 pip install "vllm==0.19.1"   # adjust to your driver CUDA; see note below
 
 # 2) Then FunASR and the rest.
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 
 cd /path/to/FunASR && pip install -e .
 ```

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -45,7 +45,7 @@
 pip install "vllm==0.19.1"   # 按你的驱动 CUDA 调整;见下方说明
 
 # 2) 再装 FunASR 与其余依赖。
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
 cd /path/to/FunASR && pip install -e .

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -45,7 +45,7 @@
 pip install "vllm==0.19.1"   # 按你的驱动 CUDA 调整;见下方说明
 
 # 2) 再装 FunASR 与其余依赖。
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
 cd /path/to/FunASR && pip install -e .

--- a/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md
+++ b/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 ```
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 ```
 
 ## Data Prepare

--- a/examples/industrial_data_pretraining/fun_asr_nano/docs/fintune_zh.md
+++ b/examples/industrial_data_pretraining/fun_asr_nano/docs/fintune_zh.md
@@ -5,7 +5,7 @@
 ## 安装训练环境
 
 ```
-pip install "funasr>=1.3.19"
+pip install "funasr>=1.3.23"
 ```
 
 ## 数据准备

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -17,7 +17,7 @@ DOCS_WITH_CURRENT_FUNASR_INSTALL = [
 def test_current_funasr_install_commands_are_quoted():
     for relpath in DOCS_WITH_CURRENT_FUNASR_INSTALL:
         text = (ROOT / relpath).read_text()
-        assert '"funasr>=1.3.19"' in text
+        assert '"funasr>=1.3.23"' in text
         assert "funasr>=1.3.0" not in text
         assert not re.search(r"pip install funasr>=", text)
 


### PR DESCRIPTION
## Summary
- update current Fun-ASR-Nano vLLM and finetuning install docs from `funasr>=1.3.19` to `funasr>=1.3.23`
- update the docs regression test to guard the current public PyPI release floor
- leave historical release-note text unchanged

## Validation
- asserted the changed current docs and regression test use `funasr>=1.3.23` with no `funasr>=1.3.19` remaining in those files
- `python3 -m pytest -q tests/test_docs_funasr_install_commands.py`
- `git diff --check`
