### PR TITLE
fix(auto-model): report vda model typo

### DIFF
--- a/funasr/auto/auto_model.py
+++ b/funasr/auto/auto_model.py
@@ -421,6 +421,11 @@ class AutoModel:
             >>> model = AutoModel(model="FunAudioLLM/Fun-ASR-Nano-2512", trust_remote_code=True,
             ...                   remote_code="./model.py", vad_model="fsmn-vad", spk_model="cam++", hub="hf")
         """
+        if "vda_model" in kwargs:
+            raise TypeError(
+                "`vda_model` is not a valid AutoModel argument; use `vad_model` to enable voice activity detection."
+            )
+
         try:
             from funasr.utils.version_checker import check_for_update
 

--- a/tests/test_auto_model.py
+++ b/tests/test_auto_model.py
@@ -23,6 +23,13 @@ class TestAutoModel(unittest.TestCase):
             "disable_update": True,
         }
 
+    def test_vda_model_typo_reports_vad_model_parameter(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            r"`vda_model`.*`vad_model`",
+        ):
+            AutoModel(vda_model="fsmn-vad", disable_update=True)
+
     def test_merge_thr_in_cb_model(self):
         kwargs = self.base_kwargs.copy()
         kwargs["spk_model"] = "cam++"


### PR DESCRIPTION
## Summary

- reject the common `vda_model` misspelling before model download or construction
- point users directly to the supported `vad_model` argument
- add a no-download regression for the exact failure reported in Discussion #3430

Without this guard, `vda_model` is silently carried as a model-specific override, the VAD model is never built, and long-audio segmentation, speaker post-processing, and `sentence_info` do not run.

Closes the diagnostic gap in #3430.

## Validation

- red: the regression reached the unrelated missing-main-model assertion
- green: 26 focused AutoModel/VAD/CLI tests passed
- `python -m compileall -q funasr/auto/auto_model.py tests/test_auto_model.py`
- `git diff --check`

The two legacy ModelScope pipeline tests cannot collect in the host system Python because optional `modelscope` is absent; the same collection error reproduces on the unchanged base. The old `test_merge_thr_in_cb_model` also fails identically on base because optional imports leave its remote model unregistered.

Signed-off-by: Zhifu Gao <gaozhifu.gzf@alibaba-inc.com>