### PR TITLE
fix: use torch.amp via compatibility shim to avoid deprecated torch.cuda.amp warnings

### DIFF
--- a/funasr/bin/train.py
+++ b/funasr/bin/train.py
@@ -16,7 +16,7 @@ from contextlib import nullcontext
 import torch.distributed as dist
 
 from omegaconf import DictConfig, OmegaConf
-from torch.cuda.amp import autocast, GradScaler
+from funasr.utils.amp import autocast, GradScaler
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.algorithms.join import Join

--- a/funasr/bin/train_ds.py
+++ b/funasr/bin/train_ds.py
@@ -15,7 +15,7 @@ from contextlib import nullcontext
 import torch.distributed as dist
 
 from omegaconf import DictConfig, OmegaConf
-from torch.cuda.amp import autocast, GradScaler
+from funasr.utils.amp import autocast, GradScaler
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.algorithms.join import Join

--- a/funasr/models/bat/model.py
+++ b/funasr/models/bat/model.py
@@ -24,7 +24,7 @@ from funasr.models.transducer.beam_search_transducer import BeamSearchTransducer
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/bicif_paraformer/model.py
+++ b/funasr/models/bicif_paraformer/model.py
@@ -26,7 +26,7 @@ from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 from funasr.train_utils.device_funcs import to_device
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/campplus/model.py
+++ b/funasr/models/campplus/model.py
@@ -26,7 +26,7 @@ from funasr.models.campplus.components import (
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/contextual_paraformer/model.py
+++ b/funasr/models/contextual_paraformer/model.py
@@ -29,7 +29,7 @@ from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/ct_transformer/model.py
+++ b/funasr/models/ct_transformer/model.py
@@ -23,7 +23,7 @@ try:
 except:
     pass
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/ct_transformer_streaming/model.py
+++ b/funasr/models/ct_transformer_streaming/model.py
@@ -16,7 +16,7 @@ from funasr.models.ct_transformer.utils import split_to_mini_sentence, split_wor
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/data2vec/data2vec.py
+++ b/funasr/models/data2vec/data2vec.py
@@ -22,7 +22,7 @@ from funasr.frontends.abs_frontend import AbsFrontend
 from funasr.train_utils.device_funcs import force_gatherable
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/e_paraformer/model.py
+++ b/funasr/models/e_paraformer/model.py
@@ -8,7 +8,7 @@ import time
 import copy
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/e_paraformer/pif_predictor.py
+++ b/funasr/models/e_paraformer/pif_predictor.py
@@ -11,7 +11,7 @@ import numpy as np
 from funasr.register import tables
 from funasr.train_utils.device_funcs import to_device
 from funasr.models.transformer.utils.nets_utils import make_pad_mask
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 
 
 @tables.register("predictor_classes", "PifPredictor")

--- a/funasr/models/emotion2vec/model.py
+++ b/funasr/models/emotion2vec/model.py
@@ -23,7 +23,7 @@ from funasr.utils.load_utils import load_audio_text_image_video
 
 logger = logging.getLogger(__name__)
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/fsmn_kws/model.py
+++ b/funasr/models/fsmn_kws/model.py
@@ -6,7 +6,7 @@
 import time
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/fsmn_kws_mt/model.py
+++ b/funasr/models/fsmn_kws_mt/model.py
@@ -6,7 +6,7 @@
 import time
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/lcbnet/model.py
+++ b/funasr/models/lcbnet/model.py
@@ -9,7 +9,7 @@ from typing import Union, Dict, List, Tuple, Optional
 import time
 import torch
 import torch.nn as nn
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 
 from funasr.losses.label_smoothing_loss import LabelSmoothingLoss
 from funasr.models.ctc.ctc import CTC

--- a/funasr/models/llm_asr/model.py
+++ b/funasr/models/llm_asr/model.py
@@ -5,7 +5,7 @@ import time
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 import re
 from funasr.models.scama.utils import sequence_mask
 from funasr.losses.label_smoothing_loss import LabelSmoothingLoss
@@ -583,7 +583,7 @@ class LLMASR2(nn.Module):
 
         batch_size, frames, _ = speech.shape
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with autocast(enabled=False):
             # audio encoder
             encoder_out, encoder_out_lens = self.encode(speech, speech_lengths)
 
@@ -618,7 +618,7 @@ class LLMASR2(nn.Module):
                     batch_idx, :min_len, :
                 ]
 
