### PR TITLE
Display review-gated integration PRs clearly

### DIFF
--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -564,15 +564,7 @@ def recommend_integration_action(
 
 def display_mergeable_state(integration: Dict[str, Any]) -> str:
     mergeable_state = integration.get("mergeable_state")
-    if mergeable_state and mergeable_state != "unknown":
-        return str(mergeable_state)
-
     mergeable = integration.get("mergeable")
-    if isinstance(mergeable, bool):
-        return "mergeable" if mergeable else "not mergeable"
-    if mergeable and str(mergeable).lower() not in {"unknown", "none"}:
-        return str(mergeable).lower()
-
     checks = integration.get("checks") or {}
     next_action = integration.get("next_action") or "inspect"
     has_check_blocker = bool(checks.get("failed_check_runs") or checks.get("pending_check_runs"))
@@ -584,8 +576,17 @@ def display_mergeable_state(integration: Dict[str, Any]) -> str:
             integration.get("known_review_gate_reason")
             or integration.get("known_assisted_review_reason")
         )
+        and (mergeable is True or mergeable_state in {"blocked", "unknown", "unstable", None})
     ):
         return "review-gated"
+
+    if mergeable_state and mergeable_state != "unknown":
+        return str(mergeable_state)
+
+    if isinstance(mergeable, bool):
+        return "mergeable" if mergeable else "not mergeable"
+    if mergeable and str(mergeable).lower() not in {"unknown", "none"}:
+        return str(mergeable).lower()
 
     return str(mergeable_state or mergeable or "unknown")
 

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -1270,6 +1270,38 @@ def test_format_integration_markdown_marks_unknown_review_gate_as_review_gated()
     ) in output
 
 
+def test_format_integration_markdown_marks_mergeable_blocked_review_wait_as_review_gated():
+    module = load_growth_metrics_module()
+    metrics = {
+        "collected_at_utc": "2026-07-02T00:00:00+00:00",
+        "integrations": [
+            {
+                "pr": "huggingface/transformers#46180",
+                "html_url": "https://github.com/huggingface/transformers/pull/46180",
+                "state": "open",
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "repo_stars": 162_000,
+                "repo_forks": 33_000,
+                "updated_at": "2026-07-22T08:50:59Z",
+                "updated_age_days": 0,
+                "next_action": "wait for maintainer review",
+                "known_assisted_review_reason": (
+                    "checks are green and the remaining blocker is an active maintainer-held review thread"
+                ),
+                "checks": {"state": "success", "failed_check_runs": [], "pending_check_runs": []},
+            }
+        ],
+    }
+
+    output = module.format_integration_markdown(metrics)
+
+    assert (
+        "| [huggingface/transformers#46180](https://github.com/huggingface/transformers/pull/46180) | "
+        "162,000 | 33,000 | open | review-gated | success | 0 | 0 | 0d | wait for maintainer review | `2026-07-22T08:50:59Z` |"
+    ) in output
+
+
 def test_format_integration_markdown_lists_high_exposure_priorities_by_stars():
     module = load_growth_metrics_module()
     metrics = {


### PR DESCRIPTION
## Summary
- display mergeable-but-review-blocked integration PRs as review-gated instead of blocked
- preserve blocked/dirty-style states for PRs that still need operator work
- add regression coverage for the Transformers review-gated state

## Validation
- unset GITHUB_TOKEN; python3 -m pytest -q tests/test_collect_growth_metrics.py
- unset GITHUB_TOKEN; python3 scripts/collect_growth_metrics.py --integrations --integration-prs huggingface/transformers#46180 getpaseo/paseo#1634 josephmisiti/awesome-machine-learning#1339 --format markdown
- git diff --check