### PR TITLE
ops(growth): track SGLang Fun-ASR CI gate

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -71,6 +71,12 @@ As of 2026-08-17 00:48 UTC, the ecosystem has 36,584 combined GitHub stars, or 5
 - Local evidence passed 109 Python tests and 22 Playwright tests, including desktop and mobile order, visibility, row-layout, overflow, console, and network assertions. Two clean builds each generated 27 product pages and validated 102 public pages with no diff; exact-head GitHub Actions passed both required checks.
 - Production release `20260817T012430Z` was built twice from the exact merge commit, atomically replaced `20260817T004144Z`, and retained that previous release for rollback. The 7,175,781-byte archive has SHA-256 `5c5b96595d4cb893c83aedeca4d5dfe5a4cf0a665a1b4d489808886a7aacc1a3`; preflight, staging, post-switch, Chinese and English public-page, all four redirect, nginx, cache-header, and security-header checks passed.
 
+### 2026-08-17 SGLang Omni Fun-ASR prefill coalescing
+
+- SGLang Omni PR [#1460](https://github.com/sgl-project/sglang-omni/pull/1460) enables prefill coalescing for Fun-ASR-Nano. Its published benchmark holds corpus WER at `0.01710`, improves concurrency-32 throughput by 19.9% over current main, and reports a 5.7% gain at concurrency 8, with the expected latency trade-off at concurrency 1.
+- Exact head `54361fb022a7da13e1f18a85d5125ac24752c382` had a red Omni CI run `31439644442`, but log inspection proved the failure was only the missing `run-ci` opt-in label: environment setup and all ASR GPU tests were skipped before any PR code ran.
+- The repository's trusted slash-command handler permits the PR author, but not LauraGPT, to start the model-specific run. The [author handoff](https://github.com/sgl-project/sglang-omni/pull/1460#issuecomment-5310829913) gives the exact first-line command `/tag-and-rerun-ci fun-asr`, which adds both `run-ci` and `run-fun-asr` before a full exact-head rerun. This PR is now part of the default integration patrol until real GPU CI completes or a maintainer closes the lane.
+
 ### 2026-08-16 OpenClaw realtime transcription SDK unblock
 
 - OpenClaw PR [#118977](https://github.com/openclaw/openclaw/pull/118977) was synchronized with `openclaw/main@2d3612da6bd28f6a7956d82b0795c31fd18bab8a`, resolving its only merge conflict while preserving both upstream SDK surface-budget changes and the FunASR WebSocket subprotocol work.

--- a/scripts/collect_growth_metrics.py
+++ b/scripts/collect_growth_metrics.py
@@ -37,6 +37,7 @@ DEFAULT_INTEGRATION_PRS = [
     "huggingface/optimum-intel#1874",
     "yuekaizhang/Fun-ASR-vllm#21",
     "ray-project/ray#64053",
+    "sgl-project/sglang-omni#1460",
     "huggingface/speech-to-speech#319",
     "livekit/agents#6176",
     "punkpeye/awesome-mcp-servers#7153",
@@ -113,7 +114,15 @@ KNOWN_EXTERNAL_CHECK_FAILURES = {
         },
         "reason": "Current Ray failures are Buildkite/ReadTheDocs gates already triaged; the remaining PR-local Black fix is waiting on the contributor branch owner",
         "action": "wait for contributor branch update",
-    }
+    },
+    "sgl-project/sglang-omni#1460": {
+        "failed_check_names": {"omni-ci-gate"},
+        "reason": (
+            "Omni CI stopped at the missing run-ci opt-in before setup or ASR GPU tests; "
+            "the PR author must run `/tag-and-rerun-ci fun-asr`"
+        ),
+        "action": "wait for PR author CI opt-in",
+    },
 }
 KNOWN_REVIEW_GATES = {
     "punkpeye/awesome-mcp-servers#7153": {
@@ -301,6 +310,7 @@ CONTRIBUTOR_WAITING_LABELS = {"good first issue", "help wanted", "ready for PR"}
 MANUAL_HANDOFF_ACTIONS = {
     "submit Glama",
     "wait for author CLA",
+    "wait for PR author CI opt-in",
     "wait for contributor conflict resolution",
     "wait for preview authorization",
 }
@@ -491,6 +501,25 @@ def summarize_commit_checks(repo: str, head_sha: str) -> Dict[str, Any]:
         github_headers(),
     )
     check_runs = check_runs_payload.get("check_runs", [])
+    latest_check_runs: Dict[tuple[str, Any], tuple[tuple[str, int, int], Dict[str, Any]]] = {}
+    for position, check_run in enumerate(check_runs):
+        app = check_run.get("app") or {}
+        key = (str(check_run.get("name") or ""), app.get("slug") or app.get("id"))
+        timestamp = str(
+            check_run.get("completed_at")
+            or check_run.get("started_at")
+            or check_run.get("created_at")
+            or ""
+        )
+        try:
+            run_id = int(check_run.get("id") or 0)
+        except (TypeError, ValueError):
+            run_id = 0
+        rank = (timestamp, run_id, -position)
+        previous = latest_check_runs.get(key)
+        if previous is None or rank > previous[0]:
+            latest_check_runs[key] = (rank, check_run)
+    check_runs = [entry[1] for entry in latest_check_runs.values()]
     failed_check_runs = []
     pending_check_runs = []
     for check_run in check_runs:
@@ -1061,7 +1090,11 @@ def format_integration_markdown(metrics: Dict[str, Any]) -> str:
     if manual_handoff_integrations:
         lines.extend(["", "## Manual handoff gates", ""])
         for integration in manual_handoff_integrations:
-            reason = integration.get("known_review_gate_reason") or "manual action required"
+            reason = (
+                integration.get("known_review_gate_reason")
+                or integration.get("known_external_failure_reason")
+                or "manual action required"
+            )
             lines.append(
                 f"- [{integration['pr']}]({integration.get('html_url')}): "
                 f"{integration.get('next_action') or 'inspect'}; {reason}"

--- a/tests/test_collect_growth_metrics.py
+++ b/tests/test_collect_growth_metrics.py
@@ -19,8 +19,73 @@ def load_growth_metrics_module():
 def test_default_integration_prs_include_sglang_omni_fun_asr():
     module = load_growth_metrics_module()
 
+    assert "sgl-project/sglang-omni#1460" in module.DEFAULT_INTEGRATION_PRS
     assert "sgl-project/sglang-omni#1078" not in module.DEFAULT_INTEGRATION_PRS
     assert "sgl-project/sglang-omni#898" not in module.DEFAULT_INTEGRATION_PRS
+
+
+def test_sglang_omni_fun_asr_ci_gate_waits_for_pr_author_opt_in():
+    module = load_growth_metrics_module()
+
+    failure = module.KNOWN_EXTERNAL_CHECK_FAILURES["sgl-project/sglang-omni#1460"]
+
+    assert failure["failed_check_names"] == {"omni-ci-gate"}
+    assert failure["action"] == "wait for PR author CI opt-in"
+    assert "`/tag-and-rerun-ci fun-asr`" in failure["reason"]
+    assert "before setup or ASR GPU tests" in failure["reason"]
+    assert failure["action"] in module.MANUAL_HANDOFF_ACTIONS
+
+
+def test_summarize_commit_checks_uses_latest_run_for_each_check_name(monkeypatch):
+    module = load_growth_metrics_module()
+
+    def fake_fetch_json(url, headers=None):
+        if url.endswith("/commits/head/status"):
+            return {"state": "success", "statuses": []}
+        if url.endswith("/commits/head/check-runs?per_page=100"):
+            return {
+                "total_count": 4,
+                "check_runs": [
+                    {
+                        "id": 4,
+                        "name": "build-docs",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "completed_at": "2026-08-10T22:46:02Z",
+                    },
+                    {
+                        "id": 3,
+                        "name": "omni-ci-gate",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "completed_at": "2026-08-10T22:45:59Z",
+                    },
+                    {
+                        "id": 2,
+                        "name": "build-docs",
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                        "completed_at": "2026-08-10T22:45:58Z",
+                    },
+                    {
+                        "id": 1,
+                        "name": "omni-ci-gate",
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                        "completed_at": "2026-08-10T22:45:57Z",
+                    },
+                ],
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    checks = module.summarize_commit_checks("sgl-project/sglang-omni", "head")
+
+    assert checks["total_check_runs"] == 4
+    assert checks["failed_check_runs"] == [
+        {"name": "omni-ci-gate", "conclusion": "failure", "url": None}
+    ]
 
 
 def test_github_headers_falls_back_to_gh_auth_token(monkeypatch):

--- a/tests/test_growth_plan_doc.py
+++ b/tests/test_growth_plan_doc.py
@@ -428,3 +428,22 @@ def test_growth_plan_records_four_repo_homepage_routing_release():
     ]
     for marker in required_markers:
         assert marker in text
+
+
+def test_growth_plan_records_sglang_funasr_ci_handoff():
+    text = PLAN.read_text()
+
+    required_markers = [
+        "### 2026-08-17 SGLang Omni Fun-ASR prefill coalescing",
+        "[#1460](https://github.com/sgl-project/sglang-omni/pull/1460)",
+        "concurrency-32 throughput by 19.9%",
+        "corpus WER at `0.01710`",
+        "`54361fb022a7da13e1f18a85d5125ac24752c382`",
+        "`31439644442`",
+        "setup and all ASR GPU tests were skipped",
+        "`/tag-and-rerun-ci fun-asr`",
+        "#issuecomment-5310829913",
+        "default integration patrol",
+    ]
+    for marker in required_markers:
+        assert marker in text


### PR DESCRIPTION
## Summary
- add SGLang Omni Fun-ASR prefill-coalescing PR #1460 to the default integration patrol
- classify its current red check as an author-only CI opt-in gate with the exact rerun command
- ignore stale duplicate check runs by keeping the latest run for each check name and app
- record benchmark, exact-head CI, and author-handoff evidence in the growth ledger

## Validation
- `pytest -q tests/test_collect_growth_metrics.py tests/test_growth_plan_doc.py` (88 passed)
- live single-PR integration collection classifies only `omni-ci-gate` and recommends `wait for PR author CI opt-in`
- `python3 -m py_compile scripts/collect_growth_metrics.py`
- `git diff --check`