### PR TITLE
docs(vllm): clarify official model paths

### DIFF
--- a/docs/vllm_guide.md
+++ b/docs/vllm_guide.md
@@ -49,6 +49,50 @@ pip install "funasr>=1.3.26"
 cd /path/to/FunASR && pip install -e .
 ```
 
+### Choose the model path before you start
+
+There are two different Fun-ASR-Nano vLLM integrations. Their checkpoints and
+APIs are not interchangeable:
+
+#### A. FunASR split-engine integration (this guide)
+
+Use the official `FunAudioLLM/Fun-ASR-Nano-2512` checkpoint from
+[ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) or
+[Hugging Face](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512). The
+official Hugging Face repository does contain the complete `model.pt` at its
+root. The `Qwen3-0.6B/` subdirectory intentionally contains only the LLM config
+and tokenizer; it is not a standalone model download.
+
+```python
+from funasr.auto.auto_model_vllm import AutoModelVLLM
+
+# Choose one official hub. ModelScope is the default.
+model = AutoModelVLLM(
+    model="FunAudioLLM/Fun-ASR-Nano-2512",
+    hub="ms",
+)
+# model = AutoModelVLLM(
+#     model="FunAudioLLM/Fun-ASR-Nano-2512",
+#     hub="hf",
+# )
+```
+
+On first load, FunASR calls `prepare_vllm_model_dir()` automatically. It copies
+the config/tokenizer from `Qwen3-0.6B/`, extracts the `llm.*` tensors from the
+root `model.pt`, and writes
+`Qwen3-0.6B-vllm/model.safetensors`. Do not point `model` at `Qwen3-0.6B/` and
+do not try to serve that config-only directory directly with vLLM.
+
+#### B. Native vLLM transcription integration
+
+The vLLM supported-model table lists
+[`allendou/Fun-ASR-Nano-2512-vllm`](https://huggingface.co/allendou/Fun-ASR-Nano-2512-vllm)
+for its native `FunASRForConditionalGeneration` architecture. That is a
+community-converted full checkpoint hosted outside the official FunAudioLLM
+organization. Use its model card and vLLM's native transcription API only when
+you intentionally choose that separate path. Do not substitute it for the
+official checkpoint in the FunASR `AutoModelVLLM` examples below.
+
 **Hardware**: GPU ≥ 8 GB VRAM, CUDA ≥ 11.8. 16 GB+ recommended.
 
 Why not pip install torch torchaudio? The torch/torchaudio/torchvision versions are determined by the vLLM release — each major vLLM version bumps them together (see vLLM's requirements/cuda.txt). Installing them by hand pulls the newest wheel, which may be built for a newer CUDA runtime than your driver supports; PyTorch then fails during CUDA initialization with The NVIDIA driver on your system is too old before FunASR even starts. Letting vLLM own the trio avoids this. If you still hit a driver-too-old error, install a vLLM version whose CUDA build matches the CUDA reported by nvidia-smi (e.g. vllm==0.19.1 for CUDA 12.x), or update the NVIDIA driver first.

--- a/docs/vllm_guide_zh.md
+++ b/docs/vllm_guide_zh.md
@@ -51,6 +51,46 @@ pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipa
 cd /path/to/FunASR && pip install -e .
 ```
 
