### PR TITLE
Refresh public entrypoint links

### DIFF
--- a/benchmarks/benchmark_pipeline_cer.md
+++ b/benchmarks/benchmark_pipeline_cer.md
@@ -56,7 +56,7 @@ bash infer.sh
     <tr align="center">
         <td style="border: 1px solid"></td>
         <td style="border: 1px solid"></td>
-        <td style="border: 1px solid">dev</td> 
+        <td style="border: 1px solid">dev</td>
         <td style="border: 1px solid">test</td>
         <td style="border: 1px solid">dev_ios</td>
         <td style="border: 1px solid">test_ios</td>
@@ -67,7 +67,7 @@ bash infer.sh
         <td style="border: 1px solid">test_net</td>
     </tr>
     <tr align="center">
-        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary">Paraformer-large</a> </td>
+        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary">Paraformer-large</a> </td>
         <td style="border: 1px solid">Offline</td>
         <td style="border: 1px solid">1.76</td>
         <td style="border: 1px solid">1.94</td>
@@ -80,8 +80,8 @@ bash infer.sh
         <td style="border: 1px solid">6.66</td>
     </tr>
     <tr align="center">
-        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary">Paraformer-large-long</a> </td> 
-        <td style="border: 1px solid">Offline</td>      
+        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary">Paraformer-large-long</a> </td>
+        <td style="border: 1px solid">Offline</td>
         <td style="border: 1px solid">1.80</td>
         <td style="border: 1px solid">2.10</td>
         <td style="border: 1px solid">2.78</td>
@@ -106,7 +106,7 @@ bash infer.sh
         <td style="border: 1px solid">6.72</td>
     </tr>
     <tr align="center">
-        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-online/summary">Paraformer-large-online</a> </td>
+        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-online/summary">Paraformer-large-online</a> </td>
         <td style="border: 1px solid">Online</td>
         <td style="border: 1px solid">2.37</td>
         <td style="border: 1px solid">3.34</td>
@@ -119,7 +119,7 @@ bash infer.sh
         <td style="border: 1px solid">7.78</td>
     </tr>
     <tr align="center">
-        <td style="border: 1px solid"> <a href="https://modelscope.cn/models/damo/speech_paraformer_asr_nat-zh-cn-16k-common-vocab8358-tensorflow1/summary">Paraformer</a> </td> 
+        <td style="border: 1px solid"> <a href="https://modelscope.cn/models/damo/speech_paraformer_asr_nat-zh-cn-16k-common-vocab8358-tensorflow1/summary">Paraformer</a> </td>
         <td style="border: 1px solid">Offline</td>
         <td style="border: 1px solid">3.24</td>
         <td style="border: 1px solid">3.69</td>
@@ -132,7 +132,7 @@ bash infer.sh
         <td style="border: 1px solid">9.19</td>
     </tr>
    <tr align="center">
-        <td style="border: 1px solid"> <a href="https://modelscope.cn/models/damo/speech_UniASR_asr_2pass-zh-cn-16k-common-vocab8358-tensorflow1-online/summary">UniASR</a> </td> 
+        <td style="border: 1px solid"> <a href="https://modelscope.cn/models/damo/speech_UniASR_asr_2pass-zh-cn-16k-common-vocab8358-tensorflow1-online/summary">UniASR</a> </td>
         <td style="border: 1px solid">Online</td>
         <td style="border: 1px solid">3.34</td>
         <td style="border: 1px solid">3.99</td>
@@ -145,8 +145,8 @@ bash infer.sh
         <td style="border: 1px solid">9.70</td>
     </tr>
    <tr align="center">
-        <td style="border: 1px solid"> <a href="https://modelscope.cn/models/damo/speech_UniASR-large_asr_2pass-zh-cn-16k-common-vocab8358-tensorflow1-offline/summary">UniASR-large</a> </td> 
-        <td style="border: 1px solid">Offline</td>      
+        <td style="border: 1px solid"> <a href="https://modelscope.cn/models/damo/speech_UniASR-large_asr_2pass-zh-cn-16k-common-vocab8358-tensorflow1-offline/summary">UniASR-large</a> </td>
+        <td style="border: 1px solid">Offline</td>
         <td style="border: 1px solid">2.93</td>
         <td style="border: 1px solid">3.48</td>
         <td style="border: 1px solid">3.95</td>
