### PR TITLE
docs(site): route homepage traffic to all four repositories

### DIFF
--- a/web-pages/product-site/assets/css/site.css
+++ b/web-pages/product-site/assets/css/site.css
@@ -612,7 +612,7 @@ td a {
 
 .ecosystem-repositories {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 44px;
 }
 
@@ -630,6 +630,10 @@ td a {
 
 .ecosystem-repositories article:nth-child(3) {
   border-color: #d08a21;
+}
+
+.ecosystem-repositories article:nth-child(4) {
+  border-color: #d84b55;
 }
 
 .repository-role {
@@ -1249,6 +1253,10 @@ td a {
   .responsibility-grid,
   .ecosystem-repositories {
     gap: 24px;
+  }
+
+  .ecosystem-repositories {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .page-intro {

--- a/web-pages/product-site/templates/home.html
+++ b/web-pages/product-site/templates/home.html
@@ -155,27 +155,33 @@
   </div>
 </section>
 
-<section class="section ecosystem-section" data-section="ecosystem-adoption">
+<section id="projects" class="section ecosystem-section" data-section="ecosystem-adoption">
   <div class="section-heading">
     <p class="eyebrow">{{ '生态仓库' if language == 'zh' else 'Ecosystem repositories' }}</p>
     <h2>{{ '从模型到视频工作流' if language == 'zh' else 'From models to video workflows' }}</h2>
     <p>{{ '按目标进入专用仓库，核对模型、部署边界与可复现示例。' if language == 'zh' else 'Open the focused repository for its models, deployment boundaries, and reproducible examples.' }}</p>
   </div>
   <div class="ecosystem-repositories">
-    <article>
-      <p class="repository-role">{{ '端到端语音识别' if language == 'zh' else 'End-to-end speech recognition' }}</p>
+    <article data-project="funasr">
+      <p class="repository-role">{{ '工业语音工具箱' if language == 'zh' else 'Production speech toolkit' }}</p>
+      <h3>FunASR</h3>
+      <p>{{ '统一语音识别、VAD、标点、说话人分离与工业部署的开源工具箱。' if language == 'zh' else 'The open toolkit unifying ASR, VAD, punctuation, diarization, and production deployment.' }}</p>
+      <a class="text-link" href="/go/github">{{ '查看 FunASR' if language == 'zh' else 'Open FunASR on GitHub' }} <img src="{{ assets['lucide/arrow-right.svg'] }}" alt=""></a>
+    </article>
+    <article data-project="fun-asr">
+      <p class="repository-role">{{ '高精度转写' if language == 'zh' else 'High-accuracy ASR' }}</p>
       <h3>Fun-ASR</h3>
       <p>{{ '端到端语音识别模型家族，覆盖旗舰与 31 语言 MLT 检查点。' if language == 'zh' else 'A family of end-to-end speech recognition models spanning flagship and 31-language MLT checkpoints.' }}</p>
       <a class="text-link" href="/go/fun-asr">{{ '查看 Fun-ASR' if language == 'zh' else 'Open Fun-ASR on GitHub' }} <img src="{{ assets['lucide/arrow-right.svg'] }}" alt=""></a>
     </article>
-    <article>
-      <p class="repository-role">{{ '多语言语音理解' if language == 'zh' else 'Multilingual speech understanding' }}</p>
+    <article data-project="sensevoice">
+      <p class="repository-role">{{ '多语种与情感' if language == 'zh' else 'Languages and emotion' }}</p>
       <h3>SenseVoice</h3>
       <p>{{ '覆盖语音识别、语言、情感与音频事件的多语言理解模型。' if language == 'zh' else 'Multilingual understanding across speech recognition, language, emotion, and audio events.' }}</p>
       <a class="text-link" href="/go/sensevoice">{{ '查看 SenseVoice' if language == 'zh' else 'Open SenseVoice on GitHub' }} <img src="{{ assets['lucide/arrow-right.svg'] }}" alt=""></a>
     </article>
-    <article>
-      <p class="repository-role">{{ '视频理解与剪辑' if language == 'zh' else 'Video understanding and clipping' }}</p>
+    <article data-project="funclip">
+      <p class="repository-role">{{ '智能视频剪辑' if language == 'zh' else 'AI video editing' }}</p>
       <h3>FunClip</h3>
       <p>{{ '以语音与文本定位为核心的视频理解与智能剪辑工作流。' if language == 'zh' else 'Video understanding and intelligent clipping workflows driven by speech and text localization.' }}</p>
       <a class="text-link" href="/go/funclip">{{ '查看 FunClip' if language == 'zh' else 'Open FunClip on GitHub' }} <img src="{{ assets['lucide/arrow-right.svg'] }}" alt=""></a>

--- a/web-pages/product-site/tests/browser/product-site.spec.ts
+++ b/web-pages/product-site/tests/browser/product-site.spec.ts
@@ -52,6 +52,47 @@ for (const viewport of viewports) {
   });
 }
 
+for (const viewport of [
+  { name: 'mobile', width: 390, height: 844, expectedRows: 4 },
+  { name: 'desktop', width: 1440, height: 900, expectedRows: 1 },
+]) {
+  test(`four-project selector is stable at ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    const consoleErrors: string[] = [];
+    const networkErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('requestfailed', (request) => networkErrors.push(request.url()));
+
+    for (const route of ['/', '/en/']) {
+      await page.goto(route);
+      const projects = page.locator('#projects [data-project]');
+      await expect(projects).toHaveCount(4);
+      expect(
+        await projects.evaluateAll((nodes) =>
+          nodes.map((node) => node.getAttribute('data-project')),
+        ),
+      ).toEqual(['funasr', 'fun-asr', 'sensevoice', 'funclip']);
+
+      const layout = await projects.evaluateAll((nodes) => ({
+        overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        rows: new Set(nodes.map((node) => Math.round(node.getBoundingClientRect().top))).size,
+        visible: nodes.every((node) => {
+          const rect = node.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        }),
+      }));
+      expect(layout.overflow).toBeLessThanOrEqual(1);
+      expect(layout.rows).toBe(viewport.expectedRows);
+      expect(layout.visible).toBe(true);
+    }
+
+    expect(consoleErrors).toEqual([]);
+    expect(networkErrors).toEqual([]);
+  });
+}
+
 test('mobile navigation supports keyboard operation and visible focus', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');

--- a/web-pages/product-site/tests/test_build.py
+++ b/web-pages/product-site/tests/test_build.py
@@ -127,7 +127,14 @@ def test_home_surfaces_attributed_ecosystem_repositories(tmp_path):
 
         assert section
         assert section.h2.get_text(strip=True) == expected_heading
+        assert [item.get('data-project') for item in section.select('[data-project]')] == [
+            'funasr',
+            'fun-asr',
+            'sensevoice',
+            'funclip',
+        ]
         assert {link.get('href') for link in section.select('a[href]')} == {
+            '/go/github',
             '/go/fun-asr',
             '/go/sensevoice',
             '/go/funclip',

--- a/web-pages/product-site/tests/test_output.py
+++ b/web-pages/product-site/tests/test_output.py
@@ -33,6 +33,42 @@ def route_path(root: Path, route: str) -> Path:
     return root / route.lstrip('/')
 
 
+@pytest.mark.parametrize(
+    ('relative', 'markers'),
+    (
+        (
+            'index.html',
+            ('工业语音工具箱', '高精度转写', '多语种与情感', '智能视频剪辑'),
+        ),
+        (
+            'en/index.html',
+            ('Production speech toolkit', 'High-accuracy ASR', 'Languages and emotion', 'AI video editing'),
+        ),
+    ),
+)
+def test_homepage_routes_each_project_by_workload(built_site, relative, markers):
+    soup = read_soup(built_site / relative)
+    section = soup.select_one('#projects')
+
+    assert section
+    rows = section.select('[data-project]')
+    assert [row['data-project'] for row in rows] == [
+        'funasr',
+        'fun-asr',
+        'sensevoice',
+        'funclip',
+    ]
+    assert {link['href'] for link in section.select('a[href]')} == {
+        '/go/github',
+        '/go/fun-asr',
+        '/go/sensevoice',
+        '/go/funclip',
+    }
+    text = section.get_text(' ', strip=True)
+    for marker in markers:
+        assert marker in text
+
+
 def test_every_deployment_page_has_operational_contract(built_site):
     registry = load_registry(SITE_ROOT / 'data' / 'deployments.json')
 


### PR DESCRIPTION
## Summary
- add FunASR itself to the product homepage ecosystem selector
- label all four repositories by workload in Chinese and English
- keep a four-column desktop, two-column tablet, and one-column mobile layout
- add static and browser regression coverage for links, order, layout, console, and network failures

## Validation
- `pytest -q web-pages/product-site/tests tests/test_check_funasr_website_static.py` (109 passed)
- `npx playwright test` (22 passed)
- two deterministic builds: 27 generated pages / 157 files, no diff
- `python validate.py <build>` (102 pages)
- `git diff --check`