### PR TITLE
Refresh type4me integration review state

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -199,7 +199,7 @@ KNOWN_ASSISTED_REVIEW_REQUESTS = {
         "reason": "FunASR scientific-audio listing evidence already posted; avoid duplicate pings",
     },
     "joewongjc/type4me#207": {
-        "reason": "draft validation status already posted; keep draft until Qwen3-only ASR smoke test",
+        "reason": "Qwen3-only ASR smoke evidence posted and PR is ready for maintainer review",
     },
     "ga642381/speech-trident#31": {
         "reason": "SenseVoice model-list evidence already posted; avoid duplicate pings",

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -195,6 +195,16 @@ def test_missing_validated_discovery_lanes_wait_for_maintainer_review():
     assert expected_prs.issubset(set(module.KNOWN_ASSISTED_REVIEW_REQUESTS))
 
 
+def test_type4me_review_wait_reflects_completed_qwen3_smoke():
+    module = load_growth_metrics_module()
+
+    reason = module.KNOWN_ASSISTED_REVIEW_REQUESTS["joewongjc/type4me#207"]["reason"]
+
+    assert "Qwen3-only ASR smoke evidence posted" in reason
+    assert "keep draft" not in reason
+    assert "until Qwen3-only ASR smoke test" not in reason
+
+
 def test_default_integration_prs_include_mcp_discovery_lanes():
     module = load_growth_metrics_module()
 


### PR DESCRIPTION
## Summary
- update the type4me integration tracker note now that Qwen3-only ASR smoke evidence has been posted and the PR is no longer draft
- add a regression test so future patrol output does not regress to the stale draft-wait wording

## Validation
- python3 -m pytest -q tests/test_collect_growth_metrics.py
- python3 scripts/collect_growth_metrics.py --integrations --integration-prs joewongjc/type4me#207 --format markdown
- python3 scripts/collect_growth_metrics.py --integrations --integration-prs yuekaizhang/Fun-ASR-vllm#21 --format markdown
- git diff --check
