### PR TITLE
fix: route paraformer-en to the English HF model

### DIFF
--- a/funasr/download/name_maps_from_hub.py
+++ b/funasr/download/name_maps_from_hub.py
@@ -21,7 +21,7 @@ name_maps_ms = {
 name_maps_hf = {
     "paraformer": "funasr/paraformer-zh",
     "paraformer-zh": "funasr/paraformer-zh",
-    "paraformer-en": "funasr/paraformer-zh",
+    "paraformer-en": "funasr/paraformer-en",
     "paraformer-zh-streaming": "funasr/paraformer-zh-streaming",
     "fsmn-vad": "funasr/fsmn-vad",
     "ct-punc": "funasr/ct-punc",

--- a/tests/test_hf_model_aliases.py
+++ b/tests/test_hf_model_aliases.py
@@ -1,0 +1,5 @@
+from funasr.download.name_maps_from_hub import name_maps_hf
+
+
+def test_hf_paraformer_en_alias_targets_english_checkpoint():
+    assert name_maps_hf["paraformer-en"] == "funasr/paraformer-en"


### PR DESCRIPTION
## Summary

- route the `paraformer-en` Hugging Face alias to the official `funasr/paraformer-en` checkpoint
- add a focused regression test for the language-specific alias

## Root cause

`name_maps_hf` mapped `paraformer-en` to `funasr/paraformer-zh`, so `AutoModel(model="paraformer-en", hub="hf")` silently downloaded the Chinese model. This was independently reported during an external ONNX conversion campaign in TigreGotico/onnx-asr#21.

## Validation

- red-first regression reproduced the old `funasr/paraformer-zh` resolution
- `pytest tests/test_hf_model_aliases.py tests/test_cli.py -q` -> 5 passed
- Ruff check and format check passed
- anonymous download from an empty Hugging Face cache resolved `funasr/paraformer-en@d043d604`
- the 887 MB checkpoint loaded with all keys matched and completed CPU inference (RTF 0.057)
- `git diff --check` passed

The commit is SSH-signed and DCO-signed.
