### PR TITLE
fix: include runtime package data in PyPI artifacts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,16 @@ setup(
     long_description_content_type="text/markdown",
     license="The MIT License",
     packages=find_packages(include=["funasr*"]),
-    package_data={"funasr": ["version.txt"]},
+    package_data={
+        "funasr": [
+            "version.txt",
+            "models/sense_voice/whisper_lib/normalizers/english.json",
+            "models/rwkv_bat/cuda_encoder/*.cpp",
+            "models/rwkv_bat/cuda_encoder/*.cu",
+            "models/rwkv_bat/cuda_decoder/*.cpp",
+            "models/rwkv_bat/cuda_decoder/*.cu",
+        ]
+    },
     install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=tests_require,

--- a/tests/test_release_package_data.py
+++ b/tests/test_release_package_data.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import subprocess
+import sys
+from zipfile import ZipFile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_PACKAGE_FILES = {
+    "funasr/models/sense_voice/whisper_lib/normalizers/english.json",
+    "funasr/models/rwkv_bat/cuda_encoder/wkv_cuda.cu",
+    "funasr/models/rwkv_bat/cuda_encoder/wkv_op.cpp",
+    "funasr/models/rwkv_bat/cuda_decoder/wkv_cuda.cu",
+    "funasr/models/rwkv_bat/cuda_decoder/wkv_op.cpp",
+}
+
+
+def test_wheel_includes_runtime_package_data(tmp_path):
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from setuptools import build_meta; "
+            "build_meta.build_wheel(sys.argv[1])",
+            str(tmp_path),
+        ],
+        check=True,
+        cwd=ROOT,
+    )
+    [wheel_path] = tmp_path.glob("*.whl")
+
+    with ZipFile(wheel_path) as wheel:
+        wheel_files = set(wheel.namelist())
+
+    assert RUNTIME_PACKAGE_FILES <= wheel_files


### PR DESCRIPTION
## Summary

- include SenseVoice's English spelling map in wheel and sdist artifacts
- include the four RWKV-BAT CUDA kernel source files loaded at runtime
- add a release contract that builds a real wheel and checks all five files

## Root cause

`setup.py` declared only `version.txt` as package data. The public `funasr==1.3.30` wheel and the initial `1.4.0` candidate therefore omit `english.json` and the RWKV kernel `.cpp/.cu` sources. Installed-wheel English normalization and CUDA kernel compilation can consequently fail with missing files.

## Validation

- red-first wheel contract reproduced all five missing files on public 1.3.30 and current main
- final focused suite: 135 passed
- order-sensitive package-data + WebSocket regression pair: 2 passed
- isolated wheel install: `EnglishSpellingNormalizer()(\"colour centre\") == \"color center\"`
- installed wheel contains all four RWKV-BAT kernel sources
- wheel and sdist pass `twine check`
- all five sdist files are byte-identical to source
- `compileall` and `git diff --check` pass

This should merge before the prepared `1.4.0` PyPI release is rebuilt from exact current `main`.
