### PR TITLE
Use ops GitHub token for growth metrics

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -2,7 +2,8 @@
 """Collect lightweight growth metrics for the FunASR repository.
 
 The script uses only Python's standard library and public APIs by default.
-Set GITHUB_TOKEN to raise GitHub API rate limits in CI or release workflows.
+Set GITHUB_TOKEN, or place a token in the FunASR ops token file, to raise
+GitHub API rate limits in CI or release workflows.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ DEFAULT_PACKAGE = "funasr"
 DEFAULT_BASELINE_STARS = 31224
 DEFAULT_TARGET_ADDITIONAL_STARS = 20000
 DEFAULT_TARGET_DATE = "2026-09-30"
+OPS_GITHUB_TOKEN_PATH = Path("/cpfs_speech/user/zhifu.gzf/.config/funasr-ops/github_token")
 DEFAULT_INTEGRATION_PRS = [
     "huggingface/transformers#46180",
     "yuekaizhang/Fun-ASR-vllm#21",
@@ -334,11 +336,13 @@ def github_headers() -> Dict[str, str]:
     }
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        token_path = Path.home() / ".config" / "funasr-ops" / "github_token"
-        try:
-            token = token_path.read_text(encoding="utf-8").strip()
-        except OSError:
-            token = None
+        for token_path in github_token_paths():
+            try:
+                token = token_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if token:
+                break
     if not token:
         try:
             completed = subprocess.run(
@@ -356,6 +360,13 @@ def github_headers() -> Dict[str, str]:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
+
+
+def github_token_paths() -> Sequence[Path]:
+    return (
+        Path.home() / ".config" / "funasr-ops" / "github_token",
+        OPS_GITHUB_TOKEN_PATH,
+    )
 
 
 def collect_github_repo_metrics(repo: str) -> Dict[str, Any]:

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -27,6 +27,11 @@ def test_github_headers_falls_back_to_gh_auth_token(monkeypatch):
     module = load_growth_metrics_module()
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("HOME", "/tmp/funasr-growth-metrics-no-token-home")
+    monkeypatch.setattr(
+        module,
+        "OPS_GITHUB_TOKEN_PATH",
+        Path("/tmp/funasr-growth-metrics-missing-ops-token"),
+    )
 
     def fake_run(args, **kwargs):
         assert args == ["gh", "auth", "token"]
@@ -55,6 +60,25 @@ def test_github_headers_reads_funasr_ops_token_file(monkeypatch, tmp_path):
     headers = module.github_headers()
 
     assert headers["Authorization"] == "Bearer file-token"
+
+
+def test_github_headers_reads_configured_ops_token_file(monkeypatch, tmp_path):
+    module = load_growth_metrics_module()
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    ops_token_path = tmp_path / "ops" / "github_token"
+    ops_token_path.parent.mkdir(parents=True)
+    ops_token_path.write_text("ops-file-token\n")
+    monkeypatch.setattr(module, "OPS_GITHUB_TOKEN_PATH", ops_token_path)
+
+    def fake_run(args, **kwargs):
+        raise AssertionError("gh auth token should not be called when ops token exists")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    headers = module.github_headers()
+
+    assert headers["Authorization"] == "Bearer ops-file-token"
 
 
 def test_default_integration_prs_include_high_visibility_external_queue():


### PR DESCRIPTION
## Summary
- let growth metrics read the FunASR ops GitHub token path when GITHUB_TOKEN is not exported
- keep environment variable and HOME token file precedence, with gh auth token as the final fallback
- add regression coverage for the configured ops token path and isolated gh fallback

## Validation
- unset GITHUB_TOKEN; python3 -m pytest -q tests/test_collect_growth_metrics.py
- unset GITHUB_TOKEN; python3 scripts/collect_growth_metrics.py --integrations --integration-prs Uberi/speech_recognition#903 --format markdown
- unset GITHUB_TOKEN; python3 scripts/collect_growth_metrics.py --integrations --format markdown
- git diff --check