### PR TITLE
docs: refresh remaining stale FunASR links

### DIFF
--- a/docs/m2met2/Baseline.md
+++ b/docs/m2met2/Baseline.md
@@ -6,7 +6,7 @@ We will release an E2E SA-ASR baseline conducted on [FunASR](https://github.com/
 
 ## Quick start
 To run the baseline, first you need to install FunASR and ModelScope. ([installation](https://github.com/modelscope/FunASR#installation))
-There are two startup scripts, `run.sh` for training and evaluating on the old eval and test sets, and `run_m2met_2023_infer.sh` for inference on the new test set of the Multi-Channel Multi-Party Meeting Transcription 2.0 ([M2MeT2.0](https://alibaba-damo-academy.github.io/FunASR/m2met2/index.html)) Challenge.  
+There are two startup scripts, `run.sh` for training and evaluating on the old eval and test sets, and `run_m2met_2023_infer.sh` for inference on the new test set of the Multi-Channel Multi-Party Meeting Transcription 2.0 ([M2MeT2.0](https://modelscope.github.io/FunASR/m2met2/index.html)) Challenge.
 Before running `run.sh`, you must manually download and unpack the [AliMeeting](http://www.openslr.org/119/) corpus and place it in the `./dataset` directory:
 ```shell
 dataset

--- a/examples/industrial_data_pretraining/monotonic_aligner/README_zh.md
+++ b/examples/industrial_data_pretraining/monotonic_aligner/README_zh.md
@@ -3,7 +3,7 @@
 # 语音识别
 
 > **注意**:
-> pipeline 支持 [modelscope模型仓库](https://alibaba-damo-academy.github.io/FunASR/en/model_zoo/modelscope_models.html#pretrained-models-on-modelscope) 中的所有模型进行推理和微调。这里我们以典型模型作为示例来演示使用方法。
+> pipeline 支持 [modelscope模型仓库](https://github.com/modelscope/FunASR/tree/main/model_zoo#pretrained-models-on-modelscope) 中的所有模型进行推理和微调。这里我们以典型模型作为示例来演示使用方法。
 
 ## 推理
 
@@ -20,7 +20,7 @@ print(res)
 
 ### API接口说明
 #### AutoModel 定义
-- `model`: [模型仓库](https://alibaba-damo-academy.github.io/FunASR/en/model_zoo/modelscope_models.html#pretrained-models-on-modelscope) 中的模型名称，或本地磁盘中的模型路径
+- `model`: [模型仓库](https://github.com/modelscope/FunASR/tree/main/model_zoo#pretrained-models-on-modelscope) 中的模型名称，或本地磁盘中的模型路径
 - `device`: `cuda`（默认），使用 GPU 进行推理。如果为`cpu`，则使用 CPU 进行推理
 - `ncpu`: `None` （默认），设置用于 CPU 内部操作并行性的线程数
 - `output_dir`: `None` （默认），如果设置，输出结果的输出路径

--- a/examples/industrial_data_pretraining/sense_voice/README.md
+++ b/examples/industrial_data_pretraining/sense_voice/README.md
@@ -241,7 +241,7 @@ fastapi run --port 50000
 ### Requirements
 
 ```shell
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
 

--- a/examples/industrial_data_pretraining/sense_voice/README_ja.md
+++ b/examples/industrial_data_pretraining/sense_voice/README_ja.md
@@ -243,7 +243,7 @@ fastapi run --port 50000
 ### トレーニング環境のインストール
 
 ```shell
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
 

--- a/examples/industrial_data_pretraining/sense_voice/README_zh.md
+++ b/examples/industrial_data_pretraining/sense_voice/README_zh.md
@@ -260,7 +260,7 @@ fastapi run --port 50000
 ### 安装训练环境
 
 ```shell
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
 

--- a/runtime/html5/readme.md
+++ b/runtime/html5/readme.md
@@ -31,7 +31,7 @@ Support the deployment of Python and C++ versions, where
 pip3 install -U modelscope funasr flask
 # Users in mainland China, if encountering network issues, can install with the following command:
 # pip3 install -U modelscope funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 ```
 
 #### Start ASR Service

--- a/runtime/html5/readme_zh.md
+++ b/runtime/html5/readme_zh.md
@@ -31,7 +31,7 @@
 pip3 install -U modelscope funasr flask
 # 中国大陆用户，如果遇到网络问题，可以通过下面指令安装：
 # pip3 install -U modelscope funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 ```
 
 #### 启动ASR服务

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -31,6 +31,13 @@ PUBLIC_DOCS_SHOULD_USE_CURRENT_HOSTS = [
     "runtime/python/libtorch/README.md",
     "runtime/python/onnxruntime/README.md",
     "runtime/python/websocket/README.md",
+    "docs/m2met2/Baseline.md",
+    "examples/industrial_data_pretraining/monotonic_aligner/README_zh.md",
+    "examples/industrial_data_pretraining/sense_voice/README.md",
+    "examples/industrial_data_pretraining/sense_voice/README_zh.md",
+    "examples/industrial_data_pretraining/sense_voice/README_ja.md",
+    "runtime/html5/readme.md",
+    "runtime/html5/readme_zh.md",
 ]
 
 


### PR DESCRIPTION
## Summary
- refresh remaining stale FunASR public docs links in M2MeT2, monotonic aligner, SenseVoice examples, and HTML5 runtime docs
- replace old Alibaba GitHub clone URLs with the current ModelScope repository URL
- extend the public-doc host regression test to cover these pages

## Tests
- python3 -m pytest -q tests/test_docs_funasr_install_commands.py
- python3 -m pytest -q tests/test_markdown_relative_links.py
- git diff --check
