### PR TITLE
chore: classify external review wait states

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -114,6 +114,14 @@ KNOWN_EXTERNAL_CHECK_FAILURES = {
         },
         "reason": "Current c70504e failures are unrelated OpenVINO matrix failures in Pix2Struct, image-text quantization/export, and tiny-random T5; direct cleanup mirror #1856 was closed for maintainer preliminary PR",
         "action": "wait for maintainer preliminary PR",
+    },
+    "ray-project/ray#64053": {
+        "failed_check_names": {
+            "buildkite/microcheck",
+            "docs/readthedocs.com:anyscale-ray",
+        },
+        "reason": "Current Ray failures are Buildkite/ReadTheDocs gates already triaged; the remaining PR-local Black fix is waiting on the contributor branch owner",
+        "action": "wait for contributor branch update",
     }
 }
 KNOWN_REVIEW_GATES = {
@@ -147,6 +155,9 @@ KNOWN_REVIEW_GATES = {
     }
 }
 KNOWN_ASSISTED_REVIEW_REQUESTS = {
+    "huggingface/transformers#46180": {
+        "reason": "checks are green and the remaining blocker is an active maintainer-held review thread",
+    },
     "infiniflow/ragflow#16473": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },
@@ -310,6 +321,7 @@ PASSIVE_INTEGRATION_ACTIONS = {
     "preview auth gate",
     "resolve CLA",
     "wait for checks",
+    "wait for contributor branch update",
     "wait for maintainer preliminary PR",
     "wait for maintainer rerun",
     "wait for maintainer review",

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -476,6 +476,50 @@ def test_collect_integration_metrics_classifies_known_external_ci_failure(monkey
     assert integration["next_action"] == "wait for maintainer rerun"
 
 
+def test_collect_integration_metrics_classifies_ray_docs_infra_failure(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/ray-project/ray/pulls/64053":
+            return {
+                "number": 64053,
+                "title": "docs(serve): add FunASR ASR integration example",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "html_url": "https://github.com/ray-project/ray/pull/64053",
+                "updated_at": "2026-07-22T13:46:40Z",
+                "head": {"sha": "9b2a3b3", "ref": "issue-64052"},
+                "base": {"ref": "master"},
+                "user": {"login": "nh-atuan"},
+            }
+        if url == "https://api.github.com/repos/ray-project/ray/commits/9b2a3b3/status":
+            return {
+                "state": "failure",
+                "statuses": [
+                    {"context": "buildkite/microcheck", "state": "failure"},
+                    {"context": "docs/readthedocs.com:anyscale-ray", "state": "failure"},
+                ],
+            }
+        if url == "https://api.github.com/repos/ray-project/ray/commits/9b2a3b3/check-runs?per_page=100":
+            return {"total_count": 0, "check_runs": []}
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["ray-project/ray#64053"])
+
+    integration = metrics["integrations"][0]
+    assert integration["checks"]["state"] == "failure"
+    assert integration["known_external_failure_reason"] == (
+        "Current Ray failures are Buildkite/ReadTheDocs gates already triaged; "
+        "the remaining PR-local Black fix is waiting on the contributor branch owner"
+    )
+    assert integration["known_external_failure_action"] == "wait for contributor branch update"
+    assert integration["next_action"] == "wait for contributor branch update"
+
+
 def test_collect_integration_metrics_handles_known_external_ci_aggregate_race(monkeypatch):
     module = load_growth_metrics_module()
 
@@ -520,6 +564,46 @@ def test_collect_integration_metrics_handles_known_external_ci_aggregate_race(mo
     )
     assert integration["known_external_failure_action"] == "wait for maintainer rerun"
     assert integration["next_action"] == "wait for maintainer rerun"
+
+
+def test_collect_integration_metrics_treats_transformers_review_gate_as_passive_wait(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url == "https://api.github.com/repos/huggingface/transformers/pulls/46180":
+            return {
+                "number": 46180,
+                "title": "Add Fun-ASR-Nano model",
+                "state": "open",
+                "draft": False,
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "html_url": "https://github.com/huggingface/transformers/pull/46180",
+                "updated_at": "2026-07-22T04:24:15Z",
+                "head": {"sha": "5efce76", "ref": "add-fun-asr-nano"},
+                "base": {"ref": "main"},
+                "user": {"login": "LauraGPT"},
+            }
+        if url == "https://api.github.com/repos/huggingface/transformers/commits/5efce76/status":
+            return {"state": "success", "statuses": []}
+        if url == "https://api.github.com/repos/huggingface/transformers/commits/5efce76/check-runs?per_page=100":
+            return {
+                "total_count": 2,
+                "check_runs": [
+                    {"name": "pr-ci / Check code quality", "status": "completed", "conclusion": "success"},
+                    {"name": "pr-ci / PR CI status", "status": "completed", "conclusion": "success"},
+                ],
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    metrics = module.collect_integration_metrics(["huggingface/transformers#46180"])
+
+    integration = metrics["integrations"][0]
+    assert integration["checks"]["state"] == "success"
+    assert integration["next_action"] == "wait for maintainer review"
+    assert "active maintainer-held review thread" in integration["known_assisted_review_reason"]
 
 
 def test_format_ecosystem_markdown_includes_open_pull_requests():


### PR DESCRIPTION
## Summary
- classify the current Ray Serve FunASR PR failures as a known contributor-branch wait instead of an active fix-checks item
- classify the Transformers Fun-ASR-Nano PR review gate as a passive maintainer-review wait when checks are green
- add regression coverage for both queue states

## Verification
- python3 -m pytest -q tests/test_collect_growth_metrics.py
- git diff --check