### PR TITLE
test(site): align homepage patrol with product build

### DIFF
--- a/scripts/check_funasr_website_static.py
+++ b/scripts/check_funasr_website_static.py
@@ -41,7 +41,7 @@ class StaticAssetContract:
 PAGE_CONTRACTS: dict[str, PageContract] = {
     f"{BASE_URL}/": PageContract(
         required=(
-            "工业级",
+            "可私有化部署的语音智能基础设施",
             "/v1/audio/transcriptions",
             "vLLM",
             "/donors.html",
@@ -49,7 +49,7 @@ PAGE_CONTRACTS: dict[str, PageContract] = {
     ),
     f"{BASE_URL}/en/": PageContract(
         required=(
-            "Industrial Speech Recognition",
+            "Private-deployment speech infrastructure",
             "OpenAI-compatible",
             "/v1/audio/transcriptions",
             "vLLM",

--- a/tests/test_check_funasr_website_static.py
+++ b/tests/test_check_funasr_website_static.py
@@ -18,18 +18,33 @@ def _load_module():
     return module
 
 
+def _load_product_site_builder():
+    site_root = ROOT / "web-pages" / "product-site"
+    spec = importlib.util.spec_from_file_location(
+        "funasr_product_site_build", site_root / "build.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    sys.path.insert(0, str(site_root))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(site_root))
+    return module
+
+
 def test_website_contract_accepts_current_public_copy():
     checker = _load_module()
 
     pages = {
         "https://www.funasr.com/": """
-            工业级 语音识别服务
+            可私有化部署的语音智能基础设施
             /v1/audio/transcriptions
             vLLM 加速
             <a href="/donors.html">功德榜</a>
         """,
         "https://www.funasr.com/en/": """
-            Industrial Speech Recognition
+            Private-deployment speech infrastructure
             OpenAI-compatible
             /v1/audio/transcriptions
             vLLM Acceleration
@@ -230,6 +245,24 @@ def test_website_contract_accepts_current_public_copy():
             </body>
         """,
     }
+
+    assert checker.validate_pages(pages) == []
+
+
+def test_homepage_contract_accepts_current_product_site_build(tmp_path, monkeypatch):
+    checker = _load_module()
+    builder = _load_product_site_builder()
+    builder.build(tmp_path)
+    urls = ("https://www.funasr.com/", "https://www.funasr.com/en/")
+    pages = {
+        urls[0]: (tmp_path / "index.html").read_text(encoding="utf-8"),
+        urls[1]: (tmp_path / "en" / "index.html").read_text(encoding="utf-8"),
+    }
+    monkeypatch.setattr(
+        checker,
+        "PAGE_CONTRACTS",
+        {url: checker.PAGE_CONTRACTS[url] for url in urls},
+    )
 
     assert checker.validate_pages(pages) == []
 


### PR DESCRIPTION
## Summary

- align the public homepage patrol with the current product-site titles
- add a regression that builds the canonical product site and validates both homepages against the patrol contracts
- keep the existing OpenAI endpoint, vLLM, and donor-link checks unchanged

The old two phrases were absent from the current release and the preceding three immutable releases, so this removes a pre-existing false alarm without weakening the active product checks.

## Validation

- `python scripts/check_funasr_website_static.py --timeout 15 --retries 3`
  - 20 page contracts, 88 navigation pages, 3 assets passed
- `python -m pytest -q tests/test_check_funasr_website_static.py tests/test_growth_plan_doc.py web-pages/product-site/tests`
  - 92 passed
- `git diff --check`

Signed-off-by: Zhifu Gao <gaozhifu.gzf@alibaba-inc.com>