### PR TITLE
Retry funasr.com static page checks

### DIFF
--- a/scripts/check_funasr_website_static.py
+++ b/scripts/check_funasr_website_static.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
 import urllib.request
 from dataclasses import dataclass
 
@@ -90,21 +91,35 @@ def validate_pages(pages: dict[str, str]) -> list[str]:
     return failures
 
 
-def fetch_pages(timeout: float) -> dict[str, str]:
+def _fetch_url(url: str, timeout: float, retries: int) -> str:
+    last_error: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:
+                body = response.read()
+            return body.decode("utf-8", errors="replace")
+        except Exception as exc:
+            last_error = exc
+            if attempt == retries:
+                break
+            time.sleep(min(0.25 * (attempt + 1), 1.0))
+    raise last_error
+
+
+def fetch_pages(timeout: float, retries: int = 3) -> dict[str, str]:
     pages: dict[str, str] = {}
     for url in PAGE_CONTRACTS:
-        with urllib.request.urlopen(url, timeout=timeout) as response:
-            body = response.read()
-        pages[url] = body.decode("utf-8", errors="replace")
+        pages[url] = _fetch_url(url, timeout=timeout, retries=retries)
     return pages
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--retries", type=int, default=3)
     args = parser.parse_args(argv)
 
-    failures = validate_pages(fetch_pages(timeout=args.timeout))
+    failures = validate_pages(fetch_pages(timeout=args.timeout, retries=args.retries))
     if failures:
         print("funasr.com static page contract failed:", file=sys.stderr)
         for failure in failures:

--- a/tests/test_check_funasr_website_static.py
+++ b/tests/test_check_funasr_website_static.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+import urllib.error
 from pathlib import Path
 
 
@@ -83,3 +84,43 @@ def test_website_contract_reports_stale_runtime_and_star_copy():
         and "forbidden `runtime-llamacpp-v0.1.1`" in failure
         for failure in failures
     )
+
+
+def test_fetch_pages_retries_transient_url_errors(monkeypatch):
+    checker = _load_module()
+    calls = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"ok"
+
+    def fake_urlopen(url, timeout):
+        calls.append((url, timeout))
+        if len(calls) == 1:
+            raise urllib.error.URLError("temporary SSL handshake timeout")
+        return FakeResponse()
+
+    monkeypatch.setattr(checker.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        checker,
+        "PAGE_CONTRACTS",
+        {
+            "https://www.funasr.com/example.html": checker.PageContract(
+                required=("ok",)
+            )
+        },
+    )
+
+    pages = checker.fetch_pages(timeout=3, retries=2)
+
+    assert pages == {"https://www.funasr.com/example.html": "ok"}
+    assert calls == [
+        ("https://www.funasr.com/example.html", 3),
+        ("https://www.funasr.com/example.html", 3),
+    ]


### PR DESCRIPTION
## Summary
- add retry support to `scripts/check_funasr_website_static.py`
- expose `--retries` for daily patrols and manual runs
- cover transient URL errors with a regression test so SSL handshake/network blips do not cause false patrol failures

## Why
The website contract has passed on content but occasionally hit transient SSL handshake timeouts from the patrol host. Retrying the fetch keeps the growth-critical website guard useful without hiding real content regressions.

## Validation
- TDD red: `python3 -m pytest -q tests/test_check_funasr_website_static.py` failed because `fetch_pages()` did not accept `retries`
- `python3 -m pytest -q tests/test_check_funasr_website_static.py`
- `python3 scripts/check_funasr_website_static.py --timeout 20 --retries 3`
- `python3 -m py_compile scripts/check_funasr_website_static.py`
- `git diff --check`
- `python3 -m pytest -q tests/test_markdown_relative_links.py tests/test_collect_growth_metrics.py tests/test_check_funasr_website_static.py`
