### PR TITLE
fix(site): prevent mobile evidence overflow

### DIFF
--- a/web-pages/product-site/assets/css/site.css
+++ b/web-pages/product-site/assets/css/site.css
@@ -989,6 +989,11 @@ td a {
 .evidence-list a {
   color: var(--blue-dark);
   font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.evidence-list li {
+  min-width: 0;
 }
 
 .benchmark-intro > div {

--- a/web-pages/product-site/tests/browser/product-site.spec.ts
+++ b/web-pages/product-site/tests/browser/product-site.spec.ts
@@ -160,6 +160,40 @@ for (const viewport of [
   });
 }
 
+for (const viewport of [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'desktop', width: 1440, height: 900 },
+]) {
+  test(`audio.cpp deployment is stable at ${viewport.name}`, async ({ page }, testInfo) => {
+    await page.setViewportSize(viewport);
+    await page.goto('/deploy/audio-cpp.html');
+
+    await expect(page.locator('h1')).toHaveText('audio.cpp 原生 Fun-ASR-Nano 与 SenseVoice');
+    await expect(page.getByText('pinned SenseVoice GGUF package', { exact: false })).toBeVisible();
+    await expect(page.locator('a[href="https://github.com/0xShug0/audio.cpp/pull/219"]')).toBeVisible();
+
+    const layout = await page.evaluate(() => ({
+      overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      evidenceWidths: [...document.querySelectorAll<HTMLElement>('.evidence-list li')].map((node) => ({
+        client: node.clientWidth,
+        scroll: node.scrollWidth,
+      })),
+      commandWidths: [...document.querySelectorAll<HTMLElement>('.command-block')].map((node) => ({
+        parent: node.parentElement?.getBoundingClientRect().width ?? 0,
+        width: node.getBoundingClientRect().width,
+      })),
+    }));
+    expect(layout.overflow).toBeLessThanOrEqual(1);
+    expect(layout.evidenceWidths.every(({ client, scroll }) => scroll <= client + 1)).toBe(true);
+    expect(layout.commandWidths.every(({ parent, width }) => width <= parent + 1)).toBe(true);
+
+    await page.screenshot({
+      path: testInfo.outputPath(`audio-cpp-${viewport.name}.png`),
+      fullPage: true,
+    });
+  });
+}
+
 test('reduced motion disables smooth scrolling', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/en/');


### PR DESCRIPTION
## Summary

- allow long evidence labels such as pinned SHA-256 values to wrap inside their grid track
- give evidence list items a zero minimum width so one unbroken token cannot widen the page
- add mobile and desktop Playwright coverage for the audio.cpp deployment page

## Root cause

The new pinned SenseVoice GGUF evidence label contains a 64-character SHA-256. The evidence grid item retained its intrinsic minimum width, so the mobile document expanded from a 375 px client width to a 628 px scroll width. Command blocks already scroll internally and were not the document-level cause.

## Validation

- reproduced before the fix at a 390 x 844 viewport: `clientWidth=375`, `scrollWidth=628`
- after the fix at 390 x 844: `clientWidth=375`, `scrollWidth=375`; all five evidence items have `scrollWidth == clientWidth`
- after the fix at 1440 x 900: no horizontal overflow and the evidence grid remains three columns
- all 14 audio.cpp command blocks stay within their parent width on mobile
- `python3 -m pytest web-pages/product-site/tests -q` (`68 passed`)
- generated 25 product pages and validated 100 HTML pages

The added Playwright cases run both mobile and desktop layouts in CI and save full-page screenshots.
