### PR TITLE
docs(site): add SenseVoice audio.cpp deployment

### DIFF
--- a/web-pages/product-site/data/deployments.json
+++ b/web-pages/product-site/data/deployments.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "verified": "2026-08-11",
+  "verified": "2026-08-13",
   "deployments": [
     {
       "id": "vllm",
@@ -244,19 +244,23 @@
       "workloads": ["edge", "batch", "private-api"],
       "hardware": ["cpu", "nvidia-gpu", "desktop-edge-gpu"],
       "priorities": ["portability", "compatibility"],
-      "models": ["Fun-ASR-Nano-2512"],
+      "models": ["Fun-ASR-Nano-2512", "SenseVoice-Small"],
       "operating_systems": ["Linux", "macOS", "Windows"],
-      "interfaces": ["CLI", "OpenAI-compatible HTTP"],
-      "tested": {"funasr": "Fun-ASR-Nano-2512", "runtime": "audio.cpp@1778b23a", "verified": "2026-07-30"},
+      "interfaces": ["CLI", "OpenAI-compatible HTTP", "Buffered streaming CLI/SSE"],
+      "tested": {"funasr": "Fun-ASR-Nano-2512 + SenseVoice-Small", "runtime": "audio.cpp@1778b23a + SenseVoice candidate@b748ca5", "verified": "2026-08-13"},
       "commands": {
         "install": [
           "git clone https://github.com/0xShug0/audio.cpp.git && cd audio.cpp",
-          "bash scripts/build_linux.sh --backend cpu --model-set custom --models fun_asr_nano --target audiocpp_cli --target audiocpp_server",
-          "python3 tools/model_manager_v2.py install fun_asr_nano"
+          "git checkout b748ca509adc16c15aff44f76456fd47b257c933",
+          "bash scripts/build_linux.sh --backend cpu --model-set custom --models fun_asr_nano,sense_asr --target audiocpp_cli --target audiocpp_server",
+          "python3 tools/model_manager_v2.py install fun_asr_nano",
+          "python3 tools/model_manager_v2.py install sensevoice_small_q8"
         ],
         "launch": [
           "build/linux-cpu-release/bin/audiocpp_cli --task asr --family fun_asr_nano --model models/Fun-ASR-Nano-2512-GGUF/fun-asr-nano-2512-q8_0.gguf --backend cpu --audio speech.wav --text-out transcript.txt",
-          "printf '%s\\n' '{\"host\":\"127.0.0.1\",\"port\":8080,\"backend\":\"cpu\",\"threads\":4,\"lazy_load\":true,\"models\":[{\"id\":\"fun-asr-nano\",\"family\":\"fun_asr_nano\",\"path\":\"models/Fun-ASR-Nano-2512-GGUF/fun-asr-nano-2512-q8_0.gguf\",\"task\":\"asr\",\"mode\":\"offline\"}]}' > server.json",
+          "build/linux-cpu-release/bin/audiocpp_cli --task asr --family sense_asr --model models/SenseVoice-Small-GGUF/sensevoice-small-q8-audiocpp-v1.gguf --backend cpu --audio speech.wav --text-out sensevoice.txt",
+          "build/linux-cpu-release/bin/audiocpp_cli --task asr --family sense_asr --model models/SenseVoice-Small-GGUF/sensevoice-small-q8-audiocpp-v1.gguf --backend cpu --mode streaming --audio - --request-option audio_chunk_duration_sec=5 --request-option audio_chunk_mode=none < 16k_s16.pcm",
+          "printf '%s\\n' '{\"host\":\"127.0.0.1\",\"port\":8080,\"backend\":\"cpu\",\"threads\":4,\"lazy_load\":true,\"models\":[{\"id\":\"fun-asr-nano\",\"family\":\"fun_asr_nano\",\"path\":\"models/Fun-ASR-Nano-2512-GGUF/fun-asr-nano-2512-q8_0.gguf\",\"task\":\"asr\",\"mode\":\"offline\"},{\"id\":\"sense-asr\",\"family\":\"sense_asr\",\"path\":\"models/SenseVoice-Small-GGUF/sensevoice-small-q8-audiocpp-v1.gguf\",\"task\":\"asr\",\"mode\":\"streaming\"}]}' > server.json",
           "build/linux-cpu-release/bin/audiocpp_server --config server.json"
         ],
         "health": [
@@ -264,13 +268,16 @@
           "curl -fsS http://127.0.0.1:8080/v1/models"
         ],
         "smoke": [
-          "curl -fsS http://127.0.0.1:8080/v1/audio/transcriptions -F model=fun-asr-nano -F language=auto -F file=@speech.wav"
+          "curl -fsS http://127.0.0.1:8080/v1/audio/transcriptions -F model=fun-asr-nano -F language=auto -F file=@speech.wav",
+          "curl -fsS http://127.0.0.1:8080/v1/audio/transcriptions -F model=sense-asr -F language=auto -F file=@speech.wav"
         ]
       },
       "evidence": [
         {"label": "audio.cpp Fun-ASR-Nano guide", "url": "https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md"},
         {"label": "merged implementation", "url": "https://github.com/0xShug0/audio.cpp/pull/155"},
-        {"label": "pinned GGUF package", "url": "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF/tree/ce72677f84900f0dc57f498ace253bfb3c9155b6"}
+        {"label": "pinned Fun-ASR-Nano GGUF package", "url": "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF/tree/ce72677f84900f0dc57f498ace253bfb3c9155b6"},
+        {"label": "SenseVoice candidate implementation (6/6 CI)", "url": "https://github.com/0xShug0/audio.cpp/pull/219"},
+        {"label": "pinned SenseVoice GGUF package (SHA-256 4dedf169f625437fb336f2959674f399819729a765e184128c0e25a6e16ff0ec)", "url": "https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF-audiocpp/tree/5c3fcfe748a8714216bc135476d5863084fddb72"}
       ],
       "benchmarks": [
         {
@@ -285,32 +292,45 @@
           "qualification": "Single-sample parity smoke, not a capacity benchmark. Reproduce on target hardware with production audio and concurrency.",
           "source": "https://github.com/0xShug0/audio.cpp/blob/1778b23a5f6a4951c788e4bb0e7baa04f20012a2/docs/models/fun_asr_nano.md",
           "verified": "2026-07-29"
+        },
+        {
+          "model": "SenseVoice-Small Q8_0 GGUF candidate",
+          "runtime": "audio.cpp native sense_asr candidate b748ca5",
+          "hardware": "CPU; validation host details are not a cross-hardware benchmark contract",
+          "workload": "Offline Chinese transcription plus buffered streaming partials",
+          "audio": "Known 16 kHz reference WAV and PCM stream",
+          "settings": "Standalone schema-v1 Q8_0 GGUF; CPU backend; two-second streaming windows during validation",
+          "timing_scope": "Functional parity and loader validation; no capacity claim",
+          "result": "919 tensors loaded without sidecar overrides; transcript 开饭时间早上9点至下午5点。; GGUF SHA-256 4dedf169f625437fb336f2959674f399819729a765e184128c0e25a6e16ff0ec",
+          "qualification": "Candidate PR with all six official CI jobs passing; pin the exact commit until upstream merges it.",
+          "source": "https://github.com/0xShug0/audio.cpp/pull/219",
+          "verified": "2026-08-13"
         }
       ],
       "translations": {
         "zh": {
-          "name": "audio.cpp 原生 Fun-ASR-Nano",
-          "summary": "用原生 C++ / GGML 在 CPU 或 CUDA 上运行 Fun-ASR-Nano Q8_0，并提供 CLI 与兼容 OpenAI 的本地转写服务。",
-          "fit": ["不希望安装 Python 推理环境", "桌面、边缘与离线批量转写", "需要兼容 OpenAI 的本地音频接口"],
-          "not_fit": ["需要实时流式结果或时间戳", "需要 Fun-ASR-Nano 之外的 FunASR 模型", "尚未在目标硬件完成容量与准确率复测的公网服务"],
-          "selection_reason": "原生 GGML、Q8_0 模型和统一 CLI/HTTP 接口适合低依赖的离线 Fun-ASR-Nano 部署。",
-          "primary_limitation": "当前只输出离线转写文本，不暴露 streaming 或 timestamps；其他模型家族仍应选择对应 FunASR 运行时。",
+          "name": "audio.cpp 原生 Fun-ASR-Nano 与 SenseVoice",
+          "summary": "用原生 C++ / GGML 在 CPU 或 GPU 上运行 Fun-ASR-Nano 与 SenseVoice Q8，并提供离线 CLI、兼容 OpenAI 的本地接口和 SenseVoice 缓冲流式结果。",
+          "fit": ["不希望安装 Python 推理环境", "桌面、边缘、离线批量与低依赖私有部署", "需要兼容 OpenAI 的本地音频接口或 SenseVoice 多语言流式 partial"],
+          "not_fit": ["需要词级时间戳或严格低延迟在线流式", "不接受固定候选提交的生产环境", "尚未在目标硬件完成容量与准确率复测的公网服务"],
+          "selection_reason": "稳定的 Fun-ASR-Nano 路径与候选 SenseVoice 路径共用原生 GGML、Q8 模型及 CLI/HTTP 接口，适合低依赖部署。",
+          "primary_limitation": "Fun-ASR-Nano 已合并稳定；SenseVoice 仍是固定到 b748ca5 的候选 PR，虽已通过 6/6 CI，但合并前不应跟随浮动分支；当前两条路径都不提供词级 timestamps。",
           "status_label": "社区验证",
-          "operations": ["固定 audio.cpp 提交与 GGUF revision", "先用已知 WAV 核对 transcript 再接业务流量", "分别记录冷启动、预热 RTF、内存与并发队列"],
+          "operations": ["分别固定稳定 Nano 提交、SenseVoice 候选提交与 GGUF revision", "先用已知 WAV 核对两种模型的 transcript 再接业务流量", "分别记录冷启动、预热 RTF、内存、流式窗口与并发队列"],
           "security": ["服务默认绑定 127.0.0.1 或可信内网", "在反向代理限制上传大小、MIME、认证与并发", "只加载经过 SHA-256 校验的 GGUF 和配置"],
-          "troubleshooting": ["先用 CPU + Q8_0 路径排除 CUDA 环境问题", "构建 backend 必须与运行参数一致", "输入异常时先核对 WAV、单声道和 16 kHz 转换路径"]
+          "troubleshooting": ["先用 CPU + Q8_0 路径排除 GPU 环境问题", "构建 backend 必须与运行参数一致", "SenseVoice 输入异常时先核对 schema-v1 GGUF revision、WAV 或 16 kHz 单声道 PCM"]
         },
         "en": {
-          "name": "audio.cpp native Fun-ASR-Nano",
-          "summary": "Run Fun-ASR-Nano Q8_0 with native C++ and GGML on CPU or CUDA, using a CLI or local OpenAI-compatible transcription service.",
-          "fit": ["No Python inference environment", "Desktop, edge, and offline batch transcription", "A local OpenAI-compatible audio endpoint is required"],
-          "not_fit": ["Realtime streaming results or timestamps", "FunASR model families other than Fun-ASR-Nano", "Internet-facing service before capacity and accuracy tests on target hardware"],
-          "selection_reason": "Native GGML, Q8_0 weights, and shared CLI/HTTP surfaces fit low-dependency offline Fun-ASR-Nano deployment.",
-          "primary_limitation": "The current path returns offline transcript text only and exposes neither streaming nor timestamps; use the corresponding FunASR runtime for other model families.",
+          "name": "audio.cpp native Fun-ASR-Nano and SenseVoice",
+          "summary": "Run Fun-ASR-Nano and SenseVoice Q8 with native C++ and GGML on CPU or GPU, using offline CLI, a local OpenAI-compatible API, and buffered SenseVoice streaming results.",
+          "fit": ["No Python inference environment", "Desktop, edge, offline batch, and low-dependency private deployment", "A local OpenAI-compatible endpoint or multilingual SenseVoice streaming partials are required"],
+          "not_fit": ["Word-level timestamps or strict low-latency online streaming", "Production environments that cannot pin a candidate commit", "Internet-facing service before capacity and accuracy tests on target hardware"],
+          "selection_reason": "The stable Fun-ASR-Nano path and candidate SenseVoice path share native GGML, Q8 weights, and CLI/HTTP surfaces for low-dependency deployment.",
+          "primary_limitation": "Fun-ASR-Nano is merged and stable; SenseVoice remains a candidate pinned to b748ca5. Its 6/6 CI is green, but do not track a floating branch before merge. Neither path currently provides word-level timestamps.",
           "status_label": "Community verified",
-          "operations": ["Pin the audio.cpp commit and GGUF revision", "Verify a known WAV transcript before business traffic", "Measure cold start, warm RTF, memory, and concurrent queueing separately"],
+          "operations": ["Pin the stable Nano commit, SenseVoice candidate commit, and both GGUF revisions", "Verify known WAV transcripts with both models before business traffic", "Measure cold start, warm RTF, memory, streaming windows, and concurrent queueing separately"],
           "security": ["Bind the service to 127.0.0.1 or a trusted private network", "Enforce upload size, MIME, authentication, and concurrency at the proxy", "Load only GGUF and configuration files verified with SHA-256"],
-          "troubleshooting": ["Start with CPU and Q8_0 to isolate CUDA setup", "Match the compiled backend to the runtime argument", "For input failures, verify WAV decoding, mono conversion, and 16 kHz resampling"]
+          "troubleshooting": ["Start with CPU and Q8_0 to isolate GPU setup", "Match the compiled backend to the runtime argument", "For SenseVoice input failures, verify the schema-v1 GGUF revision plus WAV or 16 kHz mono PCM"]
         }
       }
     },

--- a/web-pages/product-site/tests/test_registry.py
+++ b/web-pages/product-site/tests/test_registry.py
@@ -44,26 +44,60 @@ def test_language_pairs_have_identical_fields(valid_registry):
     assert all(set(zh) == set(en) for zh, en in deployment_pairs(valid_registry))
 
 
-def test_audio_cpp_contract_tracks_merged_offline_runtime(valid_registry):
+def test_audio_cpp_contract_tracks_stable_nano_and_candidate_sensevoice(valid_registry):
     entry = next(item for item in valid_registry['deployments'] if item['id'] == 'audio-cpp')
     llama_cpp = next(item for item in valid_registry['deployments'] if item['id'] == 'llama-cpp')
 
+    assert valid_registry['verified'] == '2026-08-13'
     assert entry['maturity'] == 'community-verified'
     assert entry['selector_rank'] > llama_cpp['selector_rank']
     assert entry['tested'] == {
-        'funasr': 'Fun-ASR-Nano-2512',
-        'runtime': 'audio.cpp@1778b23a',
-        'verified': '2026-07-30',
+        'funasr': 'Fun-ASR-Nano-2512 + SenseVoice-Small',
+        'runtime': 'audio.cpp@1778b23a + SenseVoice candidate@b748ca5',
+        'verified': '2026-08-13',
     }
-    assert entry['models'] == ['Fun-ASR-Nano-2512']
-    assert any('model_manager_v2.py install fun_asr_nano' in command for command in entry['commands']['install'])
+    assert entry['models'] == ['Fun-ASR-Nano-2512', 'SenseVoice-Small']
+    assert 'Buffered streaming CLI/SSE' in entry['interfaces']
+    assert any(
+        'git checkout b748ca509adc16c15aff44f76456fd47b257c933' in command
+        for command in entry['commands']['install']
+    )
+    assert any(
+        'model_manager_v2.py install fun_asr_nano' in command
+        for command in entry['commands']['install']
+    )
+    assert any(
+        'model_manager_v2.py install sensevoice_small_q8' in command
+        for command in entry['commands']['install']
+    )
     build_command = next(command for command in entry['commands']['install'] if '--model-set custom' in command)
     assert build_command.startswith('bash scripts/build_linux.sh ')
+    assert '--models fun_asr_nano,sense_asr' in build_command
+    assert any('--family sense_asr' in command for command in entry['commands']['launch'])
+    assert any(
+        '--mode streaming' in command and 'audio_chunk_duration_sec=5' in command
+        for command in entry['commands']['launch']
+    )
     assert any('/v1/audio/transcriptions' in command for command in entry['commands']['smoke'])
     assert any('/health' in command for command in entry['commands']['health'])
     assert any('1778b23a5f6a4951c788e4bb0e7baa04f20012a2' in item['url'] for item in entry['evidence'])
     assert any('ce72677f84900f0dc57f498ace253bfb3c9155b6' in item['url'] for item in entry['evidence'])
-    assert 'streaming' in entry['translations']['en']['primary_limitation'].lower()
+    assert any('/pull/219' in item['url'] for item in entry['evidence'])
+    assert any(
+        '5c3fcfe748a8714216bc135476d5863084fddb72' in item['url']
+        for item in entry['evidence']
+    )
+    assert any(
+        '4dedf169f625437fb336f2959674f399819729a765e184128c0e25a6e16ff0ec'
+        in item['label']
+        for item in entry['evidence']
+    )
+    assert any(
+        '4dedf169f625437fb336f2959674f399819729a765e184128c0e25a6e16ff0ec'
+        in benchmark['result']
+        for benchmark in entry['benchmarks']
+    )
+    assert 'candidate' in entry['translations']['en']['primary_limitation'].lower()
     assert 'timestamp' in entry['translations']['en']['primary_limitation'].lower()
 
 


### PR DESCRIPTION
## Summary

- expand the audio.cpp deployment contract from Fun-ASR-Nano-only to stable Fun-ASR-Nano plus the SenseVoice candidate runtime
- pin the SenseVoice path to audio.cpp commit `b748ca509adc16c15aff44f76456fd47b257c933` and the official schema-v1 GGUF revision
- document offline CLI, buffered streaming CLI/SSE, OpenAI-compatible API, verification evidence, limitations, and the GGUF SHA-256
- keep the candidate status explicit until audio.cpp PR #219 is merged

## Why

The existing product page said audio.cpp supported only Fun-ASR-Nano and did not support streaming. That became incomplete after the SenseVoice schema-v1 implementation passed all six upstream CI jobs. Users need one accurate deployment contract that distinguishes the merged Nano path from the pinned SenseVoice candidate instead of following a floating branch.

## Validation

- `python3 -m pytest web-pages/product-site/tests -q` (`68 passed`)
- generated 25 product pages with `web-pages/product-site/build.py`
- `web-pages/product-site/validate.py` validated 100 HTML pages
- checked both generated audio.cpp pages for bilingual titles, exact candidate commit, 6/6 CI status, install/streaming commands, pinned HF revision, GGUF SHA-256, and evidence links

## Evidence

- audio.cpp candidate: https://github.com/0xShug0/audio.cpp/pull/219
- pinned GGUF: https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF-audiocpp/tree/5c3fcfe748a8714216bc135476d5863084fddb72
- GGUF SHA-256: `4dedf169f625437fb336f2959674f399819729a765e184128c0e25a6e16ff0ec`