+### 开始前先选定模型路径
+
+目前有两条不同的 Fun-ASR-Nano vLLM 集成路径，checkpoint 与调用接口不能混用：
+
+#### A. FunASR 拆分引擎路径（本指南）
+
+请从 [ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512)
+或 [Hugging Face](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512)
+下载官方 `FunAudioLLM/Fun-ASR-Nano-2512`。官方 Hugging Face 仓库的根目录
+实际包含完整的 `model.pt`；`Qwen3-0.6B/` 子目录按设计只保存 LLM 配置与
+tokenizer，不是可以单独加载的权重目录。
+
+```python
+from funasr.auto.auto_model_vllm import AutoModelVLLM
+
+# 二选一；默认使用 ModelScope。
+model = AutoModelVLLM(
+    model="FunAudioLLM/Fun-ASR-Nano-2512",
+    hub="ms",
+)
+# model = AutoModelVLLM(
+#     model="FunAudioLLM/Fun-ASR-Nano-2512",
+#     hub="hf",
+# )
+```
+
+首次加载时，FunASR 会自动调用 `prepare_vllm_model_dir()`：从
+`Qwen3-0.6B/` 复制配置与 tokenizer，从根目录 `model.pt` 提取 `llm.*`
+权重，并生成 `Qwen3-0.6B-vllm/model.safetensors`。不要把 `model` 指向
+`Qwen3-0.6B/`，也不要直接让 vLLM 加载这个只有配置的子目录。
+
+#### B. vLLM 原生转写路径
+
+vLLM 的支持模型表把
+[`allendou/Fun-ASR-Nano-2512-vllm`](https://huggingface.co/allendou/Fun-ASR-Nano-2512-vllm)
+列为原生 `FunASRForConditionalGeneration` 架构的示例。这是托管在官方
+FunAudioLLM 组织之外的社区转换完整 checkpoint。只有明确选择 vLLM 原生转写
+接口时，才应按该模型卡与 vLLM 文档使用它；不要用它替换下文 FunASR
+`AutoModelVLLM` 示例中的官方 checkpoint。
+
 **硬件**：GPU ≥ 8GB VRAM，CUDA ≥ 11.8。推荐 16GB+。
 
 为什么不要单独执行 `pip install torch torchaudio` ? torch/torchaudio/torchvision 的版本由 vLLM 版本决定—— 每个大版本会一起升级(见 vLLM 的 [requirements/cuda.txt](https://github.com/vllm-project/vllm/blob/main/requirements/cuda.txt))。手动安装会拉到最新 wheel,可能是为比你驱动更新的 CUDA runtime 编译的;PyTorch 会在 CUDA 初始化阶段、FunASR 启动前就报 The NVIDIA driver on your system is too old。让 vLLM 统一钉定这三件套即可避免。若仍遇到该错误,请安装其 CUDA 构建与 nvidia-smi 显示的 CUDA 匹配的 vLLM 版本(如 CUDA 12.x 用 vllm==0.19.1),或先升级 NVIDIA 驱动。

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -51,6 +51,46 @@ pip install safetensors tiktoken websockets regex fastapi uvicorn python-multipa
 cd /path/to/FunASR && pip install -e .
 ```
 
+### 开始前先选定模型路径
+
+目前有两条不同的 Fun-ASR-Nano vLLM 集成路径，checkpoint 与调用接口不能混用：
+
+#### A. FunASR 拆分引擎路径（本指南）
+
+请从 [ModelScope](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512)
+或 [Hugging Face](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512)
+下载官方 `FunAudioLLM/Fun-ASR-Nano-2512`。官方 Hugging Face 仓库的根目录
+实际包含完整的 `model.pt`；`Qwen3-0.6B/` 子目录按设计只保存 LLM 配置与
+tokenizer，不是可以单独加载的权重目录。
+
+```python
+from funasr.auto.auto_model_vllm import AutoModelVLLM
+
+# 二选一；默认使用 ModelScope。
+model = AutoModelVLLM(
+    model="FunAudioLLM/Fun-ASR-Nano-2512",
+    hub="ms",
+)
+# model = AutoModelVLLM(
+#     model="FunAudioLLM/Fun-ASR-Nano-2512",
+#     hub="hf",
+# )
+```
+
+首次加载时，FunASR 会自动调用 `prepare_vllm_model_dir()`：从
+`Qwen3-0.6B/` 复制配置与 tokenizer，从根目录 `model.pt` 提取 `llm.*`
+权重，并生成 `Qwen3-0.6B-vllm/model.safetensors`。不要把 `model` 指向
+`Qwen3-0.6B/`，也不要直接让 vLLM 加载这个只有配置的子目录。
+
+#### B. vLLM 原生转写路径
+
+vLLM 的支持模型表把
+[`allendou/Fun-ASR-Nano-2512-vllm`](https://huggingface.co/allendou/Fun-ASR-Nano-2512-vllm)
+列为原生 `FunASRForConditionalGeneration` 架构的示例。这是托管在官方
+FunAudioLLM 组织之外的社区转换完整 checkpoint。只有明确选择 vLLM 原生转写
+接口时，才应按该模型卡与 vLLM 文档使用它；不要用它替换下文 FunASR
+`AutoModelVLLM` 示例中的官方 checkpoint。
+
 **硬件**：GPU ≥ 8GB VRAM，CUDA ≥ 11.8。推荐 16GB+。
 
 为什么不要单独执行 `pip install torch torchaudio` ? torch/torchaudio/torchvision 的版本由 vLLM 版本决定—— 每个大版本会一起升级(见 vLLM 的 [requirements/cuda.txt](https://github.com/vllm-project/vllm/blob/main/requirements/cuda.txt))。手动安装会拉到最新 wheel,可能是为比你驱动更新的 CUDA runtime 编译的;PyTorch 会在 CUDA 初始化阶段、FunASR 启动前就报 The NVIDIA driver on your system is too old。让 vLLM 统一钉定这三件套即可避免。若仍遇到该错误,请安装其 CUDA 构建与 nvidia-smi 显示的 CUDA 匹配的 vLLM 版本(如 CUDA 12.x 用 vllm==0.19.1),或先升级 NVIDIA 驱动。

--- a/tests/test_vllm_model_source_docs.py
+++ b/tests/test_vllm_model_source_docs.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VLLM_GUIDES = [
+    "docs/vllm_guide.md",
+    "docs/vllm_guide_zh.md",
+    "docs/vllm_guide_zh_v2.md",
+]
+
+
+@pytest.mark.parametrize("relpath", VLLM_GUIDES)
+def test_vllm_guides_distinguish_official_and_native_model_paths(relpath):
+    text = (ROOT / relpath).read_text(encoding="utf-8")
+    required_markers = [
+        "https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512",
+        "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512",
+        "model.pt",
+        "Qwen3-0.6B/",
+        "prepare_vllm_model_dir()",
+        "Qwen3-0.6B-vllm/model.safetensors",
+        'hub="ms"',
+        'hub="hf"',
+        "allendou/Fun-ASR-Nano-2512-vllm",
+        "FunASRForConditionalGeneration",
+    ]
+
+    for marker in required_markers:
+        assert marker in text, f"{relpath} is missing {marker}"


### PR DESCRIPTION
## Summary

- clarify that the official `FunAudioLLM/Fun-ASR-Nano-2512` checkpoint stores the complete `model.pt` at the repository root
- explain that `Qwen3-0.6B/` is a config/tokenizer directory and that `prepare_vllm_model_dir()` creates `Qwen3-0.6B-vllm/model.safetensors`
- distinguish the FunASR split-engine path from the separate native vLLM `FunASRForConditionalGeneration` community checkpoint
- keep the English and both Chinese vLLM guides aligned with a regression contract test

## Why

The previous guide did not explain why the official checkpoint `Qwen3-0.6B/` directory has no weights, which made it look incomplete and encouraged users to mix two incompatible model paths.

## Validation

- `python3 -m pytest tests/test_vllm_model_source_docs.py tests/test_docs_funasr_install_commands.py tests/test_canonical_qwenaudio_links.py -q`: 21 passed
- Black pre-commit hook: passed
- `git diff --check`: passed
- official Hugging Face revision `272c57b82523ada6fd87095e955f8e29100979ab` exercised on an H100 with vLLM 0.19.1
- automatic extraction produced a 1,503,300,296-byte `model.safetensors`
- real `example/zh.mp3` transcription: `开饭时间早上九点至下午五点。`

Closes #3475