### PR TITLE
Record release discussion distribution

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -366,8 +366,8 @@ Paste the Markdown output into launch notes, weekly community updates, or releas
 
 ### Week 4: Distribution and feedback
 
-- [ ] Share the release in relevant developer communities.
-- [ ] Pin a GitHub discussion for the release.
+- [x] Share the release in relevant developer communities. On 2026-07-23, GitHub Discussion [`modelscope/FunASR#3376`](https://github.com/modelscope/FunASR/discussions/3376) was published in the `Announcements` category with the title `FunASR v1.3.26: OpenAI-compatible ASR deployment, vLLM, and llama.cpp runtime`. It routes readers to `funasr==1.3.26`, `/v1/audio/transcriptions`, WebSocket realtime examples, `docs/vllm_guide.md`, the H100 vLLM smoke evidence, `runtime-llamacpp-v0.1.8`, troubleshooting docs, and asks real app users to share hardware, model path, latency, and deployment friction.
+- [ ] Pin a GitHub discussion for the release. The release discussion exists at [`modelscope/FunASR#3376`](https://github.com/modelscope/FunASR/discussions/3376), but the GitHub GraphQL API currently exposes `createDiscussion` and `updateDiscussion` but no discussion pin mutation; pin manually in the GitHub Discussions UI or retry if GitHub exposes an API for discussion pinning.
 - [ ] Triage all new issues within 48 hours.
 - [ ] Convert top 3 support questions into docs.
 - [ ] Track stars, PyPI downloads, issue volume, and docs traffic.

--- a/tests/test_growth_plan_doc.py
+++ b/tests/test_growth_plan_doc.py
@@ -193,3 +193,23 @@ def test_growth_plan_records_pypi_description_audit():
         assert marker in text
 
     assert "[ ] Update PyPI release description if needed" not in text
+
+
+def test_growth_plan_records_release_discussion_distribution():
+    text = PLAN.read_text()
+
+    required_markers = [
+        "[x] Share the release in relevant developer communities",
+        "modelscope/FunASR#3376",
+        "https://github.com/modelscope/FunASR/discussions/3376",
+        "FunASR v1.3.26: OpenAI-compatible ASR deployment, vLLM, and llama.cpp runtime",
+        "Announcements",
+        "`/v1/audio/transcriptions`",
+        "`runtime-llamacpp-v0.1.8`",
+        "GitHub GraphQL API currently exposes `createDiscussion` and `updateDiscussion` but no discussion pin mutation",
+        "[ ] Pin a GitHub discussion for the release",
+    ]
+    for marker in required_markers:
+        assert marker in text
+
+    assert "[ ] Share the release in relevant developer communities" not in text


### PR DESCRIPTION
## Summary

- published the v1.3.26 OpenAI-compatible deployment announcement as GitHub Discussion #3376
- marked the Week 4 release-sharing checklist item complete in the 20k-star tracker
- documented that GitHub GraphQL exposes discussion create/update APIs, but no discussion pin mutation was available for automation
- added a tracker regression test so the discussion link and pin-status note stay recorded

## Validation

- `python3 -m pytest tests/test_growth_plan_doc.py -q`
- `python3 scripts/check_funasr_website_static.py --timeout 20 --retries 1`
- `git diff --check`
- GitHub GraphQL readback for Discussion #3376
