### PR TITLE
fix(diarization): scale known-speaker clustering for long audio

### DIFF
--- a/funasr/models/campplus/cluster_backend.py
+++ b/funasr/models/campplus/cluster_backend.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from sklearn.cluster._kmeans import k_means
 from sklearn.cluster import HDBSCAN
+from sklearn.preprocessing import normalize
 
 
 class SpectralCluster:
@@ -191,6 +192,21 @@ class UmapHdbscan:
         return labels
 
 
+class KMeansCluster:
+    r"""Cluster a large set of speaker embeddings into a known number of groups."""
+
+    def __call__(self, X, num_clusters):
+        """Cluster L2-normalized embeddings with bounded memory usage."""
+        normalized_X = normalize(X)
+        _, labels, _ = k_means(
+            normalized_X,
+            num_clusters,
+            random_state=0,
+            n_init=10,
+        )
+        return labels
+
+
 class ClusterBackend(torch.nn.Module):
     r"""Perfom clustering for input embeddings and output the labels.
     Args:
@@ -210,6 +226,7 @@ class ClusterBackend(torch.nn.Module):
 
         self.spectral_cluster = SpectralCluster()
         self.umap_hdbscan_cluster = UmapHdbscan()
+        self.kmeans_cluster = KMeansCluster()
 
     def forward(self, X, **params):
         # clustering and return the labels
@@ -223,9 +240,10 @@ class ClusterBackend(torch.nn.Module):
         assert len(X.shape) == 2, "modelscope error: the shape of input should be [N, C]"
         if X.shape[0] < 20:
             return np.zeros(X.shape[0], dtype="int")
-        if X.shape[0] < 2048 or k is not None:
-            # unexpected corner case
+        if X.shape[0] < 2048:
             labels = self.spectral_cluster(X, k)
+        elif k is not None:
+            labels = self.kmeans_cluster(X, k)
         else:
             labels = self.umap_hdbscan_cluster(X)
 

--- a/tests/test_cluster_backend.py
+++ b/tests/test_cluster_backend.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+import torch
+
+from funasr.models.campplus.cluster_backend import ClusterBackend
+
+
+def test_large_known_speaker_count_uses_fixed_k_clustering(monkeypatch):
+    backend = ClusterBackend()
+    embeddings = torch.ones((2048, 2))
+    expected = np.arange(embeddings.shape[0]) % 2
+
+    def fail_spectral(*args, **kwargs):
+        pytest.fail("large inputs must not use dense spectral clustering")
+
+    def fail_umap(*args, **kwargs):
+        pytest.fail("a known speaker count should use fixed-K clustering")
+
+    def fixed_k_cluster(actual_embeddings, num_clusters):
+        assert actual_embeddings is embeddings
+        assert num_clusters == 2
+        return expected
+
+    monkeypatch.setattr(backend, "spectral_cluster", fail_spectral)
+    monkeypatch.setattr(backend, "umap_hdbscan_cluster", fail_umap)
+    monkeypatch.setattr(backend, "kmeans_cluster", fixed_k_cluster, raising=False)
+
+    labels = backend(embeddings, oracle_num=2)
+
+    np.testing.assert_array_equal(labels, expected)
+
+
+def test_large_fixed_k_clustering_separates_cosine_clusters():
+    backend = ClusterBackend()
+    embeddings = torch.zeros((2048, 2))
+    embeddings[:1024, 0] = 1
+    embeddings[1024:, 1] = 1
+
+    labels = backend(embeddings, oracle_num=2)
+
+    assert np.unique(labels).size == 2
+    assert np.unique(labels[:1024]).size == 1
+    assert np.unique(labels[1024:]).size == 1
+    assert labels[0] != labels[-1]


### PR DESCRIPTION
## Summary

Closes #3514.

When `preset_spk_num` is set, `ClusterBackend` currently sends every input size through spectral clustering. For long recordings this bypasses the existing 2,048-embedding safeguard and builds an O(N²) dense affinity/Laplacian matrix before an O(N³) eigendecomposition.

This change keeps the existing dispatch for small inputs and for large inputs with an unknown speaker count, while adding a bounded-memory fixed-K path for large inputs with a known count:

- L2-normalize the speaker embeddings so Euclidean K-means follows cosine geometry;
- use deterministic K-means with the requested speaker count;
- retain spectral clustering below 2,048 embeddings;
- retain UMAP/HDBSCAN for large inputs without `oracle_num`.

## Type of change

- [x] Bug fix
- [ ] Documentation
- [ ] Example or demo
- [ ] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

- [x] `python -m compileall funasr examples tests`
- [ ] Docs or links checked
- [x] Runtime/deployment command tested

Commands and results:

- `pytest -q tests/test_cluster_backend.py tests/test_top_level_import.py` — 3 passed
- `python -m build` — sdist and wheel built successfully
- `funasr --help` — CLI started successfully
- Replayed the reported scale with 10,639×192 synthetic speaker embeddings and `oracle_num=2`: the full `ClusterBackend` path completed in 0.098 seconds on CPU, returned exactly two clusters, and separated the two cosine clusters with 100% purity.

The dispatch regression fails on the previous implementation because it observes a call to dense spectral clustering at the 2,048 boundary.

## User impact

Users can provide `preset_spk_num` for long recordings without turning a scalable clustering path into an effectively unbounded dense eigendecomposition. Small-recording behavior and automatic speaker-count behavior remain unchanged.

## Notes for reviewers

The 2,048 threshold is not changed. The new tests cover both dispatch at the threshold and the actual fixed-K clustering result. The implementation uses the existing scikit-learn dependency and does not add a package or public API.
