### PR TITLE
Make torchaudio import optional in paraformer_v2, fun_asr_nano and dataset preprocessors

### DIFF
--- a/funasr/datasets/audio_datasets/preprocessor.py
+++ b/funasr/datasets/audio_datasets/preprocessor.py
@@ -7,7 +7,10 @@ import librosa
 import torch.distributed as dist
 from typing import Collection
 import torch
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None
 from torch import nn
 import random
 import re

--- a/funasr/datasets/llm_datasets/preprocessor.py
+++ b/funasr/datasets/llm_datasets/preprocessor.py
@@ -7,7 +7,10 @@ import librosa
 import torch.distributed as dist
 from typing import Collection
 import torch
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None
 from torch import nn
 import random
 import re

--- a/funasr/models/fun_asr_nano/tools/utils.py
+++ b/funasr/models/fun_asr_nano/tools/utils.py
@@ -2,8 +2,12 @@ from itertools import groupby
 
 import soundfile as sf
 import torch
-import torchaudio
-import torchaudio.functional as F
+try:
+    import torchaudio
+    import torchaudio.functional as F
+except ImportError:
+    torchaudio = None
+    F = None
 
 
 def load_audio(wav_path, rate: int = None, offset: float = 0, duration: float = None):

--- a/funasr/models/paraformer_v2_community/model.py
+++ b/funasr/models/paraformer_v2_community/model.py
@@ -25,7 +25,10 @@ from funasr.models.transformer.utils.nets_utils import make_pad_mask
 from funasr.utils.timestamp_tools import ts_prediction_lfr6_standard
 from funasr.utils.load_utils import load_audio_text_image_video, extract_fbank
 from torch.nn.utils.rnn import pad_sequence
-import torchaudio
+try:
+    import torchaudio
+except ImportError:
+    torchaudio = None
 
 @tables.register("model_classes", "Paraformer_v2_community")
 class Paraformer(torch.nn.Module):


### PR DESCRIPTION
Make torchaudio import optional in paraformer_v2, fun_asr_nano and dataset preprocessors

Follow-up to the inference-path change: make the remaining top-level
torchaudio imports optional so these modules import cleanly when
torchaudio is not installed (e.g. on Ascend NPU servers).

- funasr/models/paraformer_v2_community/model.py
- funasr/models/fun_asr_nano/tools/utils.py
- funasr/datasets/audio_datasets/preprocessor.py
- funasr/datasets/llm_datasets/preprocessor.py

Functions that still require torchaudio (forced_align, Resample) degrade
to a clear error only when called, rather than a hard import failure.