### PR TITLE
feat(site): attribute repository conversions

### DIFF
--- a/docs/operations/funasr-com-site-release.md
+++ b/docs/operations/funasr-com-site-release.md
@@ -75,6 +75,12 @@ kill -HUP <master-pid>
 
 ## Monitoring
 
+Visible repository, documentation, and release links use the fixed `/go/github`,
+`/go/docs`, and `/go/releases` routes. The JSON-LD `codeRepository` value remains
+the direct GitHub URL so attribution does not change search metadata. Redirect
+targets are defined only in `web-pages/nginx/conversion-map.conf`; never accept a
+target from a query parameter.
+
 Check after one hour and again after 24 hours:
 
 ```bash
@@ -83,6 +89,13 @@ tail -200 /var/log/nginx/funasr-conversions.log
 curl -fsSI https://www.funasr.com/
 curl -fsSI https://www.funasr.com/deploy/vllm.html
 curl -fsSI https://www.funasr.com/blog/
+```
+
+Count non-smoke conversion requests by route:
+
+```bash
+grep -vE '"(FunASR release smoke|curl/)' /var/log/nginx/funasr-conversions.log \
+  | awk '{print $7}' | sort | uniq -c | sort -nr
 ```
 
 Roll back on elevated 5xx responses, missing indexed routes, mobile overflow, missing assets, invalid conversion redirects, or a failed static validation.

--- a/web-pages/product-site/build.py
+++ b/web-pages/product-site/build.py
@@ -21,6 +21,7 @@ from selector import MATCH_WEIGHTS
 
 SITE_ROOT = Path(__file__).resolve().parent
 BASE_URL = 'https://www.funasr.com'
+GITHUB_REPOSITORY_URL = 'https://github.com/modelscope/FunASR'
 
 
 def sha256(path: Path) -> str:
@@ -129,7 +130,10 @@ def _page_context(
         'description': description,
         'navigation': _navigation(navigation, language),
         'assets': assets,
-        'github_url': 'https://github.com/modelscope/FunASR',
+        'github_repository_url': GITHUB_REPOSITORY_URL,
+        'github_url': '/go/github',
+        'docs_url': '/go/docs',
+        'releases_url': '/go/releases',
     }
 
 

--- a/web-pages/product-site/templates/base.html
+++ b/web-pages/product-site/templates/base.html
@@ -21,7 +21,7 @@
     'applicationCategory': 'DeveloperApplication',
     'operatingSystem': 'Linux, macOS, Windows',
     'url': canonical,
-    'codeRepository': github_url,
+    'codeRepository': github_repository_url,
     'license': 'https://www.apache.org/licenses/LICENSE-2.0'
   } | tojson }}</script>
 </head>
@@ -60,7 +60,8 @@
     </div>
     <div class="footer-links">
       <a href="{{ '/deploy/' if language == 'zh' else '/en/deploy/' }}">{{ '部署' if language == 'zh' else 'Deploy' }}</a>
-      <a href="https://github.com/modelscope/FunASR/tree/main/docs">{{ '文档' if language == 'zh' else 'Docs' }}</a>
+      <a href="{{ docs_url }}">{{ '文档' if language == 'zh' else 'Docs' }}</a>
+      <a href="{{ releases_url }}">{{ '发布' if language == 'zh' else 'Releases' }}</a>
       <a href="{{ '/donors.html' if language == 'zh' else '/en/donors.html' }}">{{ '功德榜' if language == 'zh' else 'Donors' }}</a>
     </div>
   </footer>

--- a/web-pages/product-site/tests/test_build.py
+++ b/web-pages/product-site/tests/test_build.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -73,6 +74,25 @@ def test_language_metadata_is_symmetric(tmp_path):
     assert en.select_one('link[rel="canonical"]')['href'] == 'https://www.funasr.com/en/'
     assert zh.select_one('link[hreflang="en"]')['href'] == 'https://www.funasr.com/en/'
     assert en.select_one('link[hreflang="zh-CN"]')['href'] == 'https://www.funasr.com/'
+
+
+def test_visible_repository_links_use_fixed_conversion_routes(tmp_path):
+    build(tmp_path)
+
+    for relative in ('index.html', 'en/index.html'):
+        soup = read_soup(tmp_path / relative)
+        github_links = soup.select('a[aria-label="GitHub"], .final-cta a')
+        github_hrefs = {
+            link.get('href')
+            for link in github_links
+            if link.get_text(strip=True) == 'GitHub' or link.get('aria-label') == 'GitHub'
+        }
+        json_ld = json.loads(soup.select_one('script[type="application/ld+json"]').string)
+
+        assert github_hrefs == {'/go/github'}
+        assert soup.select_one('.site-footer a[href="/go/docs"]')
+        assert soup.select_one('.site-footer a[href="/go/releases"]')
+        assert json_ld['codeRepository'] == 'https://github.com/modelscope/FunASR'
 
 
 def test_build_manifest_records_asset_hashes(tmp_path):


### PR DESCRIPTION
## Summary

FunASR.com already sends meaningful traffic to the repository, but the product site's visible GitHub and documentation links bypass the fixed `/go/*` routes, so the conversion log only records release smoke checks.

This change:

- routes visible GitHub and documentation links through `/go/github` and `/go/docs`;
- adds a visible `/go/releases` footer link for the wheel, sdist, and runtime assets;
- keeps JSON-LD `codeRepository` pointed directly at `https://github.com/modelscope/FunASR` so search metadata remains canonical;
- documents non-smoke conversion counting and the fixed-target/no-query-redirect security boundary;
- adds a bilingual build contract covering visible links and JSON-LD.

The Nginx redirect map remains fixed and already rejects unknown routes. No query-controlled redirect is introduced.

## Evidence

- GitHub 14-day traffic before the change: 36,115 views / 9,106 unique visitors; `funasr.com` referred 1,560 visits / 603 unique visitors.
- Red test first showed visible links still used the direct repository URL.
- Product-site Python suite: **42 passed**.
- Static build and validator: **21 product pages built, 92 HTML pages validated**.
- Representative bilingual conversion contract: passed on home, vLLM, and llama.cpp pages.
- Playwright: **7 passed** across 390x844, 768x1024, 1440x900, and 1920x1080, including overflow/overlap, keyboard navigation, selector, copy, compatibility routes, and reduced motion.
- Ruff fatal-error rules and `git diff --check`: passed.

## Rollback

- Base: `866cf910dc856655ce36ac8fb34184cb6807f27d`
- Base backup: `codex/backup-site-conversion-base-866cf91-20260727`
- Candidate backup: `codex/backup-site-conversion-pre-pr-996ff77-20260727`