@@ -184,7 +184,7 @@ bash infer.sh
         <td style="border: 1px solid">-</td>
     </tr>
    <tr align="center">
-        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformer_asr_nat-zh-cn-16k-aishell2-vocab5212-pytorch/summary">Paraformer-aishell2</a> </td> 
+        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformer_asr_nat-zh-cn-16k-aishell2-vocab5212-pytorch/summary">Paraformer-aishell2</a> </td>
         <td style="border: 1px solid">Offline</td>
         <td style="border: 1px solid">-</td>
         <td style="border: 1px solid">-</td>
@@ -197,7 +197,7 @@ bash infer.sh
         <td style="border: 1px solid">-</td>
     </tr>
    <tr align="center">
-        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformerbert_asr_nat-zh-cn-16k-aishell2-vocab5212-pytorch/summary">ParaformerBert-aishell2</a> </td> 
+        <td style="border: 1px solid"> <a href="https://www.modelscope.cn/models/damo/speech_paraformerbert_asr_nat-zh-cn-16k-aishell2-vocab5212-pytorch/summary">ParaformerBert-aishell2</a> </td>
         <td style="border: 1px solid">Offline</td>
         <td style="border: 1px solid">-</td>
         <td style="border: 1px solid">-</td>
@@ -213,4 +213,3 @@ bash infer.sh
 
 
 ### English Dataset
-

--- a/runtime/docs/benchmark_libtorch.md
+++ b/runtime/docs/benchmark_libtorch.md
@@ -35,7 +35,7 @@ nohup bash test_cer.sh &> log.txt &
 ```
 
 
-## [Paraformer-large](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) 
+## [Paraformer-large](https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary)
 
 
 ### Intel(R) Xeon(R) Platinum 8269CY CPU @ 2.50GHz   16core-32processor    with avx512_vnni

--- a/runtime/docs/benchmark_onnx.md
+++ b/runtime/docs/benchmark_onnx.md
@@ -35,9 +35,9 @@ set the model, data path and output_dir
 nohup bash test_cer.sh &> log.txt &
 ```
 
-## [Paraformer-large](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) 
+## [Paraformer-large](https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary)
 
-Number of Parameter: 220M 
+Number of Parameter: 220M
 
 Storage size: 880MB
 
@@ -95,7 +95,7 @@ CER after int8-quant: 1.95%
 
 ## [Paraformer](https://modelscope.cn/models/damo/speech_paraformer_asr_nat-zh-cn-16k-common-vocab8358-tensorflow1/summary)
 
-Number of Parameter: 68M 
+Number of Parameter: 68M
 
 Storage size: 275MB
 

--- a/runtime/docs/benchmark_onnx_cpp.md
+++ b/runtime/docs/benchmark_onnx_cpp.md
@@ -43,7 +43,7 @@ cmake  -DCMAKE_BUILD_TYPE=release .. -DONNXRUNTIME_DIR=/path/to/onnxruntime-linu
 make
 ```
 
-## [Paraformer-large](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) 
+## [Paraformer-large](https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary)
 ```shell
 ./funasr-onnx-offline-rtf \
     --model-dir    ./damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch \
@@ -51,10 +51,10 @@ make
     --wav-path     ./aishell1_test.scp  \
     --thread-num 32
 
-Node: '--quantize false' means fp32, otherwise it will be int8 
+Node: '--quantize false' means fp32, otherwise it will be int8
 ```
 
-Number of Parameter: 220M 
+Number of Parameter: 220M
 
 Storage size: 880MB
 
@@ -100,7 +100,7 @@ CER after int8-quant: 1.95%
 |  96   (onnx fp32)   |        115s        | 0.003183 |     314      |
 |  96   (onnx int8)   |        80s         | 0.002222 |     450      |
 
-## [FSMN-VAD](https://www.modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-onnx/summary) + [Paraformer-large](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) + [CT-Transformer](https://www.modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary)
+## [FSMN-VAD](https://www.modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-onnx/summary) + [Paraformer-large](https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) + [CT-Transformer](https://www.modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary)
 
 ```shell
 ./funasr-onnx-offline-rtf \
