### PR TITLE
docs: require FunASR 1.3.25 for Nano guides

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -44,7 +44,7 @@ Install vLLM first, choosing a version compatible with your NVIDIA driver's CUDA
 pip install "vllm==0.19.1"   # adjust to your driver CUDA; see note below
 
 # 2) Then FunASR and the rest.
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.25"
 
 cd /path/to/FunASR && pip install -e .
 ```

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -45,7 +45,7 @@
 pip install "vllm==0.19.1"   # 按你的驱动 CUDA 调整;见下方说明
 
 # 2) 再装 FunASR 与其余依赖。
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.25"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
 cd /path/to/FunASR && pip install -e .

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -45,7 +45,7 @@
 pip install "vllm==0.19.1"   # 按你的驱动 CUDA 调整;见下方说明
 
 # 2) 再装 FunASR 与其余依赖。
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.25"
 pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipart
 
 cd /path/to/FunASR && pip install -e .

--- a/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md
+++ b/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 ```
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.25"
 ```
 
 ## Data Prepare

--- a/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune_zh.md
+++ b/examples/industrial_data_pretraining/fun_asr_nano/docs/finetune_zh.md
@@ -5,7 +5,7 @@
 ## 安装训练环境
 
 ```
-pip install "funasr>=1.3.23"
+pip install "funasr>=1.3.25"
 ```
 
 ## 数据准备

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -44,7 +44,7 @@ PUBLIC_DOCS_SHOULD_USE_CURRENT_HOSTS = [
 def test_current_funasr_install_commands_are_quoted():
     for relpath in DOCS_WITH_CURRENT_FUNASR_INSTALL:
         text = (ROOT / relpath).read_text()
-        assert '"funasr>=1.3.23"' in text
+        assert '"funasr>=1.3.25"' in text
         assert "funasr>=1.3.0" not in text
         assert not re.search(r"pip install funasr>=", text)
 


### PR DESCRIPTION
## Summary
- update Fun-ASR-Nano vLLM and finetuning install commands to the current funasr 1.3.25 release
- keep the docs regression test aligned so current Nano install docs do not drift back to older release floors

## Verification
- python3 -m pytest -q tests/test_docs_funasr_install_commands.py
- python3 -m pytest -q tests/test_markdown_relative_links.py
- python3 -m pytest -q tests/test_realtime_ws_service.py -k 'postprocess_hotwords or postprocess_hotword_file'
- git diff --check