### PR TITLE
test(site): refresh ecosystem contract

### DIFF
--- a/scripts/check_funasr_website_static.py
+++ b/scripts/check_funasr_website_static.py
@@ -57,7 +57,7 @@ PAGE_CONTRACTS: dict[str, PageContract] = {
     ),
     f"{BASE_URL}/ecosystem.html": PageContract(
         required=(
-            "35K+",
+            "36K+",
             "/donors.html",
             "LiteLLM",
             "custom_openai",
@@ -67,12 +67,18 @@ PAGE_CONTRACTS: dict[str, PageContract] = {
             ("FunASR 官方插件 0.1.1", r"FunASR 官方插件 0\.1\.1(?![\w.+-])"),
             ("最大 25 MB 音频上传", r"最大 (?<!\d)25 MB 音频上传"),
         ),
-        required_links=("https://marketplace.dify.ai/plugin/langgenius/funasr",),
+        required_links=(
+            "https://marketplace.dify.ai/plugin/langgenius/funasr",
+            "https://github.com/modelscope/FunClip/releases/tag/v2.1.1",
+            "https://github.com/0xShug0/audio.cpp",
+            "https://github.com/0xShug0/audio.cpp/pull/155",
+            "https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md",
+        ),
         forbidden=("16K+",),
     ),
     f"{BASE_URL}/en/ecosystem.html": PageContract(
         required=(
-            "35K+",
+            "36K+",
             "/en/donors.html",
             "LiteLLM",
             "custom_openai",
@@ -82,7 +88,13 @@ PAGE_CONTRACTS: dict[str, PageContract] = {
             ("FunASR plugin 0.1.1", r"FunASR plugin 0\.1\.1(?![\w.+-])"),
             ("25 MB uploads", r"(?<!\d)25 MB uploads"),
         ),
-        required_links=("https://marketplace.dify.ai/plugin/langgenius/funasr",),
+        required_links=(
+            "https://marketplace.dify.ai/plugin/langgenius/funasr",
+            "https://github.com/modelscope/FunClip/releases/tag/v2.1.1",
+            "https://github.com/0xShug0/audio.cpp",
+            "https://github.com/0xShug0/audio.cpp/pull/155",
+            "https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md",
+        ),
         forbidden=("16K+",),
     ),
     f"{BASE_URL}/donors.html": PageContract(

--- a/tests/test_check_funasr_website_static.py
+++ b/tests/test_check_funasr_website_static.py
@@ -50,9 +50,13 @@ def test_website_contract_accepts_current_public_copy():
             vLLM Acceleration
         """,
         "https://www.funasr.com/ecosystem.html": """
-            <div class="stat-num">35K+</div>
+            <div class="stat-num">36K+</div>
             <a href="/donors.html">功德榜</a>
             <a href="https://github.com/BerriAI/litellm">LiteLLM</a>
+            <a href="https://github.com/modelscope/FunClip/releases/tag/v2.1.1">FunClip v2.1.1</a>
+            <a href="https://github.com/0xShug0/audio.cpp">audio.cpp</a>
+            <a href="https://github.com/0xShug0/audio.cpp/pull/155">merged PR</a>
+            <a href="https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md">pinned guide</a>
             <div>custom_openai</div>
             <div>54.3K stars</div>
             <a href="https://marketplace.dify.ai/plugin/langgenius/funasr">
@@ -61,9 +65,13 @@ def test_website_contract_accepts_current_public_copy():
             <div>支持最大 25 MB 音频上传</div>
         """,
         "https://www.funasr.com/en/ecosystem.html": """
-            <div class="stat-num">35K+</div>
+            <div class="stat-num">36K+</div>
             <a href="/en/donors.html">Thanks</a>
             <a href="https://github.com/BerriAI/litellm">LiteLLM</a>
+            <a href="https://github.com/modelscope/FunClip/releases/tag/v2.1.1">FunClip v2.1.1</a>
+            <a href="https://github.com/0xShug0/audio.cpp">audio.cpp</a>
+            <a href="https://github.com/0xShug0/audio.cpp/pull/155">merged PR</a>
+            <a href="https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md">pinned guide</a>
             <div>custom_openai</div>
             <div>54.3K stars</div>
             <a href="https://marketplace.dify.ai/plugin/langgenius/funasr">
@@ -276,13 +284,31 @@ def test_website_contract_includes_homepage_entrypoints():
     assert "https://www.funasr.com/en/llama-cpp.html" in checker.PAGE_CONTRACTS
 
 
+def test_ecosystem_contract_requires_current_release_and_native_runtime():
+    checker = _load_module()
+    evidence_links = {
+        "https://github.com/modelscope/FunClip/releases/tag/v2.1.1",
+        "https://github.com/0xShug0/audio.cpp",
+        "https://github.com/0xShug0/audio.cpp/pull/155",
+        "https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md",
+    }
+
+    for url in (
+        "https://www.funasr.com/ecosystem.html",
+        "https://www.funasr.com/en/ecosystem.html",
+    ):
+        contract = checker.PAGE_CONTRACTS[url]
+        assert "36K+" in contract.required
+        assert evidence_links <= set(contract.required_links)
+
+
 def test_ecosystem_contract_requires_live_dify_marketplace():
     checker = _load_module()
     url = "https://www.funasr.com/en/ecosystem.html"
     pages = {
         url: """
             <body>
-            <div class="stat-num">35K+</div>
+            <div class="stat-num">36K+</div>
             <a href="/en/donors.html">Thanks</a>
             <a href="https://github.com/BerriAI/litellm">LiteLLM</a>
             <div>custom_openai</div>
@@ -313,9 +339,13 @@ def test_ecosystem_contract_requires_live_dify_marketplace():
 def _valid_english_ecosystem_html():
     return """
         <body>
-        <div class="stat-num">35K+</div>
+        <div class="stat-num">36K+</div>
         <a href="/en/donors.html">Thanks</a>
         <a href="https://github.com/BerriAI/litellm">LiteLLM</a>
+        <a href="https://github.com/modelscope/FunClip/releases/tag/v2.1.1">FunClip v2.1.1</a>
+        <a href="https://github.com/0xShug0/audio.cpp">audio.cpp</a>
+        <a href="https://github.com/0xShug0/audio.cpp/pull/155">merged PR</a>
+        <a href="https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md">pinned guide</a>
         <div>custom_openai</div>
         <div>54.3K stars</div>
         <a href="https://marketplace.dify.ai/plugin/langgenius/funasr">


### PR DESCRIPTION
## Summary

- update the public ecosystem checker from 35K+ to 36K+
- require the current FunClip v2.1.1 release link
- require the audio.cpp repository, merged PR #155, and pinned Fun-ASR-Nano guide in both languages

## Why

PR #3473 updated the bilingual ecosystem pages. This keeps the public-site monitor aligned with the deployed contract and prevents those verified release and native-runtime links from regressing.

## Verification

- regression tests failed before the checker update for the stale 35K+ contract
- focused contract tests: 2 passed
- complete static-checker tests: 26 passed
- Python bytecode compilation: passed
- `git diff --check`: passed

The commit is signed and includes a DCO sign-off.
