### PR TITLE
fix: honor server hub for default Nano model

### DIFF
--- a/funasr/bin/_server_app.py
+++ b/funasr/bin/_server_app.py
@@ -137,9 +137,10 @@ def create_app(device: str = "cuda", preload_model: str = "auto", model_path: st
 
             logger.info("Loading Fun-ASR-Nano vLLM engine...")
             t0 = time.time()
-            # Use custom model_path if provided, otherwise default
+            # Use custom model_path if provided, otherwise default. In both
+            # cases, honor the server-level hub selection.
             vllm_model = app.state.model_path if app.state.model_path else "FunAudioLLM/Fun-ASR-Nano-2512"
-            vllm_hub = app.state.hub if app.state.model_path else "hf"
+            vllm_hub = app.state.hub
             app.state.engine = FunASRNanoVLLM.from_pretrained(
                 model=vllm_model,
                 hub=vllm_hub,
@@ -160,7 +161,7 @@ def create_app(device: str = "cuda", preload_model: str = "auto", model_path: st
             from funasr import AutoModel
             cfg = {
                 "model": app.state.model_path if app.state.model_path else "FunAudioLLM/Fun-ASR-Nano-2512",
-                "hub": app.state.hub if app.state.model_path else "hf",
+                "hub": app.state.hub,
                 "trust_remote_code": True,
                 "vad_model": "fsmn-vad",
                 "vad_kwargs": {"max_single_segment_time": 30000},

--- a/tests/test_server_app_openai_segments.py
+++ b/tests/test_server_app_openai_segments.py
@@ -55,13 +55,15 @@ def install_dummy_funasr(monkeypatch):
     return DummyAutoModel
 
 
-def install_dummy_vllm(monkeypatch):
+def install_dummy_vllm(monkeypatch, raise_on_load=False):
     class DummyVLLM:
         calls = []
 
         @classmethod
         def from_pretrained(cls, **kwargs):
             cls.calls.append(kwargs)
+            if raise_on_load:
+                raise RuntimeError("vllm unavailable")
             return object()
 
     monkeypatch.setitem(sys.modules, "funasr.models", types.ModuleType("funasr.models"))
@@ -101,7 +103,7 @@ def test_fallback_segments_keep_short_text_single_cue(monkeypatch):
     ]
 
 
-def test_default_fun_asr_nano_uses_huggingface_hub(monkeypatch):
+def test_default_fun_asr_nano_uses_requested_modelscope_hub(monkeypatch):
     module = load_server_app(monkeypatch)
     DummyAutoModel = install_dummy_funasr(monkeypatch)
     DummyVLLM = install_dummy_vllm(monkeypatch)
@@ -109,8 +111,20 @@ def test_default_fun_asr_nano_uses_huggingface_hub(monkeypatch):
     module.create_app(device="cuda", preload_model="fun-asr-nano", hub="ms")
 
     assert DummyVLLM.calls[0]["model"] == "FunAudioLLM/Fun-ASR-Nano-2512"
-    assert DummyVLLM.calls[0]["hub"] == "hf"
+    assert DummyVLLM.calls[0]["hub"] == "ms"
     assert DummyAutoModel.instances[0]["model"] == "fsmn-vad"
+
+
+def test_default_fun_asr_nano_fallback_uses_requested_modelscope_hub(monkeypatch):
+    module = load_server_app(monkeypatch)
+    DummyAutoModel = install_dummy_funasr(monkeypatch)
+    install_dummy_vllm(monkeypatch, raise_on_load=True)
+
+    module.create_app(device="cuda", preload_model="fun-asr-nano", hub="ms")
+
+    fallback = DummyAutoModel.instances[-1]
+    assert fallback["model"] == "FunAudioLLM/Fun-ASR-Nano-2512"
+    assert fallback["hub"] == "ms"
 
 
 def test_custom_model_path_fallback_uses_empty_config_and_requested_hub(monkeypatch):


### PR DESCRIPTION
## Summary
- fix `funasr-server --hub ms --model fun-asr-nano` so the default Nano model honors the requested hub instead of forcing Hugging Face
- apply the same hub selection to the AutoModel fallback path when vLLM is unavailable
- update server app regression tests for both vLLM and fallback loading

Fixes #3321.

## Verification
- red first: the two new hub regression tests failed with `hf` before the fix
- python3 -m pytest -q tests/test_server_app_openai_segments.py tests/test_cli.py tests/test_realtime_ws_service.py -k "hub or server or fallback or default_fun_asr_nano"
- python3 -m py_compile funasr/bin/_server_app.py funasr/bin/server.py
- python3 -m pytest -q tests/test_server_app_openai_segments.py tests/test_docs_funasr_install_commands.py tests/test_collect_growth_metrics.py
- git diff --check