### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,11 +378,11 @@ asset is published.
 
 ## Star History
 
-<a href="https://star-history.com/#modelscope/FunASR&Date">
+<a href="https://star-history.dera.page/#modelscope/FunASR&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=modelscope/FunASR&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=modelscope/FunASR&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=modelscope/FunASR&type=Date" width="600" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=modelscope/FunASR&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=modelscope/FunASR&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=modelscope/FunASR&type=Date" width="600" />
  </picture>
 </a>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -368,11 +368,11 @@ compute capability 12.0（`sm_120`），在专用 CUDA 产物发布前，请使�
 
 ## Star 趋势
 
-<a href="https://star-history.com/#modelscope/FunASR&Date">
+<a href="https://star-history.dera.page/#modelscope/FunASR&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=modelscope/FunASR&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=modelscope/FunASR&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=modelscope/FunASR&type=Date" width="600" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=modelscope/FunASR&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=modelscope/FunASR&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=modelscope/FunASR&type=Date" width="600" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README files is currently broken and does not render properly. This change points the chart to a working service so the stargazer history is visible again for both the English and Chinese README.