@@ -111,7 +111,7 @@ CER after int8-quant: 1.95%
     --wav-path     ./aishell1_test.scp  \
     --thread-num 32
 
-Node: '--quantize false' means fp32, otherwise it will be int8 
+Node: '--quantize false' means fp32, otherwise it will be int8
 ```
 
  ### Intel(R) Xeon(R) Platinum 8369B CPU @ 2.90GHz   16core-32processor    with avx512_vnni
@@ -152,7 +152,7 @@ Node: '--quantize false' means fp32, otherwise it will be int8
 
 
 
-## [FSMN-VAD](https://www.modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-onnx/summary) + [Paraformer-large](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) +[Ngram](https://www.modelscope.cn/models/damo/speech_ngram_lm_zh-cn-ai-wesp-fst/summary) + [CT-Transformer](https://www.modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary) 
+## [FSMN-VAD](https://www.modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-onnx/summary) + [Paraformer-large](https://www.modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) +[Ngram](https://www.modelscope.cn/models/damo/speech_ngram_lm_zh-cn-ai-wesp-fst/summary) + [CT-Transformer](https://www.modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary)
 
 ```shell
 ./funasr-onnx-offline-rtf \
@@ -164,7 +164,7 @@ Node: '--quantize false' means fp32, otherwise it will be int8
     --wav-path     ./aishell1_test.scp  \
     --thread-num 32
 
-Node: '--quantize false' means fp32, otherwise it will be int8 
+Node: '--quantize false' means fp32, otherwise it will be int8
 ```
 
  ### Intel(R) Xeon(R) Platinum 8369B CPU @ 2.90GHz   16core-32processor    with avx512_vnni
@@ -197,7 +197,7 @@ Node: '--quantize false' means fp32, otherwise it will be int8
     --wav-path     ./aishell1_test.scp  \
     --thread-num 32
 
-Node: '--quantize false' means fp32, otherwise it will be int8 
+Node: '--quantize false' means fp32, otherwise it will be int8
 ```
 
  ### Intel(R) Xeon(R) Platinum 8369B CPU @ 2.90GHz   16core-32processor    with avx512_vnni
@@ -218,7 +218,7 @@ Node: '--quantize false' means fp32, otherwise it will be int8
 | 96   (onnx int8) |        122s        | 0.0033 |      294      |
 
 
