### PR TITLE
Raise real exceptions instead of strings in the runtime Python bindings

### DIFF
--- a/runtime/python/libtorch/funasr_torch/paraformer_bin.py
+++ b/runtime/python/libtorch/funasr_torch/paraformer_bin.py
@@ -37,14 +37,18 @@ class Paraformer:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.torchscript")
         if quantize:
@@ -53,8 +57,10 @@ class Paraformer:
             print(".torchscripts does not exist, begin to export torchscript")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="torchscript", quantize=quantize, **kwargs)
@@ -258,14 +264,18 @@ class ContextualParaformer(Paraformer):
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         if quantize:
             model_bb_file = os.path.join(model_dir, "model_bb_quant.torchscript")
@@ -278,8 +288,10 @@ class ContextualParaformer(Paraformer):
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="torchscript", quantize=quantize, **kwargs)

--- a/runtime/python/libtorch/funasr_torch/sensevoice_bin.py
+++ b/runtime/python/libtorch/funasr_torch/sensevoice_bin.py
@@ -43,14 +43,18 @@ class SenseVoiceSmall:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.torchscript")
         if quantize:
@@ -59,8 +63,10 @@ class SenseVoiceSmall:
             print(".torchscripts does not exist, begin to export torchscript")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="torchscript", quantize=quantize, **kwargs)

--- a/runtime/python/onnxruntime/funasr_onnx/paraformer_bin.py
+++ b/runtime/python/onnxruntime/funasr_onnx/paraformer_bin.py
@@ -49,14 +49,18 @@ class Paraformer:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.onnx")
         if quantize:
@@ -65,8 +69,10 @@ class Paraformer:
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)
@@ -284,14 +290,18 @@ class ContextualParaformer(Paraformer):
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         if quantize:
             model_bb_file = os.path.join(model_dir, "model_quant.onnx")
@@ -304,8 +314,10 @@ class ContextualParaformer(Paraformer):
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)

--- a/runtime/python/onnxruntime/funasr_onnx/paraformer_online_bin.py
+++ b/runtime/python/onnxruntime/funasr_onnx/paraformer_online_bin.py
@@ -39,14 +39,18 @@ class Paraformer:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         encoder_model_file = os.path.join(model_dir, "model.onnx")
         decoder_model_file = os.path.join(model_dir, "decoder.onnx")
@@ -57,8 +61,10 @@ class Paraformer:
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)

--- a/runtime/python/onnxruntime/funasr_onnx/punc_bin.py
+++ b/runtime/python/onnxruntime/funasr_onnx/punc_bin.py
@@ -39,14 +39,18 @@ class CT_Transformer:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.onnx")
         if quantize:
@@ -55,8 +59,10 @@ class CT_Transformer:
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)

--- a/runtime/python/onnxruntime/funasr_onnx/sensevoice_bin.py
+++ b/runtime/python/onnxruntime/funasr_onnx/sensevoice_bin.py
@@ -46,14 +46,18 @@ class SenseVoiceSmall:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.onnx")
         if quantize:
@@ -62,8 +66,10 @@ class SenseVoiceSmall:
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)

--- a/runtime/python/onnxruntime/funasr_onnx/vad_bin.py
+++ b/runtime/python/onnxruntime/funasr_onnx/vad_bin.py
@@ -39,14 +39,18 @@ class Fsmn_vad:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.onnx")
         if quantize:
@@ -55,8 +59,10 @@ class Fsmn_vad:
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)
@@ -224,14 +230,18 @@ class Fsmn_vad_online:
         if not Path(model_dir).exists():
             try:
                 from modelscope.hub.snapshot_download import snapshot_download
-            except:
-                raise "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting model from modelscope, please install modelscope and try it again. To install modelscope, you could:\n" "\npip3 install -U modelscope\n" "For the users in China, you could install with the command:\n" "\npip3 install -U modelscope -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
             try:
                 model_dir = snapshot_download(model_dir, cache_dir=cache_dir)
