### PR TITLE
docs: surface the deployment product hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="#quick-start">Quick Start</a> · <a href="./examples/colab/">Colab</a> · <a href="#benchmark">Benchmark</a> · <a href="./docs/model_selection.md">Model selection</a> · <a href="./docs/migration_from_whisper.md">Migration guide</a> · <a href="./docs/use_case_showcase.md">Use cases</a> · <a href="./docs/community_projects.md">Community integrations</a> · <a href="./docs/deployment_matrix.md">Deployment matrix</a> · <a href="./docs/troubleshooting.md">Troubleshooting</a> · <a href="#model-zoo">Models</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent Integration</a> · <a href="https://modelscope.github.io/FunASR/">Docs</a> · <a href="./CONTRIBUTING.md">Contribute</a>
+  <a href="#quick-start">Quick Start</a> · <a href="./examples/colab/">Colab</a> · <a href="#benchmark">Benchmark</a> · <a href="./docs/model_selection.md">Model selection</a> · <a href="./docs/migration_from_whisper.md">Migration guide</a> · <a href="./docs/use_case_showcase.md">Use cases</a> · <a href="./docs/community_projects.md">Community integrations</a> · <a href="./docs/deployment_matrix.md">Deployment matrix</a> · <a href="https://www.funasr.com/">Deployment hub</a> · <a href="./docs/troubleshooting.md">Troubleshooting</a> · <a href="#model-zoo">Models</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent Integration</a> · <a href="https://modelscope.github.io/FunASR/">Docs</a> · <a href="./CONTRIBUTING.md">Contribute</a>
 </p>
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="#快速开始">快速开始</a> · <a href="./examples/colab/README_zh.md">Colab</a> · <a href="#性能评测">性能评测</a> · <a href="./docs/model_selection_zh.md">模型选择</a> · <a href="./docs/migration_from_whisper_zh.md">迁移指南</a> · <a href="./docs/use_case_showcase_zh.md">场景速览</a> · <a href="./docs/community_projects_zh.md">社区集成</a> · <a href="./docs/deployment_matrix_zh.md">部署选型</a> · <a href="./docs/troubleshooting_zh.md">排障 FAQ</a> · <a href="#模型列表">模型列表</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent 集成</a> · <a href="https://modelscope.github.io/FunASR/zh/">文档</a> · <a href="./CONTRIBUTING.md">贡献</a>
+  <a href="#快速开始">快速开始</a> · <a href="./examples/colab/README_zh.md">Colab</a> · <a href="#性能评测">性能评测</a> · <a href="./docs/model_selection_zh.md">模型选择</a> · <a href="./docs/migration_from_whisper_zh.md">迁移指南</a> · <a href="./docs/use_case_showcase_zh.md">场景速览</a> · <a href="./docs/community_projects_zh.md">社区集成</a> · <a href="./docs/deployment_matrix_zh.md">部署选型</a> · <a href="https://www.funasr.com/">部署中心</a> · <a href="./docs/troubleshooting_zh.md">排障 FAQ</a> · <a href="#模型列表">模型列表</a> · <a href="https://modelscope.github.io/FunASR/agent.html">Agent 集成</a> · <a href="https://modelscope.github.io/FunASR/zh/">文档</a> · <a href="./CONTRIBUTING.md">贡献</a>
 </p>
 
 ---

--- a/tests/test_readme_deployment_hub_links.py
+++ b/tests/test_readme_deployment_hub_links.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOYMENT_HUB_URL = "https://www.funasr.com/"
+
+
+@pytest.mark.parametrize(
+    ("readme", "label"),
+    (("README.md", "Deployment hub"), ("README_zh.md", "部署中心")),
+)
+def test_deployment_hub_is_in_readme_primary_navigation(readme: str, label: str) -> None:
+    primary_navigation = "\n".join((ROOT / readme).read_text(encoding="utf-8").splitlines()[:40])
+    link = f'<a href="{DEPLOYMENT_HUB_URL}">{label}</a>'
+
+    assert primary_navigation.count(link) == 1


### PR DESCRIPTION
## Summary

- add the live FunASR deployment product hub to the English README primary navigation
- add the matching deployment-center entry to the Chinese README primary navigation
- guard both first-screen links with a focused bilingual regression test

The target page is already live and provides the evidence-backed selector for vLLM, llama.cpp/GGUF, OpenAI-compatible APIs, realtime serving, containers, and ONNX/C++ CPU deployment.

## Why

GitHub traffic for the last 14 days shows `funasr.com` already referred 603 unique visitors to FunASR, but the README only exposed the site in its bottom resource table. This change makes the deployment path discoverable from the most-viewed repository entry points without adding promotional copy to the body.

## Verification

- red-first contract: 2 expected failures before the links were added
- `35 passed` across the new contract, documentation install checks, and growth-plan checks
- `git diff --check`
- `https://www.funasr.com/` returns HTTP/2 200 with the production CSP and cache policy
