### PR TITLE
Record API curl examples in growth tracker

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -349,7 +349,7 @@ Paste the Markdown output into launch notes, weekly community updates, or releas
 
 ### Week 2: Deployment proof
 
-- [ ] Publish API server curl examples.
+- [x] Publish API server curl examples. On 2026-07-23, the OpenAI-compatible API docs already publish copy-paste curl paths in `examples/openai_api/README.md` and `examples/openai_api/README_zh.md`, plus scripted smoke tests in `examples/openai_api/smoke_test.sh` and `examples/openai_api/smoke_test.py`. The manual flow downloads `sample.wav`, checks `/health`, and posts to `/v1/audio/transcriptions` with `-F file=@sample.wav`, `-F model=sensevoice`, and `response_format=verbose_json`; no-code and gateway users can use `examples/openai_api/POSTMAN.md` and `examples/openai_api/OPENAPI.md`.
 - [ ] Publish WebSocket streaming examples.
 - [ ] Validate Docker CPU and GPU images.
 - [ ] Validate vLLM guide on one GPU server.

--- a/tests/test_growth_plan_doc.py
+++ b/tests/test_growth_plan_doc.py
@@ -56,3 +56,25 @@ def test_growth_plan_records_github_metadata_completion():
         assert marker in text
 
     assert "[ ] Confirm GitHub repo description and topics mention ASR" not in text
+
+
+def test_growth_plan_records_api_curl_examples_completion():
+    text = PLAN.read_text()
+
+    required_markers = [
+        "[x] Publish API server curl examples",
+        "`examples/openai_api/README.md`",
+        "`examples/openai_api/README_zh.md`",
+        "`examples/openai_api/smoke_test.sh`",
+        "`examples/openai_api/smoke_test.py`",
+        "`/v1/audio/transcriptions`",
+        "`-F file=@sample.wav`",
+        "`-F model=sensevoice`",
+        "`response_format=verbose_json`",
+        "`examples/openai_api/POSTMAN.md`",
+        "`examples/openai_api/OPENAPI.md`",
+    ]
+    for marker in required_markers:
+        assert marker in text
+
+    assert "[ ] Publish API server curl examples" not in text


### PR DESCRIPTION
## Summary
- mark the API server curl examples item complete in the 20k-star growth plan
- record the existing OpenAI-compatible API doc entry points, shell/Python smoke tests, and Postman/OpenAPI paths
- add a guard so the published curl example evidence stays visible in the tracker

## Validation
- RED: `python3 -m pytest -q tests/test_growth_plan_doc.py` failed before the tracker update because the API curl examples item was still unchecked
- GREEN: `python3 -m pytest -q tests/test_growth_plan_doc.py tests/test_markdown_relative_links.py tests/test_collect_growth_metrics.py tests/test_docs_funasr_install_commands.py tests/test_server_app_openai_segments.py tests/test_fun_asr_nano_openai_response.py`
- GREEN: `python3 scripts/check_funasr_website_static.py --timeout 20 --retries 2`
- GREEN: `git diff --check`