-## [FSMN-VAD](https://www.modelscope.cn/models/damo/speech_fsmn_vad_zh-cn-16k-common-onnx/summary) + [Paraformer-en](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-en-16k-common-vocab10020-onnx/summary) + [CT-Transformer](https://www.modelscope.cn/models/damo/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary)
+## [FSMN-VAD](https://www.modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-onnx/summary) + [Paraformer-en](https://www.modelscope.cn/models/damo/speech_paraformer-large_asr_nat-en-16k-common-vocab10020-onnx/summary) + [CT-Transformer](https://www.modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary)
 
 ```shell
 ./funasr-onnx-offline-rtf \
@@ -229,7 +229,7 @@ Node: '--quantize false' means fp32, otherwise it will be int8
     --wav-path     ./librispeech_test_clean.scp  \
     --thread-num 32
 
-Node: '--quantize false' means fp32, otherwise it will be int8 
+Node: '--quantize false' means fp32, otherwise it will be int8
 ```
 
  ### Intel(R) Xeon(R) Platinum 8369B CPU @ 2.90GHz   16core-32processor    with avx512_vnni

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -44,6 +44,9 @@ PUBLIC_ENTRYPOINTS_SHOULD_USE_CURRENT_REPO_URLS = [
     "model_zoo/modelscope_models.md",
     "model_zoo/modelscope_models_zh.md",
     "model_zoo/readme.md",
+    "web-pages/src/views/home/index.vue",
+    "web-pages/src/views/home/lxwjzxfw.vue",
+    "web-pages/src/views/home/sstx.vue",
     "runtime/deploy_tools/funasr-runtime-deploy-offline-cpu-en.sh",
     "runtime/deploy_tools/funasr-runtime-deploy-offline-cpu-zh.sh",
     "runtime/deploy_tools/funasr-runtime-deploy-online-cpu-zh.sh",
@@ -227,6 +230,32 @@ def test_full_modelscope_tables_use_current_core_entries():
             assert marker in text
         for marker in stale_entries:
             assert marker not in text
+
+
+def test_runtime_benchmark_docs_use_current_core_modelscope_entries():
+    docs = [
+        (ROOT / "benchmarks/benchmark_pipeline_cer.md").read_text(),
+        (ROOT / "runtime/docs/benchmark_libtorch.md").read_text(),
+        (ROOT / "runtime/docs/benchmark_onnx.md").read_text(),
+        (ROOT / "runtime/docs/benchmark_onnx_cpp.md").read_text(),
+    ]
+
+    current_entries = [
+        "models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary",
+        "models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary",
+        "models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-online/summary",
+        "models/iic/speech_fsmn_vad_zh-cn-16k-common-onnx/summary",
+        "models/iic/punc_ct-transformer_zh-cn-common-vocab272727-onnx/summary",
+    ]
+    stale_entries = [
+        entry.replace("models/iic/", "models/damo/") for entry in current_entries
+    ]
+
+    combined = "\n".join(docs)
+    for marker in current_entries:
+        assert marker in combined
+    for marker in stale_entries:
+        assert marker not in combined
 
 
 def test_model_zoo_landing_tables_link_huggingface_repos():

--- a/web-pages/src/views/home/index.vue
+++ b/web-pages/src/views/home/index.vue
@@ -6,7 +6,7 @@
                 <li :ref="item.ref" v-for="(item, index) in headerList" :key="index" @click="anchorTo(item)">
                     <p>{{item.name}}</p>
                 </li>
-                <li @click="toPage({link: 'https://github.com/alibaba-damo-academy/FunASR'})">
+                <li @click="toPage({link: 'https://github.com/modelscope/FunASR'})">
                     Github
                 </li>
                 <li>

--- a/web-pages/src/views/home/lxwjzxfw.vue
+++ b/web-pages/src/views/home/lxwjzxfw.vue
@@ -135,7 +135,7 @@ export default {
                 {
                     icon: require('./assets/images/lxwj-az.png'),
                     title: '安  装',
-                    link: 'https://github.com/alibaba-damo-academy/FunASR/blob/main/runtime/docs/SDK_advanced_guide_offline_zh.md'
+                    link: 'https://github.com/modelscope/FunASR/blob/main/runtime/docs/SDK_advanced_guide_offline_zh.md'
                 },
                 {
                     icon: require('./assets/images/lxwj-sy.png'),

--- a/web-pages/src/views/home/sstx.vue
+++ b/web-pages/src/views/home/sstx.vue
@@ -153,7 +153,7 @@ export default {
                 {
                     icon: require('./assets/images/lxwj-az.png'),
                     title: '安  装',
-                    link: 'https://github.com/alibaba-damo-academy/FunASR/blob/main/runtime/docs/SDK_advanced_guide_online_zh.md'
+                    link: 'https://github.com/modelscope/FunASR/blob/main/runtime/docs/SDK_advanced_guide_online_zh.md'
                 },
                 {
                     icon: require('./assets/images/lxwj-sy.png'),


### PR DESCRIPTION
## Summary

- refresh high-traffic benchmark ModelScope links from stale `damo` paths to current `iic` model pages where verified
- refresh legacy homepage source links from `alibaba-damo-academy/FunASR` to `modelscope/FunASR`
- extend link regression tests so public entry points do not drift back to the old repository or stale core ModelScope pages

## Validation

- `python3 -m pytest tests/test_docs_funasr_install_commands.py -q`
- `python3 -m pytest tests/test_docs_funasr_install_commands.py tests/test_markdown_relative_links.py tests/test_check_funasr_website_static.py tests/test_growth_plan_doc.py -q`
- `python3 scripts/check_funasr_website_static.py --timeout 20 --retries 1`
- `git diff --check`
- HTTP 200 checks for the refreshed ModelScope and GitHub URLs
