### PR TITLE
Refresh localized Paraformer ModelScope links

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -128,7 +128,7 @@ pip install funasr
 | **Fun-ASR-Nano** | 認識 | 中/英/日 + 中国語方言 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
 | **Fun-ASR-MLT-Nano** | 認識 | 31言語 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) |
 | **SenseVoiceSmall** | 認識 + 感情 + イベント | 中/英/日/韓/粤 | 234M | [⭐](https://www.modelscope.cn/models/iic/SenseVoiceSmall) [🤗](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) [GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) |
-| **Paraformer-zh** | 認識 + タイムスタンプ | 中/英 | 220M | [⭐](https://www.modelscope.cn/models/damo/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) [🤗](https://huggingface.co/funasr/paraformer-zh) |
+| **Paraformer-zh** | 認識 + タイムスタンプ | 中/英 | 220M | [⭐](https://www.modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) [🤗](https://huggingface.co/funasr/paraformer-zh) |
 | Qwen3-ASR | 認識、52言語 | 多言語 | 1.7B | [使用法](examples/industrial_data_pretraining/qwen3_asr) |
 | GLM-ASR-Nano | 認識、17言語 | 多言語 | 1.5B | [使用法](examples/industrial_data_pretraining/glm_asr) |
 | Whisper-large-v3-turbo | 認識 + 翻訳 | 多言語 | 809M | [使用法](examples/industrial_data_pretraining/whisper) |

--- a/README_ko.md
+++ b/README_ko.md
@@ -128,7 +128,7 @@ pip install funasr
 | **Fun-ASR-Nano** | 인식 | 중/영/일 + 중국어 방언 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
 | **Fun-ASR-MLT-Nano** | 인식 | 31개 언어 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) |
 | **SenseVoiceSmall** | 인식 + 감정 + 이벤트 | 중/영/일/한/광둥어 | 234M | [⭐](https://www.modelscope.cn/models/iic/SenseVoiceSmall) [🤗](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) [GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) |
-| **Paraformer-zh** | 인식 + 타임스탬프 | 중/영 | 220M | [⭐](https://www.modelscope.cn/models/damo/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) [🤗](https://huggingface.co/funasr/paraformer-zh) |
+| **Paraformer-zh** | 인식 + 타임스탬프 | 중/영 | 220M | [⭐](https://www.modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) [🤗](https://huggingface.co/funasr/paraformer-zh) |
 | Qwen3-ASR | 인식, 52개 언어 | 다국어 | 1.7B | [사용법](examples/industrial_data_pretraining/qwen3_asr) |
 | GLM-ASR-Nano | 인식, 17개 언어 | 다국어 | 1.5B | [사용법](examples/industrial_data_pretraining/glm_asr) |
 | Whisper-large-v3-turbo | 인식 + 번역 | 다국어 | 809M | [사용법](examples/industrial_data_pretraining/whisper) |

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -84,8 +84,13 @@ def test_public_docs_do_not_advertise_stale_release_or_star_copy():
             assert marker not in text
 
 
-def test_chinese_readme_model_table_uses_current_modelscope_entries():
-    text = (ROOT / "README_zh.md").read_text()
+def test_readme_model_tables_use_current_modelscope_entries():
+    readmes = [
+        (ROOT / "README.md").read_text(),
+        (ROOT / "README_zh.md").read_text(),
+        (ROOT / "README_ja.md").read_text(),
+        (ROOT / "README_ko.md").read_text(),
+    ]
 
     current_entries = [
         "models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary",
@@ -100,10 +105,15 @@ def test_chinese_readme_model_table_uses_current_modelscope_entries():
         "models/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch/summary",
     ]
 
-    for marker in current_entries:
-        assert marker in text
-    for marker in stale_entries:
-        assert marker not in text
+    for text in readmes:
+        assert current_entries[0] in text
+        assert stale_entries[0] not in text
+
+    for text in readmes[:2]:
+        for marker in current_entries:
+            assert marker in text
+        for marker in stale_entries:
+            assert marker not in text
 
 
 def test_readme_model_tables_surface_public_gguf_entries():


### PR DESCRIPTION
## Summary
- update Japanese and Korean README Paraformer-zh ModelScope links from stale damo paths to current iic paths
- extend README model-table regression coverage across English, Chinese, Japanese, and Korean entry points

## Validation
- python3 -m pytest -q tests/test_docs_funasr_install_commands.py tests/test_markdown_relative_links.py
- python3 scripts/check_funasr_website_static.py --timeout 20 --retries 2
- git diff --check
- HTTP 200 for the updated ModelScope Paraformer link and Hugging Face Paraformer link