### PR TITLE
docs(deploy): verify realtime v1.4.2 quickstart

### DIFF
--- a/web-pages/product-site/data/deployments.json
+++ b/web-pages/product-site/data/deployments.json
@@ -506,13 +506,14 @@
       "models": ["Paraformer-online", "FSMN-VAD", "CT-Transformer punctuation", "Fun-ASR-Nano realtime"],
       "operating_systems": ["Linux"],
       "interfaces": ["WebSocket", "Python client", "C++ client", "Go client"],
-      "tested": {"funasr": "1.3.29", "runtime": "Python and C++ WebSocket runtimes", "verified": "2026-07-26"},
+      "tested": {"funasr": "1.4.2", "runtime": "FunASR v1.4.2 Python WebSocket runtime", "verified": "2026-08-17"},
       "commands": {
-        "install": ["pip install funasr websockets ffmpeg-python"],
-        "launch": ["cd runtime/python/websocket && python funasr_wss_server.py --port 10095"],
+        "install": ["python -m pip install -U \"funasr==1.4.2\"", "git clone --branch v1.4.2 --depth 1 https://github.com/modelscope/FunASR.git && python -m pip install -r FunASR/runtime/python/websocket/requirements_server.txt"],
+        "launch": ["cd FunASR/runtime/python/websocket && python funasr_wss_server.py --port 10095"],
         "health": ["ss -ltn | grep 10095"],
-        "smoke": ["cd runtime/python/websocket && python funasr_wss_client.py --host 127.0.0.1 --port 10095 --mode 2pass --chunk_size \"8,8,4\" --audio_in ../../tests/test_audio/zh.wav"]
+        "smoke": ["cd FunASR/runtime/python/websocket && python funasr_wss_client.py --host 127.0.0.1 --port 10095 --mode 2pass --chunk_size \"8,8,4\" --audio_in ../../funasr_api/asr_example.wav"]
       },
+      "source_url": "/go/github",
       "evidence": [
         {"label": "Python WebSocket runtime", "url": "https://github.com/modelscope/FunASR/blob/main/runtime/python/websocket/README.md"},
         {"label": "WebSocket protocol", "url": "https://github.com/modelscope/FunASR/blob/main/runtime/docs/websocket_protocol.md"},

--- a/web-pages/product-site/templates/deploy-detail.html
+++ b/web-pages/product-site/templates/deploy-detail.html
@@ -9,6 +9,7 @@
     <div class="detail-actions">
       <a class="button button-primary" href="#commands">{{ '开始部署' if language == 'zh' else 'Start deployment' }}</a>
       <a class="button button-secondary" href="{{ '/benchmarks.html' if language == 'zh' else '/en/benchmarks.html' }}">{{ '查看基准口径' if language == 'zh' else 'Review benchmark method' }}</a>
+      {% if entry.get('source_url') %}<a class="text-link" href="{{ entry.source_url }}">{{ '查看实时源码' if language == 'zh' else 'View realtime source' }} <img src="{{ assets['lucide/arrow-right.svg'] }}" alt=""></a>{% endif %}
     </div>
   </div>
   <dl class="detail-meta">

--- a/web-pages/product-site/tests/test_output.py
+++ b/web-pages/product-site/tests/test_output.py
@@ -128,6 +128,29 @@ def test_detail_commands_come_from_registry(built_site):
             assert command in rendered
 
 
+def test_realtime_page_publishes_verified_v142_quickstart(built_site):
+    registry = load_registry(SITE_ROOT / 'data' / 'deployments.json')
+    entry = next(item for item in registry['deployments'] if item['id'] == 'realtime')
+    commands = '\n'.join(
+        command
+        for group in ('install', 'launch', 'smoke')
+        for command in entry['commands'][group]
+    )
+
+    assert entry['tested']['funasr'] == '1.4.2'
+    assert entry['tested']['verified'] == '2026-08-17'
+    assert 'git clone --branch v1.4.2 --depth 1' in commands
+    assert 'runtime/python/websocket/requirements_server.txt' in commands
+    assert 'cd FunASR/runtime/python/websocket && python funasr_wss_server.py' in commands
+    assert '../../funasr_api/asr_example.wav' in commands
+    assert 'tests/test_audio/zh.wav' not in commands
+
+    for relative in ('deploy/realtime.html', 'en/deploy/realtime.html'):
+        soup = read_soup(built_site / relative)
+        source = soup.select_one('.detail-actions a[href="/go/github"]')
+        assert source
+
+
 @pytest.mark.parametrize(
     ('relative', 'boundary'),
     (


### PR DESCRIPTION
## Summary
- pin the highest-traffic realtime deployment quickstart to FunASR 1.4.2
- clone the matching tag and use the repository's real WebSocket sample audio
- expose the tracked GitHub source route from the deployment hero

## Verification
- `python -m pytest -q` (83 passed)
- static build: 27 product pages; validator: 102 pages
- clean venv install of public `funasr==1.4.2` plus tag `v1.4.2`
- live WebSocket server/client 2-pass smoke test produced the expected final transcript
- Chromium screenshots at 1440x1000 and 390x844

Signed-off-by: LauraGPT <170200537+LauraGPT@users.noreply.github.com>