### PR TITLE
test: track current llama.cpp runtime contract

### DIFF
--- a/scripts/check_funasr_website_static.py
+++ b/scripts/check_funasr_website_static.py
@@ -161,25 +161,25 @@ PAGE_CONTRACTS: dict[str, PageContract] = {
     ),
     f"{BASE_URL}/blog/funasr-llama-cpp-whisper-cpp-alternative.html": PageContract(
         required=(
-            "runtime-llamacpp-v0.1.9",
+            "runtime-llamacpp-v0.2.0",
             "funasr-llamacpp-linux-x64-vulkan.tar.gz",
             "funasr-llamacpp-windows-x64-vulkan.zip",
             "Fun-ASR-Nano-GGUF",
             "Linux/Windows Vulkan 与 Windows CUDA",
             "/donors.html",
         ),
-        forbidden=("runtime-llamacpp-v0.1.1",),
+        forbidden=("runtime-llamacpp-v0.1.1", "runtime-llamacpp-v0.1.9"),
     ),
     f"{BASE_URL}/en/blog/funasr-llama-cpp-whisper-cpp-alternative.html": PageContract(
         required=(
-            "runtime-llamacpp-v0.1.9",
+            "runtime-llamacpp-v0.2.0",
             "funasr-llamacpp-linux-x64-vulkan.tar.gz",
             "funasr-llamacpp-windows-x64-vulkan.zip",
             "Fun-ASR-Nano-GGUF",
             "Linux/Windows Vulkan and Windows CUDA",
             "/en/donors.html",
         ),
-        forbidden=("runtime-llamacpp-v0.1.1",),
+        forbidden=("runtime-llamacpp-v0.1.1", "runtime-llamacpp-v0.1.9"),
     ),
     f"{BASE_URL}/blog/funasr-v1-3-26-openai-vllm-llama-cpp.html": PageContract(
         required=(

--- a/tests/test_check_funasr_website_static.py
+++ b/tests/test_check_funasr_website_static.py
@@ -113,7 +113,7 @@ def test_website_contract_accepts_current_public_copy():
             GGUF
         """,
         "https://www.funasr.com/blog/funasr-llama-cpp-whisper-cpp-alternative.html": """
-            runtime-llamacpp-v0.1.9
+            runtime-llamacpp-v0.2.0
             funasr-llamacpp-linux-x64-vulkan.tar.gz
             funasr-llamacpp-windows-x64-vulkan.zip
             Fun-ASR-Nano-GGUF
@@ -121,7 +121,7 @@ def test_website_contract_accepts_current_public_copy():
             <a href="/donors.html">功德榜</a>
         """,
         "https://www.funasr.com/en/blog/funasr-llama-cpp-whisper-cpp-alternative.html": """
-            runtime-llamacpp-v0.1.9
+            runtime-llamacpp-v0.2.0
             funasr-llamacpp-linux-x64-vulkan.tar.gz
             funasr-llamacpp-windows-x64-vulkan.zip
             Fun-ASR-Nano-GGUF
@@ -270,6 +270,31 @@ def test_homepage_contract_accepts_current_product_site_build(tmp_path, monkeypa
         checker,
         "PAGE_CONTRACTS",
         {url: checker.PAGE_CONTRACTS[url] for url in urls},
+    )
+
+    assert checker.validate_pages(pages) == []
+
+
+def test_llamacpp_comparison_contract_accepts_current_product_site_build(
+    tmp_path, monkeypatch
+):
+    checker = _load_module()
+    builder = _load_product_site_builder()
+    builder.build(tmp_path)
+    routes = (
+        "blog/funasr-llama-cpp-whisper-cpp-alternative.html",
+        "en/blog/funasr-llama-cpp-whisper-cpp-alternative.html",
+    )
+    pages = {
+        f"https://www.funasr.com/{route}": (tmp_path / route).read_text(
+            encoding="utf-8"
+        )
+        for route in routes
+    }
+    monkeypatch.setattr(
+        checker,
+        "PAGE_CONTRACTS",
+        {url: checker.PAGE_CONTRACTS[url] for url in pages},
     )
 
     assert checker.validate_pages(pages) == []


### PR DESCRIPTION
## Summary

- update the bilingual llama.cpp comparison-page patrol from runtime v0.1.9 to the shipped v0.2.0 release
- reject stale v0.1.9 copy on those two current comparison pages
- validate the patrol contract against product-site build output so page and monitor updates cannot drift again

## Verification

- `pytest -q tests/test_check_funasr_website_static.py` (27 passed)
- `python scripts/check_funasr_website_static.py` (20 page contracts, 98 navigation pages, and 3 assets passed)

Signed-off-by: LauraGPT <170200537+LauraGPT@users.noreply.github.com>