-            except:
-                raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                    model_dir
-                )
+            except Exception as e:
+                raise RuntimeError(
+                    "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
+                        model_dir
+                    )
+                ) from e
 
         model_file = os.path.join(model_dir, "model.onnx")
         if quantize:
@@ -240,8 +250,10 @@ class Fsmn_vad_online:
             print(".onnx does not exist, begin to export onnx")
             try:
                 from funasr import AutoModel
-            except:
-                raise "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+            except ImportError as e:
+                raise ImportError(
+                    "You are exporting onnx, please install funasr and try it again. To install funasr, you could:\n" "\npip3 install -U funasr\n" "For the users in China, you could install with the command:\n" "\npip3 install -U funasr -i https://mirror.sjtu.edu.cn/pypi/web/simple"
+                ) from e
 
             model = AutoModel(model=model_dir)
             model_dir = model.export(type="onnx", quantize=quantize, **kwargs)


### PR DESCRIPTION
Fixes #3523.

`raise "some message"` is invalid in Python 3 — a `str` is not an exception. The
interpreter discards the intended message and raises

```
TypeError: exceptions must derive from BaseException
```

instead. Paired with the surrounding bare `except:`, the original cause is lost as well,
so the user is told to install a package they may already have while the real failure is
invisible.

### What this looked like in practice

`funasr` **was** installed. The import failed on a missing transitive dependency:

```
File ".../funasr/utils/load_utils.py", line 9, in <module>
    import torchaudio
ModuleNotFoundError: No module named 'torchaudio'
```

What I saw:

```
File ".../funasr_onnx/sensevoice_bin.py", line 66, in __init__
    raise "You are exporting onnx, please install funasr and try it again..."
TypeError: exceptions must derive from BaseException
```

The message pointed at the wrong package, and the traceback pointed at the wrong error.
Diagnosing it meant reading the library source and reproducing the import by hand. I hit
the same wall a second time on `onnxscript` (required by newer `torch.onnx`), and a third
time when loading from a local path — the `model_dir` branch fires on *any* failure, so a
mistyped path also surfaced as `TypeError`.

### The change

All 30 occurrences under `runtime/python` (7 files, both `funasr_onnx` and
`funasr_torch`):

```python
# before
try:
    from funasr import AutoModel
except:
    raise "You are exporting onnx, please install funasr and try it again. ..."

# after
try:
    from funasr import AutoModel
except ImportError as e:
    raise ImportError(
        "You are exporting onnx, please install funasr and try it again. ..."
    ) from e
```

- guarded imports → `except ImportError as e:` / `raise ImportError(...) from e`
- everything else → `except Exception as e:` / `raise RuntimeError(...) from e`

`from e` preserves the original traceback, which is the point — a missing `torchaudio`
now stays visible under the friendly message. Narrowing the bare `except:` also stops
unrelated failures from being reported as a missing package.

**Messages are unchanged.** The only behavioural difference is the exception type, which
previously could not be caught by anything anyway.

### Verification

- `raise "` no longer appears anywhere under `runtime/python`
- every changed file passes `python -m py_compile`
- chaining behaves as intended:

```
外层信息: please install funasr: pip3 install -U funasr
真实原因: No module named 'nonexistent_module_xyz'
```

I deliberately did **not** run `black` over these files. It reformats unrelated code in
them (the tree is not currently black-clean), which would have buried a 140-line fix in a
280-line diff. The new code follows the project's 100-column style by hand. Happy to run
the formatter if you would rather have it.

Two occurrences outside `runtime/python` are left alone as out of scope:
`funasr/models/qwen3_asr/model.py` and `funasr/download/runtime_sdk_download_tool.py`.

Context: found while building a local-ASR adapter for Jitsi Meet
(https://github.com/LeonardNJU/jitsi-local-asr) that runs SenseVoice and streaming
Paraformer via `funasr_onnx` on an ARM box.