### PR TITLE
chore: refresh awesome MCP tracking status

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -123,8 +123,8 @@ KNOWN_REVIEW_GATES = {
         "reason": "Contributor-owned branch is dirty; conflict recipe already posted from the FunASR side",
     },
     "punkpeye/awesome-mcp-servers#7153": {
-        "action": "submit Glama",
-        "reason": "Glama listing and score badge required before review",
+        "action": "wait for maintainer review",
+        "reason": "Glama listing and score badge are live",
     },
     "mem0ai/mem0#5571": {
         "action": "wait for preview authorization",

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -697,8 +697,8 @@ def test_collect_integration_metrics_applies_known_review_gate(monkeypatch):
 
     integration = metrics["integrations"][0]
     assert integration["checks"]["state"] == "success"
-    assert integration["known_review_gate_reason"] == "Glama listing and score badge required before review"
-    assert integration["next_action"] == "submit Glama"
+    assert integration["known_review_gate_reason"] == "Glama listing and score badge are live"
+    assert integration["next_action"] == "wait for maintainer review"
 
 
 def test_collect_integration_metrics_surfaces_pending_cla_status(monkeypatch):
@@ -1246,7 +1246,7 @@ def test_format_integration_markdown_lists_active_operator_queue():
     assert "wait for maintainer preliminary PR" not in active_queue
 
 
-def test_format_integration_markdown_lists_manual_handoff_gates():
+def test_format_integration_markdown_excludes_satisfied_review_gates_from_handoff():
     module = load_growth_metrics_module()
     metrics = {
         "collected_at_utc": "2026-07-02T00:00:00+00:00",
@@ -1260,8 +1260,8 @@ def test_format_integration_markdown_lists_manual_handoff_gates():
                 "repo_forks": 12_000,
                 "updated_at": "2026-06-16T04:21:55Z",
                 "updated_age_days": 16,
-                "next_action": "submit Glama",
-                "known_review_gate_reason": "Glama listing and score badge required before review",
+                "next_action": "wait for maintainer review",
+                "known_review_gate_reason": "Glama listing and score badge are live",
                 "checks": {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
             },
             {
@@ -1281,14 +1281,9 @@ def test_format_integration_markdown_lists_manual_handoff_gates():
 
     output = module.format_integration_markdown(metrics)
 
-    active_queue = output.split("## Active operator queue", 1)[1].split("## Manual handoff gates", 1)[0]
-    manual_gates = output.split("## Manual handoff gates", 1)[1].split("## Manual review gates", 1)[0]
+    active_queue = output.split("## Active operator queue", 1)[1].split("## Manual review gates", 1)[0]
     assert "punkpeye/awesome-mcp-servers#7153" not in active_queue
-    assert (
-        "- [punkpeye/awesome-mcp-servers#7153](https://github.com/punkpeye/awesome-mcp-servers/pull/7153): "
-        "submit Glama; Glama listing and score badge required before review"
-    ) in manual_gates
-    assert "huggingface/optimum-intel#1801" not in manual_gates
+    assert "## Manual handoff gates" not in output
 
 
 def test_format_integration_markdown_lists_known_review_gates():
@@ -1305,8 +1300,8 @@ def test_format_integration_markdown_lists_known_review_gates():
                 "repo_forks": 12_000,
                 "updated_at": "2026-06-16T04:21:55Z",
                 "updated_age_days": 14,
-                "next_action": "submit Glama",
-                "known_review_gate_reason": "Glama listing and score badge required before review",
+                "next_action": "wait for maintainer review",
+                "known_review_gate_reason": "Glama listing and score badge are live",
                 "checks": {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
             }
         ],
@@ -1317,7 +1312,7 @@ def test_format_integration_markdown_lists_known_review_gates():
     assert "## Manual review gates" in output
     assert (
         "- [punkpeye/awesome-mcp-servers#7153](https://github.com/punkpeye/awesome-mcp-servers/pull/7153): "
-        "Glama listing and score badge required before review"
+        "Glama listing and score badge are live"
     ) in output
 
 


### PR DESCRIPTION
## Summary
- update awesome-mcp-servers #7153 tracking after Glama listing and badge went live
- keep the PR in maintainer-review state instead of the manual Glama handoff queue
- refresh growth metrics tests for the new queue classification

## Tests
- python3 -m pytest -q tests/test_collect_growth_metrics.py -k 'known_review_gate or satisfied_review_gates or lists_known_review_gates'
- python3 -m pytest -q tests/test_collect_growth_metrics.py
- python3 scripts/collect_growth_metrics.py --integrations --format markdown
