### PR TITLE
fix(runtime): make AudioFrame copies own their sample data

### DIFF
--- a/runtime/onnxruntime/include/audio.h
+++ b/runtime/onnxruntime/include/audio.h
@@ -24,6 +24,7 @@ class AudioFrame {
     AudioFrame();
     AudioFrame(int len);
     AudioFrame(const AudioFrame &other);
+    AudioFrame& operator=(const AudioFrame &other);
     AudioFrame(int start, int end, bool is_final);
 
     ~AudioFrame();

--- a/runtime/onnxruntime/src/audio.cpp
+++ b/runtime/onnxruntime/src/audio.cpp
@@ -151,11 +151,40 @@ AudioFrame::AudioFrame(int len) : len(len)
     start = 0;
 }
 AudioFrame::AudioFrame(const AudioFrame &other)
+    : start(other.start), end(other.end), is_final(other.is_final), len(other.len),
+      global_start(other.global_start), global_end(other.global_end)
 {
+    if (other.data != nullptr && len > 0) {
+        data = static_cast<float*>(malloc(sizeof(float) * len));
+        if (data != nullptr) {
+            memcpy(data, other.data, sizeof(float) * len);
+        }
+    }
+}
+AudioFrame& AudioFrame::operator=(const AudioFrame &other)
+{
+    if (this == &other) {
+        return *this;
+    }
+
+    float* copied_data = nullptr;
+    if (other.data != nullptr && other.len > 0) {
+        copied_data = static_cast<float*>(malloc(sizeof(float) * other.len));
+        if (copied_data == nullptr) {
+            return *this;
+        }
+        memcpy(copied_data, other.data, sizeof(float) * other.len);
+    }
+
+    free(data);
     start = other.start;
     end = other.end;
-    len = other.len;
     is_final = other.is_final;
+    data = copied_data;
+    len = other.len;
+    global_start = other.global_start;
+    global_end = other.global_end;
+    return *this;
 }
 AudioFrame::AudioFrame(int start, int end, bool is_final):start(start),end(end),is_final(is_final){
     len = end - start;


### PR DESCRIPTION
## What does this PR do?

Complete `AudioFrame`'s copy ownership semantics:

- Deep-copy the owned sample buffer in the copy constructor.
- Copy `global_start` and `global_end` metadata.
- Add a deep-copy assignment operator with self-assignment and allocation-failure guards.

## Why is this needed?

`AudioFrame` owns `data` and releases it in its destructor. The existing copy constructor copied only part of the metadata and silently dropped the sample buffer. The implicit copy-assignment operator was more dangerous: it shallow-copied the owned pointer, allowing two frames to free the same allocation.

Implementing both copy operations keeps the existing copyable API while giving each frame independent ownership of its samples.

## Validation

- `git diff --check`
- Verified the copy constructor and assignment operator copy all frame fields.
- Verified self-assignment leaves the frame unchanged.
- Verified assignment allocates the replacement before releasing the destination buffer.
- Verified `AudioFrame` copy operations are not currently used by the in-tree runtime call sites, so this does not change hot-path behavior.
