### PR TITLE
fix(site): publish accurate deployment discovery metadata

### DIFF
--- a/web-pages/product-site/build.py
+++ b/web-pages/product-site/build.py
@@ -52,7 +52,7 @@ def legacy_route(relative: Path) -> str:
     return route
 
 
-def _write_sitemap(stage: Path) -> None:
+def _write_sitemap(stage: Path, last_modified_by_route: dict[str, str]) -> None:
     routes: set[str] = set()
     for page in sorted(stage.rglob('*.html')):
         if page.name == '404.html':
@@ -73,6 +73,11 @@ def _write_sitemap(stage: Path) -> None:
         url = ET.SubElement(urlset, '{http://www.sitemaps.org/schemas/sitemap/0.9}url')
         location = ET.SubElement(url, '{http://www.sitemaps.org/schemas/sitemap/0.9}loc')
         location.text = canonical_url(route)
+        if last_modified := last_modified_by_route.get(route):
+            modified = ET.SubElement(
+                url, '{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod'
+            )
+            modified.text = last_modified
     ET.indent(urlset, space='  ')
     tree = ET.ElementTree(urlset)
     tree.write(stage / 'sitemap.xml', encoding='utf-8', xml_declaration=True)
@@ -116,6 +121,7 @@ def _page_context(
     peer_route: str,
     title: str,
     description: str,
+    date_modified: str,
     navigation: dict[str, Any],
     assets: dict[str, str],
 ) -> dict[str, Any]:
@@ -128,6 +134,7 @@ def _page_context(
         'peer_canonical': canonical_url(peer_route),
         'title': title,
         'description': description,
+        'date_modified': date_modified,
         'navigation': _navigation(navigation, language),
         'assets': assets,
         'github_repository_url': GITHUB_REPOSITORY_URL,
@@ -251,6 +258,7 @@ def build(output_dir: Path) -> dict[str, Any]:
                 peer_route=peer_route,
                 title=language_copy[language]['home_title'],
                 description=language_copy[language]['home_description'],
+                date_modified=registry['verified'],
                 navigation=navigation,
                 assets=assets,
             )
@@ -277,6 +285,7 @@ def build(output_dir: Path) -> dict[str, Any]:
                 peer_route=peer_route,
                 title=language_copy[language]['deploy_title'],
                 description=language_copy[language]['deploy_description'],
+                date_modified=registry['verified'],
                 navigation=navigation,
                 assets=assets,
             )
@@ -301,6 +310,7 @@ def build(output_dir: Path) -> dict[str, Any]:
                     peer_route=peer_route,
                     title=f"{translation['name']} - {language_copy[language]['detail_suffix']}",
                     description=translation['summary'],
+                    date_modified=entry['tested']['verified'],
                     navigation=navigation,
                     assets=assets,
                 )
@@ -336,6 +346,7 @@ def build(output_dir: Path) -> dict[str, Any]:
                 peer_route=peer_route,
                 title=language_copy[language]['benchmarks_title'],
                 description=language_copy[language]['benchmarks_description'],
+                date_modified=registry['verified'],
                 navigation=navigation,
                 assets=assets,
             )
@@ -354,6 +365,7 @@ def build(output_dir: Path) -> dict[str, Any]:
             peer_route='/en/deploy/',
             title=language_copy['zh']['not_found_title'],
             description=language_copy['zh']['not_found_description'],
+            date_modified=registry['verified'],
             navigation=navigation,
             assets=assets,
         )
@@ -365,7 +377,12 @@ def build(output_dir: Path) -> dict[str, Any]:
             'hreflang': context['peer_canonical'],
         })
 
-        _write_sitemap(stage)
+        last_modified_by_route = {
+            entry['routes'][language]: entry['tested']['verified']
+            for entry in registry['deployments']
+            for language in ('zh', 'en')
+        }
+        _write_sitemap(stage, last_modified_by_route)
 
         manifest = {
             'schema_version': 1,

--- a/web-pages/product-site/templates/base.html
+++ b/web-pages/product-site/templates/base.html
@@ -21,8 +21,9 @@
     'applicationCategory': 'DeveloperApplication',
     'operatingSystem': 'Linux, macOS, Windows',
     'url': canonical,
+    'dateModified': date_modified,
     'codeRepository': github_repository_url,
-    'license': 'https://www.apache.org/licenses/LICENSE-2.0'
+    'license': 'https://github.com/modelscope/FunASR/blob/main/LICENSE'
   } | tojson }}</script>
 </head>
 <body data-language="{{ language }}" data-route="{{ route }}">

--- a/web-pages/product-site/tests/test_output.py
+++ b/web-pages/product-site/tests/test_output.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -46,6 +48,38 @@ def test_every_deployment_page_has_operational_contract(built_site):
             assert soup.select_one('[data-section="limitations"]')
             assert soup.select_one('[data-section="operations"]')
             assert soup.select_one('[data-section="evidence"]')
+
+
+def test_deployment_pages_publish_accurate_discovery_metadata(built_site):
+    registry = load_registry(SITE_ROOT / 'data' / 'deployments.json')
+
+    for entry in registry['deployments']:
+        for language in ('zh', 'en'):
+            page = route_path(built_site, entry['routes'][language])
+            soup = read_soup(page)
+            metadata = json.loads(soup.select_one('script[type="application/ld+json"]').string)
+
+            assert metadata['license'] == (
+                'https://github.com/modelscope/FunASR/blob/main/LICENSE'
+            )
+            assert metadata['dateModified'] == entry['tested']['verified']
+
+
+def test_deployment_sitemap_entries_use_registry_verification_dates(built_site):
+    registry = load_registry(SITE_ROOT / 'data' / 'deployments.json')
+    root = ET.parse(built_site / 'sitemap.xml').getroot()
+    namespace = {'sitemap': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+    entries = {
+        item.findtext('sitemap:loc', namespaces=namespace): item.findtext(
+            'sitemap:lastmod', namespaces=namespace
+        )
+        for item in root.findall('sitemap:url', namespace)
+    }
+
+    for entry in registry['deployments']:
+        for language in ('zh', 'en'):
+            url = f"https://www.funasr.com{entry['routes'][language]}"
+            assert entries[url] == entry['tested']['verified']
 
 
 def test_detail_commands_come_from_registry(built_site):


### PR DESCRIPTION
## Summary

- publish the repository actual MIT license URL in product-site JSON-LD
- expose each deployment registry verification date as `dateModified`
- add matching `<lastmod>` values for deployment routes in the generated sitemap
- cover the JSON-LD and sitemap contracts with regression tests

## Verification

- RED: 2 focused tests failed on the prior Apache-2.0 metadata and missing sitemap dates
- GREEN: 2/2 focused tests
- 76/76 product-site Python tests
- 102 generated HTML pages validated
- generated JSON-LD and sitemap smoke passed
- 14/14 Playwright Chromium tests
- `python3 -m py_compile` for changed Python files
- `git diff --check`

Independent review found no blocking issue. The pre-change main is preserved at `codex/backup-main-before-site-discovery-20260817`.
