### PR TITLE
chore: mark LiteLLM docs PR as review wait

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -153,6 +153,9 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
     "run-llama/llama_index#21996": {
         "reason": "FunASR dependency gate addressed; avoid duplicate pings",
     },
+    "BerriAI/litellm-docs#610": {
+        "reason": "conflict resolved and Docusaurus build/check evidence posted; avoid duplicate pings",
+    },
     "mudler/LocalAI#10090": {
         "reason": "review evidence already posted; avoid duplicate pings",
     },

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -696,6 +696,7 @@ def test_known_assisted_review_requests_include_validated_review_gate_prs():
         "livekit/agents#6176",
         "run-llama/llama_index#21958",
         "run-llama/llama_index#21996",
+        "BerriAI/litellm-docs#610",
         "mudler/LocalAI#10090",
         "ray-project/ray#64053",
         "agno-agi/agno#8501",


### PR DESCRIPTION
## Summary
- classify BerriAI/litellm-docs#610 as an assisted review wait after conflict resolution and build evidence were posted
- add a regression assertion so daily patrol does not keep asking for duplicate review pings

## Validation
- git diff --check
- python3 -m pytest -q tests/test_collect_growth_metrics.py tests/test_markdown_relative_links.py
- python3 scripts/collect_growth_metrics.py --integrations --integration-prs BerriAI/litellm-docs#610 --format markdown