### PR TITLE
docs(site): surface official repositories in footer

### DIFF
--- a/web-pages/product-site/assets/css/site.css
+++ b/web-pages/product-site/assets/css/site.css
@@ -1163,6 +1163,12 @@ td a {
   color: #aeb9c8;
 }
 
+.footer-repositories {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .footer-links {
   display: flex;
   align-items: center;

--- a/web-pages/product-site/templates/base.html
+++ b/web-pages/product-site/templates/base.html
@@ -59,6 +59,14 @@
       <strong>FunASR</strong>
       <p>{{ '面向生产部署的开源语音基础设施。' if language == 'zh' else 'Open speech infrastructure for production deployment.' }}</p>
     </div>
+    <nav class="footer-repositories" data-footer-repositories aria-label="{{ '官方仓库' if language == 'zh' else 'Official repositories' }}">
+      <strong>{{ '官方仓库' if language == 'zh' else 'Official repositories' }}</strong>
+      <div class="footer-links">
+        <a href="/go/fun-asr">Fun-ASR</a>
+        <a href="/go/sensevoice">SenseVoice</a>
+        <a href="/go/funclip">FunClip</a>
+      </div>
+    </nav>
     <div class="footer-links">
       <a href="{{ '/deploy/' if language == 'zh' else '/en/deploy/' }}">{{ '部署' if language == 'zh' else 'Deploy' }}</a>
       <a href="{{ docs_url }}">{{ '文档' if language == 'zh' else 'Docs' }}</a>

--- a/web-pages/product-site/tests/test_build.py
+++ b/web-pages/product-site/tests/test_build.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 SITE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SITE_ROOT))
 
-from build import build  # noqa: E402
+from build import build, route_path  # noqa: E402
 
 
 def read_soup(path: Path) -> BeautifulSoup:
@@ -93,6 +93,26 @@ def test_visible_repository_links_use_fixed_conversion_routes(tmp_path):
         assert soup.select_one('.site-footer a[href="/go/docs"]')
         assert soup.select_one('.site-footer a[href="/go/releases"]')
         assert json_ld['codeRepository'] == 'https://github.com/modelscope/FunASR'
+
+
+def test_every_product_page_footer_surfaces_official_repositories(tmp_path):
+    manifest = build(tmp_path)
+
+    for page in manifest['pages']:
+        soup = read_soup(route_path(tmp_path, page['route']))
+        repositories = soup.select_one('[data-footer-repositories]')
+        expected_heading = '官方仓库' if page['language'] == 'zh' else 'Official repositories'
+
+        assert repositories
+        assert repositories.strong.get_text(strip=True) == expected_heading
+        assert {
+            link.get('href'): link.get_text(strip=True)
+            for link in repositories.select('a[href]')
+        } == {
+            '/go/fun-asr': 'Fun-ASR',
+            '/go/sensevoice': 'SenseVoice',
+            '/go/funclip': 'FunClip',
+        }
 
 
 def test_home_surfaces_attributed_ecosystem_repositories(tmp_path):


### PR DESCRIPTION
## Summary
- add a bilingual official-repositories group to the shared product-site footer
- route Fun-ASR, SenseVoice, and FunClip links through the existing conversion endpoints
- verify the repository group is present on every generated product page

## Validation
- python -m pytest web-pages/product-site/tests -q (77 passed)
- deterministic double build (27 product pages) and validation (102 pages)
- npx playwright test --config playwright.config.ts (14 passed)
- desktop and 390px mobile full-page screenshots inspected with no overflow or overlap
