### PR TITLE
Infer ecosystem metrics from explicit repos

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -982,8 +982,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--repos",
         nargs="+",
-        default=DEFAULT_ECOSYSTEM_REPOS,
-        help="GitHub repositories for --ecosystem mode",
+        default=None,
+        help="GitHub repositories for --ecosystem or --issues mode; multiple explicit repos imply --ecosystem",
     )
     parser.add_argument("--ecosystem", action="store_true", help="Collect the four-repository FunASR ecosystem")
     parser.add_argument("--integrations", action="store_true", help="Collect tracked external integration PRs")
@@ -1010,14 +1010,16 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    repos = args.repos or DEFAULT_ECOSYSTEM_REPOS
+    ecosystem_mode = args.ecosystem or bool(args.repos and len(args.repos) > 1)
     try:
         if args.integrations:
             metrics = collect_integration_metrics(args.integration_prs)
         elif args.issues:
-            metrics = collect_issue_metrics(args.repos)
-        elif args.ecosystem:
+            metrics = collect_issue_metrics(repos)
+        elif ecosystem_mode:
             metrics = collect_ecosystem_metrics(
-                args.repos,
+                repos,
                 args.pypi_package,
                 args.baseline_stars,
                 args.target_additional_stars,
@@ -1035,7 +1037,7 @@ def main() -> int:
         print(format_integration_markdown(metrics), end="")
     elif args.issues:
         print(format_issue_markdown(metrics), end="")
-    elif args.ecosystem:
+    elif ecosystem_mode:
         print(format_ecosystem_markdown(metrics), end="")
     else:
         print(format_markdown(metrics, args.star_goal), end="")

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -1642,6 +1642,64 @@ def test_main_outputs_ecosystem_json(monkeypatch):
     assert payload["ecosystem"]["remaining_to_target"] == 16602
 
 
+def test_main_treats_explicit_multi_repos_as_ecosystem_json(monkeypatch):
+    module = load_growth_metrics_module()
+
+    repo_stars = {
+        "modelscope/FunASR": 18714,
+        "FunAudioLLM/Fun-ASR": 1318,
+        "FunAudioLLM/SenseVoice": 8718,
+        "modelscope/FunClip": 5872,
+    }
+
+    def fake_fetch_json(url, headers=None):
+        if url.endswith("/pulls?state=open&per_page=100"):
+            return []
+        if url.startswith("https://api.github.com/repos/"):
+            repo = url.removeprefix("https://api.github.com/repos/")
+            return {
+                "stargazers_count": repo_stars[repo],
+                "forks_count": 0,
+                "subscribers_count": 0,
+                "open_issues_count": 0,
+                "default_branch": "main",
+                "pushed_at": "2026-06-30T00:00:00Z",
+                "html_url": f"https://github.com/{repo}",
+            }
+        if url == "https://pypi.org/pypi/funasr/json":
+            return {"info": {"version": "1.3.14", "summary": "FunASR", "project_url": "https://pypi.org/project/funasr/"}}
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "collect_growth_metrics.py",
+            "--format",
+            "json",
+            "--repos",
+            "modelscope/FunASR",
+            "FunAudioLLM/Fun-ASR",
+            "FunAudioLLM/SenseVoice",
+            "modelscope/FunClip",
+        ],
+    )
+
+    with redirect_stdout(io.StringIO()) as stdout:
+        assert module.main() == 0
+
+    payload = json.loads(stdout.getvalue())
+    assert "github" not in payload
+    assert payload["ecosystem"]["total_stars"] == 34622
+    assert [repo["repo"] for repo in payload["ecosystem"]["repositories"]] == [
+        "modelscope/FunASR",
+        "FunAudioLLM/Fun-ASR",
+        "FunAudioLLM/SenseVoice",
+        "modelscope/FunClip",
+    ]
+
+
 def test_main_outputs_integrations_json(monkeypatch):
     module = load_growth_metrics_module()
 


### PR DESCRIPTION
## Summary
- treat explicit multi-repo --repos invocations as ecosystem growth snapshots
- keep the default no-flag command as the single FunASR repository snapshot
- add regression coverage so four-repo star tracking cannot silently collapse to the default repo

## Validation
- unset GITHUB_TOKEN; python3 -m pytest -q tests/test_collect_growth_metrics.py
- unset GITHUB_TOKEN; python3 scripts/collect_growth_metrics.py --repos modelscope/FunASR FunAudioLLM/Fun-ASR FunAudioLLM/SenseVoice modelscope/FunClip --format markdown
- unset GITHUB_TOKEN; python3 scripts/collect_growth_metrics.py --format markdown
- git diff --check