### PR TITLE
docs: clarify llama.cpp speaker diarization support

### DIFF
--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -78,6 +78,19 @@ segmentation, SenseVoiceSmall and Paraformer emit one entry spanning the input.
 Progress and timing diagnostics remain on stderr, so redirecting stdout produces
 a clean subtitle file. Normal text output is unchanged when `--srt` is omitted.
 
+## Speaker diarization
+
+The standalone llama.cpp / GGUF binaries do **not** currently implement CAM++
+speaker embeddings or speaker clustering. `--vad` segments speech for long-audio
+transcription, but it does not assign speaker labels.
+
+For speaker-aware transcripts, use the Python `AutoModel` pipeline with
+`spk_model="cam++"` (see the [FunASR quick start](../../README.md#quick-start)) or
+the [Fun-ASR-Nano vLLM service](../../examples/industrial_data_pretraining/fun_asr_nano/serve_vllm.py),
+which accepts `spk=true` and runs a separate speaker model. Keep using the
+llama.cpp binaries when the requirement is self-contained ASR plus optional
+FSMN-VAD without Python.
+
 ### Optional Windows CUDA backend for SenseVoiceSmall
 
 The CPU release ZIPs are portable packages. Tagged releases also publish


### PR DESCRIPTION
## Summary

- document that the standalone llama.cpp / GGUF binaries do not yet include CAM++ embeddings or speaker clustering
- distinguish FSMN-VAD segmentation from speaker-label assignment
- point diarization users to the Python `AutoModel` and Fun-ASR-Nano vLLM paths

This closes the documentation gap raised in Discussion #3478 without changing runtime behavior.

## Validation

- `git diff --check`
- both newly referenced repository paths exist on the exact base
- public-text credential scan: 0 findings
- commit is SSH-signed and includes DCO sign-off
