### PR TITLE
Guard donor page funding copy

### DIFF
--- a/scripts/check_funasr_website_static.py
+++ b/scripts/check_funasr_website_static.py
@@ -41,10 +41,10 @@ PAGE_CONTRACTS: dict[str, PageContract] = {
         forbidden=("16K+",),
     ),
     f"{BASE_URL}/donors.html": PageContract(
-        required=("服务器", "www.funasr.com", "域名"),
+        required=("捐赠金额用于购买服务器与", "www.funasr.com", "域名"),
     ),
     f"{BASE_URL}/en/donors.html": PageContract(
-        required=("servers", "www.funasr.com", "domain"),
+        required=("Donations helped purchase servers", "www.funasr.com", "domain"),
     ),
     f"{BASE_URL}/blog/funasr-cli-transcribe-command-line.html": PageContract(
         required=("推荐 funasr ≥ 1.3.26", "/donors.html"),

--- a/tests/test_check_funasr_website_static.py
+++ b/tests/test_check_funasr_website_static.py
@@ -35,7 +35,7 @@ def test_website_contract_accepts_current_public_copy():
             <div>54.3K stars</div>
         """,
         "https://www.funasr.com/donors.html": """
-            捐赠金额用于购买服务器与 <a href="https://www.funasr.com/">www.funasr.com</a> 域名
+            捐赠金额用于购买服务器与 <a href="https://www.funasr.com/">www.funasr.com</a> 域名，帮助官网和社区资料持续在线。
         """,
         "https://www.funasr.com/en/donors.html": """
             Donations helped purchase servers and the <a href="https://www.funasr.com/">www.funasr.com</a> domain.


### PR DESCRIPTION
## Summary
- require the donor page to keep the full server/domain funding explanation
- keep the English donor page contract aligned with the live copy
- refresh the website contract unit fixture with the full Chinese sentence

## Tests
- python3 -m pytest -q tests/test_check_funasr_website_static.py
- python3 scripts/check_funasr_website_static.py --timeout 20 --retries 3
- git diff --check