### PR TITLE
Record WebSocket examples in growth tracker

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -350,7 +350,7 @@ Paste the Markdown output into launch notes, weekly community updates, or releas
 ### Week 2: Deployment proof
 
 - [x] Publish API server curl examples. On 2026-07-23, the OpenAI-compatible API docs already publish copy-paste curl paths in `examples/openai_api/README.md` and `examples/openai_api/README_zh.md`, plus scripted smoke tests in `examples/openai_api/smoke_test.sh` and `examples/openai_api/smoke_test.py`. The manual flow downloads `sample.wav`, checks `/health`, and posts to `/v1/audio/transcriptions` with `-F file=@sample.wav`, `-F model=sensevoice`, and `response_format=verbose_json`; no-code and gateway users can use `examples/openai_api/POSTMAN.md` and `examples/openai_api/OPENAPI.md`.
-- [ ] Publish WebSocket streaming examples.
+- [x] Publish WebSocket streaming examples. On 2026-07-23, realtime WebSocket examples are published in `docs/vllm_guide.md`, `docs/vllm_guide_zh.md`, and `examples/industrial_data_pretraining/fun_asr_nano/docs/realtime_demo.md`. They show how to start `serve_realtime_ws.py`, connect to `ws://localhost:10095`, run `client_python.py --server ws://localhost:10095 --mic` or `client_python.py --server ws://localhost:10095 --file audio.wav`, interpret `partial`, `partial_start_ms`, and `is_final`, and run `realtime_ws_benchmark.py` for multi-client load checks.
 - [ ] Validate Docker CPU and GPU images.
 - [ ] Validate vLLM guide on one GPU server.
 - [ ] Record concise terminal outputs for release notes.

--- a/tests/test_growth_plan_doc.py
+++ b/tests/test_growth_plan_doc.py
@@ -78,3 +78,26 @@ def test_growth_plan_records_api_curl_examples_completion():
         assert marker in text
 
     assert "[ ] Publish API server curl examples" not in text
+
+
+def test_growth_plan_records_websocket_streaming_examples_completion():
+    text = PLAN.read_text()
+
+    required_markers = [
+        "[x] Publish WebSocket streaming examples",
+        "`docs/vllm_guide.md`",
+        "`docs/vllm_guide_zh.md`",
+        "`examples/industrial_data_pretraining/fun_asr_nano/docs/realtime_demo.md`",
+        "`serve_realtime_ws.py`",
+        "`ws://localhost:10095`",
+        "`client_python.py --server ws://localhost:10095 --mic`",
+        "`client_python.py --server ws://localhost:10095 --file audio.wav`",
+        "`partial`",
+        "`partial_start_ms`",
+        "`is_final`",
+        "`realtime_ws_benchmark.py`",
+    ]
+    for marker in required_markers:
+        assert marker in text
+
+    assert "[ ] Publish WebSocket streaming examples" not in text


### PR DESCRIPTION
## Summary
- mark the WebSocket streaming examples item complete in the 20k-star growth plan
- record the existing realtime guide, Fun-ASR-Nano realtime demo, client commands, partial/final protocol fields, and benchmark entry point
- add a guard so the WebSocket example evidence stays visible in the tracker

## Validation
- RED: `python3 -m pytest -q tests/test_growth_plan_doc.py` failed before the tracker update because the WebSocket examples item was still unchecked
- GREEN: `python3 -m pytest -q tests/test_growth_plan_doc.py tests/test_markdown_relative_links.py tests/test_collect_growth_metrics.py tests/test_docs_funasr_install_commands.py tests/test_realtime_ws_benchmark.py tests/test_qwen3_asr_ws_example.py`
- GREEN: `python3 scripts/check_funasr_website_static.py --timeout 20 --retries 2`
- GREEN: `git diff --check`