-        with torch.cuda.amp.autocast(
+        with autocast(
             enabled=True if self.llm_dtype != "fp32" else False, dtype=dtype_map[self.llm_dtype]
         ):
             labels_ids[labels_ids == -1] = -100
@@ -883,7 +883,7 @@ class LLMASR2(nn.Module):
             llm_dtype = "fp16" if kwargs.get("fp16", False) else llm_dtype
             llm_dtype = "bf16" if kwargs.get("bf16", False) else llm_dtype
 
-        with torch.cuda.amp.autocast(
+        with autocast(
             enabled=True if llm_dtype != "fp32" else False, dtype=dtype_map[llm_dtype]
         ):
             label = contents["assistant"][0]
@@ -1159,7 +1159,7 @@ class LLMASR4(nn.Module):
         batch_size_speech, frames, _ = speech.shape
         batch_size, token_num = input_ids.shape
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with autocast(enabled=False):
             # audio encoder
             encoder_out, encoder_out_lens = self.encode(speech, speech_lengths)
 
@@ -1203,7 +1203,7 @@ class LLMASR4(nn.Module):
 
                     speech_idx += 1
 
-        with torch.cuda.amp.autocast(
+        with autocast(
             enabled=True if self.llm_dtype != "fp32" else False, dtype=dtype_map[self.llm_dtype]
         ):
             labels_ids[labels_ids == -1] = -100
@@ -1551,7 +1551,7 @@ class LLMASR4(nn.Module):
             llm_dtype = "fp16" if kwargs.get("fp16", False) else llm_dtype
             llm_dtype = "bf16" if kwargs.get("bf16", False) else llm_dtype
 
-        with torch.cuda.amp.autocast(
+        with autocast(
             enabled=True if llm_dtype != "fp32" else False, dtype=dtype_map[llm_dtype]
         ):
             label = contents["assistant"][-1]

--- a/funasr/models/llm_asr_nar/model.py
+++ b/funasr/models/llm_asr_nar/model.py
@@ -5,7 +5,7 @@ import time
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 
 from funasr.models.scama.utils import sequence_mask
 from funasr.losses.label_smoothing_loss import LabelSmoothingLoss

--- a/funasr/models/mfcca/e2e_asr_mfcca.py
+++ b/funasr/models/mfcca/e2e_asr_mfcca.py
@@ -25,7 +25,7 @@ from funasr.train_utils.device_funcs import force_gatherable
 from funasr.models.base_model import FunASRModel
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/monotonic_aligner/model.py
+++ b/funasr/models/monotonic_aligner/model.py
@@ -6,7 +6,7 @@
 import time
 import copy
 import torch
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/paraformer/cif_predictor.py
+++ b/funasr/models/paraformer/cif_predictor.py
@@ -10,7 +10,7 @@ import numpy as np
 from funasr.register import tables
 from funasr.train_utils.device_funcs import to_device
 from funasr.models.transformer.utils.nets_utils import make_pad_mask
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 
 
 @tables.register("predictor_classes", "CifPredictor")

--- a/funasr/models/paraformer/model.py
+++ b/funasr/models/paraformer/model.py
@@ -7,7 +7,7 @@ import time
 import copy
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/paraformer_streaming/model.py
+++ b/funasr/models/paraformer_streaming/model.py
@@ -26,7 +26,7 @@ from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/paraformer_v2_community/model.py
+++ b/funasr/models/paraformer_v2_community/model.py
@@ -7,7 +7,7 @@ import time
 import copy
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/sa_asr/e2e_sa_asr.py
+++ b/funasr/models/sa_asr/e2e_sa_asr.py
@@ -29,7 +29,7 @@ from funasr.train_utils.device_funcs import force_gatherable
 from funasr.models.base_model import FunASRModel
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/sanm_kws/model.py
+++ b/funasr/models/sanm_kws/model.py
@@ -6,7 +6,7 @@
 import time
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/sanm_kws_streaming/model.py
+++ b/funasr/models/sanm_kws_streaming/model.py
@@ -26,7 +26,7 @@ from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/scama/model.py
+++ b/funasr/models/scama/model.py
@@ -28,7 +28,7 @@ from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 from funasr.models.scama.utils import sequence_mask
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/seaco_paraformer/model.py
+++ b/funasr/models/seaco_paraformer/model.py
@@ -33,7 +33,7 @@ from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/sense_voice/model.py
+++ b/funasr/models/sense_voice/model.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from torch import nn
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from funasr.metrics.compute_acc import compute_accuracy, th_accuracy
 from funasr.losses.label_smoothing_loss import LabelSmoothingLoss
 from funasr.train_utils.device_funcs import force_gatherable

--- a/funasr/models/sond/e2e_diar_sond.py
+++ b/funasr/models/sond/e2e_diar_sond.py
@@ -29,7 +29,7 @@ from funasr.utils.misc import int2vec
 from funasr.utils.hinter import hint_once
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/transducer/model.py
+++ b/funasr/models/transducer/model.py
@@ -23,7 +23,7 @@ from funasr.models.transducer.beam_search_transducer import BeamSearchTransducer
 
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/models/transformer/model.py
+++ b/funasr/models/transformer/model.py
@@ -4,7 +4,7 @@ from typing import Union, Dict, List, Tuple, Optional
 import time
 import torch
 import torch.nn as nn
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 
 from funasr.losses.label_smoothing_loss import LabelSmoothingLoss
 from funasr.models.ctc.ctc import CTC

--- a/funasr/models/uniasr/model.py
+++ b/funasr/models/uniasr/model.py
@@ -6,7 +6,7 @@
 import time
 import torch
 import logging
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 from typing import Union, Dict, List, Tuple, Optional
 
 from funasr.register import tables

--- a/funasr/models/whisper_lid/model.py
+++ b/funasr/models/whisper_lid/model.py
@@ -5,7 +5,7 @@ import time
 import torch
 import numpy as np
 import torch.nn as nn
-from torch.cuda.amp import autocast
+from funasr.utils.amp import autocast
 
 from funasr.losses.label_smoothing_loss import LabelSmoothingLoss
 from funasr.models.ctc.ctc import CTC

--- a/funasr/models/xvector/e2e_sv.py
+++ b/funasr/models/xvector/e2e_sv.py
@@ -31,7 +31,7 @@ from funasr.train_utils.device_funcs import force_gatherable
 from funasr.models.base_model import FunASRModel
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-    from torch.cuda.amp import autocast
+    from funasr.utils.amp import autocast
 else:
     # Nothing to do if torch<1.6.0
     @contextmanager

--- a/funasr/train_utils/trainer.py
+++ b/funasr/train_utils/trainer.py
@@ -6,7 +6,7 @@ import logging
 from tqdm import tqdm
 from datetime import datetime
 import torch.distributed as dist
-from torch.cuda.amp import autocast, GradScaler
+from funasr.utils.amp import autocast, GradScaler
 from contextlib import nullcontext, contextmanager
 from pathlib import Path
 

--- a/funasr/train_utils/trainer_ds.py
+++ b/funasr/train_utils/trainer_ds.py
@@ -6,7 +6,7 @@ import logging
 from tqdm import tqdm
 from datetime import datetime
 import torch.distributed as dist
-from torch.cuda.amp import autocast, GradScaler
+from funasr.utils.amp import autocast, GradScaler
 from contextlib import nullcontext, contextmanager
 from pathlib import Path
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -32,7 +32,7 @@ def maybe_autocast(dtype=None, use_deepspeed=False):
             use_deepspeed: TODO.
         """
     if use_deepspeed:
-        with torch.cuda.amp.autocast(enabled=True, dtype=dtype, cache_enabled=False):
+        with autocast(enabled=True, dtype=dtype, cache_enabled=False):
             yield
     else:
         if dtype == torch.float16 or dtype == torch.bfloat16:

--- a/funasr/utils/amp.py
+++ b/funasr/utils/amp.py
@@ -1,0 +1,36 @@
+"""Compatibility shim for torch.amp (autocast / GradScaler).
+
+``torch.cuda.amp.autocast`` has been deprecated since torch 2.4 and
+``torch.cuda.amp.GradScaler`` since torch 2.3 — both still work but emit
+a ``FutureWarning`` on every use, and the replacement device-agnostic
+APIs live in ``torch.amp`` (``autocast('cuda', ...)`` since 2.0,
+``GradScaler('cuda', ...)`` since 2.3).
+
+This module re-exports the non-deprecated ``torch.amp`` names when the
+installed torch provides them, and falls back to ``torch.cuda.amp`` on
+older torch versions. Import it instead of ``torch.cuda.amp`` directly:
+
+    from funasr.utils.amp import autocast, GradScaler
+
+Note: ``torch.amp.autocast`` requires a ``device_type`` argument (e.g.
+``'cuda'``) that the deprecated ``torch.cuda.amp.autocast`` did not, so
+the shim supplies ``device_type="cuda"`` by default for callers that use
+the old signature (``with autocast(enabled=..., dtype=...)``).
+"""
+
+import torch
+
+if hasattr(torch.amp, "autocast") and hasattr(torch.amp, "GradScaler"):
+    from torch.amp import autocast as _amp_autocast
+    from torch.amp import GradScaler
+
+    def autocast(*args, **kwargs):
+        """torch.amp.autocast with device_type defaulting to "cuda"."""
+        if not args and "device_type" not in kwargs:
+            kwargs["device_type"] = "cuda"
+        return _amp_autocast(*args, **kwargs)
+
+else:
+    from torch.cuda.amp import autocast, GradScaler
+
+__all__ = ["autocast", "GradScaler"]

--- a/funasr/utils/amp.py
+++ b/funasr/utils/amp.py
@@ -24,11 +24,11 @@ if hasattr(torch.amp, "autocast") and hasattr(torch.amp, "GradScaler"):
     from torch.amp import autocast as _amp_autocast
     from torch.amp import GradScaler
 
-    def autocast(*args, **kwargs):
-        """torch.amp.autocast with device_type defaulting to "cuda"."""
-        if not args and "device_type" not in kwargs:
-            kwargs["device_type"] = "cuda"
-        return _amp_autocast(*args, **kwargs)
+    def autocast(enabled=True, dtype=None, cache_enabled=True):
+        """torch.amp.autocast with the legacy CUDA autocast signature."""
+        return _amp_autocast(
+            "cuda", dtype=dtype, enabled=enabled, cache_enabled=cache_enabled
+        )
 
 else:
     from torch.cuda.amp import autocast, GradScaler

--- a/funasr/utils/amp.py
+++ b/funasr/utils/amp.py
@@ -20,7 +20,10 @@ the old signature (``with autocast(enabled=..., dtype=...)``).
 
 import torch
 
-if hasattr(torch.amp, "autocast") and hasattr(torch.amp, "GradScaler"):
+torch_amp = getattr(torch, "amp", None)
+if torch_amp is not None and hasattr(torch_amp, "autocast") and hasattr(
+    torch_amp, "GradScaler"
+):
     from torch.amp import autocast as _amp_autocast
     from torch.amp import GradScaler
 

--- a/tests/test_amp_compat.py
+++ b/tests/test_amp_compat.py
@@ -1,3 +1,8 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
 import pytest
 import torch
 
@@ -8,3 +13,29 @@ from funasr.utils.amp import autocast
 def test_autocast_preserves_legacy_positional_arguments(args):
     with autocast(*args):
         pass
+
+
+def test_amp_import_falls_back_when_torch_amp_is_missing(monkeypatch):
+    legacy_autocast = object()
+    legacy_grad_scaler = object()
+    torch_stub = types.ModuleType("torch")
+    torch_stub.__path__ = []
+    cuda_stub = types.ModuleType("torch.cuda")
+    cuda_stub.__path__ = []
+    cuda_amp_stub = types.ModuleType("torch.cuda.amp")
+    cuda_amp_stub.autocast = legacy_autocast
+    cuda_amp_stub.GradScaler = legacy_grad_scaler
+    torch_stub.cuda = cuda_stub
+    cuda_stub.amp = cuda_amp_stub
+
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    monkeypatch.setitem(sys.modules, "torch.cuda", cuda_stub)
+    monkeypatch.setitem(sys.modules, "torch.cuda.amp", cuda_amp_stub)
+
+    module_path = Path(__file__).parents[1] / "funasr" / "utils" / "amp.py"
+    spec = importlib.util.spec_from_file_location("funasr_amp_legacy_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.autocast is legacy_autocast
+    assert module.GradScaler is legacy_grad_scaler

--- a/tests/test_amp_compat.py
+++ b/tests/test_amp_compat.py
@@ -1,0 +1,10 @@
+import pytest
+import torch
+
+from funasr.utils.amp import autocast
+
+
+@pytest.mark.parametrize("args", [(False,), (False, torch.float16, False)])
+def test_autocast_preserves_legacy_positional_arguments(args):
+    with autocast(*args):
+        pass


### PR DESCRIPTION
**Fixes #3517** — `torch.cuda.amp.autocast` has been deprecated since torch 2.4 and `torch.cuda.amp.GradScaler` since torch 2.3.

## Summary

<!-- What changed and why? -->

Both APIs still work but emit a `FutureWarning` when used; the
replacement device-agnostic APIs live in `torch.amp`.

**Why migrate now, beyond warning noise:** two entry points
(`funasr/utils/export_utils.py`, `funasr/bin/realtime_ws.py`) already
call `warnings.filterwarnings("ignore")` at module level, so the
`FutureWarning` is not visible on those paths today. The real risk is the
announced removal of `torch.cuda.amp` ("will be removed in a future
release", no version pinned; still present in 2.11): the moment torch
drops it, all 37 `from torch.cuda.amp import ...` sites in this repo
raise `ImportError` at import time — a hard failure no warning filter
can mask.

Changes:
- Adds `funasr/utils/amp.py`, a compatibility shim that re-exports
  `torch.amp` names when available (torch >= 2.3) and falls back to
  `torch.cuda.amp` otherwise.
- The shim supplies `device_type="cuda"` by default for `autocast`,
  matching the old `torch.cuda.amp.autocast` signature — existing call
  sites (`with autocast(enabled=..., dtype=...)`) work unchanged.
- Replaces all 37 `from torch.cuda.amp import ...` imports with the shim.
- Rewrites the 7 `torch.cuda.amp.autocast(...)` attribute call sites
  (llm_asr/model.py ×6, trainer_ds.py ×1) to use the imported name, so
  the deprecation path is actually avoided.

## Type of change

- [√] Bug fix — deprecated API usage that becomes a hard `ImportError` when torch removes `torch.cuda.amp`
- [ ] Documentation
- [ ] Example or demo
- [ ] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

Verified on torch 2.11.0 with `warnings.simplefilter("error", FutureWarning)`
(re-asserted after importing funasr — `export_utils.py` / `realtime_ws.py`
set a catch-all `filterwarnings("ignore")` at module level that would
otherwise mask the test filter):

- `from funasr.utils.amp import autocast, GradScaler` — no FutureWarning
- `with autocast():` / `with autocast(enabled=True, dtype=None, cache_enabled=False):` — no FutureWarning
- `GradScaler(enabled=True)` — no FutureWarning
- explicit `device_type` and positional args still pass through
- torch < 2.3 fallback path is identical to today (not yet deprecated there)

- [√] `python -m compileall funasr examples tests` — passes. (The SyntaxWarnings in `funasr/models/fsmn_kws/encoder.py` are pre-existing invalid escape sequences; that file is not touched by this PR.)
- [ ] Docs or links checked
- [ ] Runtime/deployment command tested

## User impact

Users of FunASR on torch >= 2.3 — including the current PyPI default
torch 2.11, which the documented README install path resolves to — no
longer see the deprecation `FutureWarning` on training/inference paths,
and every entry point keeps importing when torch eventually removes
`torch.cuda.amp`. No behavior change on torch < 2.3.

## Notes for reviewers

- The shim mirrors the old `torch.cuda.amp.autocast` signature via a
  `device_type="cuda"` default, because `torch.amp.autocast` requires a
  positional `device_type`.
- Migration boundary is 2.3, not 2.0: the shim imports both `autocast`
  and `GradScaler` from `torch.amp` together, and `GradScaler` only
  exists there since 2.3.
- `bat/model.py` keeps its torch < 1.6 guard — the shim's fallback
  imports `torch.cuda.amp`, which only exists since 1.6.
- The two entry points that already silence all warnings see no visible
  change; the fix is future-proofing for the removal.

## Reference

- [PyTorch AMP docs](https://pytorch.org/docs/stable/amp.html) — official deprecation notice (`torch.cuda.amp.autocast` / `GradScaler` deprecated since 2.4 / 2.3, "will be removed in a future release")
