### PR TITLE
fix: limit vLLM VAD segments to 30 seconds

### DIFF
--- a/examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py
+++ b/examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py
@@ -93,7 +93,12 @@ def load_engine(args):
             gpu_memory_utilization=args.gpu_memory_utilization,
         )
         logger.info(f"Loading VAD: {args.vad_model}")
-        _vad_model = AutoModel(model=args.vad_model, device=args.device, disable_update=True)
+        _vad_model = AutoModel(
+            model=args.vad_model,
+            device=args.device,
+            disable_update=True,
+            max_single_segment_time=30000,
+        )
         if args.spk_model:
             logger.info(f"Loading SPK: {args.spk_model}")
             _spk_model = AutoModel(model=args.spk_model, device=args.device, disable_update=True)

--- a/tests/test_fun_asr_nano_openai_response.py
+++ b/tests/test_fun_asr_nano_openai_response.py
@@ -151,3 +151,35 @@ def test_process_audio_downmixes_stereo_before_resampling(monkeypatch):
     assert np.allclose(captured["engine_input"], 0.5)
     assert result["duration"] == 1.0
     assert result["text"] == "ok"
+
+
+def test_load_engine_limits_vad_segments_to_30_seconds(monkeypatch):
+    module = load_service_module(monkeypatch)
+    captured = {}
+
+    class EngineFactoryStub:
+        @classmethod
+        def from_pretrained(cls, **kwargs):
+            return object()
+
+    def auto_model_stub(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    module.FunASRNanoVLLM = EngineFactoryStub
+    module.AutoModel = auto_model_stub
+    module._engine = None
+    module.load_engine(
+        types.SimpleNamespace(
+            model="fun-asr-nano",
+            hub="ms",
+            device="cpu",
+            dtype="bf16",
+            max_model_len=4096,
+            gpu_memory_utilization=0.5,
+            vad_model="fsmn-vad",
+            spk_model="",
+        )
+    )
+
+    assert captured["max_single_segment_time"] == 30000


### PR DESCRIPTION
## Summary

- configure the standalone Fun-ASR-Nano vLLM server's FSMN-VAD model with a 30-second maximum segment duration
- add a regression test that verifies the limit is applied when the VAD model is constructed

## Why

The server constructed FSMN-VAD without `max_single_segment_time`, so it inherited the 60-second default. Passing this value to `AutoModel.generate()` is ineffective because FSMN-VAD stores it in `VADXOptions` at model construction time.

On the 480-second attachment from #3419, a 60-second segment omitted a substantial passage around the Blackwell/product update and robot discussion. The 30-second configuration matches the existing Fun-ASR-Nano examples and documentation.

## Validation

- `python3 -m pytest tests/test_fun_asr_nano_autocast_device.py tests/test_fun_asr_nano_ctc_batch_fallback.py tests/test_fun_asr_nano_missing_ctc_weights.py tests/test_fun_asr_nano_openai_response.py tests/test_fun_asr_nano_repetition_penalty.py -q` (`27 passed`)
- `python3 -m py_compile examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py tests/test_fun_asr_nano_openai_response.py`
- `python3 -m black --check tests/test_fun_asr_nano_openai_response.py`
- `git diff --check origin/main...HEAD`

Real-audio comparison using the issue attachment:

| Metric | Before | After |
| --- | ---: | ---: |
| VAD segments | 13 | 20 |
| Maximum segment duration | 60.01 s | 30.01 s |
| Aligned, script-normalized CER | 22.74% | 19.63% |
| RTF | 0.0087 | 0.0169 |

The CER comparison removes the unmatched 0-17.69 second teaser that is absent from the reference transcript and converts both reference and hypothesis to Simplified Chinese before retaining letters and numbers. The recovered passage is present after the change, although proper-name recognition such as `Blackwell` remains imperfect.

Related to #3419.
