### PR TITLE
fix(runtime): allow integrated GPU backends

### DIFF
--- a/runtime/llama.cpp/sensevoice/funasr-sensevoice/funasr-sensevoice.cpp
+++ b/runtime/llama.cpp/sensevoice/funasr-sensevoice/funasr-sensevoice.cpp
@@ -76,19 +76,22 @@ static std::string lower_copy(const char*s){
 
 static ggml_backend_dev_t find_gpu_backend_device(const std::string&backend_name){
   ggml_backend_load_all();
+  ggml_backend_dev_t integrated_fallback=nullptr;
   for(size_t i=0;i<ggml_backend_dev_count();i++){
     ggml_backend_dev_t dev=ggml_backend_dev_get(i);
-    if(ggml_backend_dev_type(dev)!=GGML_BACKEND_DEVICE_TYPE_GPU) continue;
+    enum ggml_backend_dev_type type=ggml_backend_dev_type(dev);
+    if(type!=GGML_BACKEND_DEVICE_TYPE_GPU&&type!=GGML_BACKEND_DEVICE_TYPE_IGPU) continue;
     std::string reg=lower_copy(ggml_backend_reg_name(ggml_backend_dev_backend_reg(dev)));
     std::string dev_name=lower_copy(ggml_backend_dev_name(dev));
     std::string dev_desc=lower_copy(ggml_backend_dev_description(dev));
     if(reg.find(backend_name)!=std::string::npos||
        dev_name.find(backend_name)!=std::string::npos||
        dev_desc.find(backend_name)!=std::string::npos){
-      return dev;
+      if(type==GGML_BACKEND_DEVICE_TYPE_GPU) return dev;
+      if(!integrated_fallback) integrated_fallback=dev;
     }
   }
-  return nullptr;
+  return integrated_fallback;
 }
 
 static graph_backend make_graph_backend(const std::string&name){

--- a/runtime/llama.cpp/tests/test_backend_flags.py
+++ b/runtime/llama.cpp/tests/test_backend_flags.py
@@ -28,3 +28,22 @@ def test_sensevoice_vulkan_backend_has_dedicated_error_message():
     assert 'name=="vulkan"' in source
     assert "GGML_VULKAN=ON" in source
     assert "unsupported backend '%s' (expected cpu|cuda|vulkan)" in source
+
+
+def test_sensevoice_prefers_discrete_gpu_and_falls_back_to_matching_igpu():
+    source = SENSEVOICE.read_text(encoding="utf-8")
+    selector = source.split(
+        "static ggml_backend_dev_t find_gpu_backend_device", maxsplit=1
+    )[1].split("static graph_backend make_graph_backend", maxsplit=1)[0]
+
+    assert "GGML_BACKEND_DEVICE_TYPE_IGPU" in selector
+    assert "integrated_fallback" in selector
+    assert "return integrated_fallback" in selector
+    discrete_return = "if(type==GGML_BACKEND_DEVICE_TYPE_GPU) return dev;"
+    integrated_save = "if(!integrated_fallback) integrated_fallback=dev;"
+    assert discrete_return in selector
+    assert integrated_save in selector
+    assert selector.index(discrete_return) < selector.index(integrated_save)
+    assert selector.index(integrated_save) < selector.index(
+        "return integrated_fallback"
+    )


### PR DESCRIPTION
## Summary
- accept matching `GGML_BACKEND_DEVICE_TYPE_IGPU` devices for the SenseVoice Vulkan/CUDA selector
- keep a matching iGPU as fallback while continuing to prefer a matching discrete GPU
- retain rejection of CPU devices and unrelated backend registrations

## Why
FunASR currently enumerates integrated Vulkan GPUs but filters them out before backend-name matching. This produces the misleading “no Vulkan GPU backend” error on devices such as the Radeon 780M reported in #3479 and also blocks the Mali path discussed in QwenAudio/SenseVoice#343.

This PR fixes only the deterministic iGPU selector bug. It does not claim to fix the separate RX 9070 XT `0xC0000005` backend-initialization crash in #3479.

## Verification
- regression test RED on `main@ae5c4ccd`, then GREEN after the fix
- `python -m pytest runtime/llama.cpp/tests -q`: 18 passed
- CPU SenseVoice target built successfully against pinned llama.cpp `803b7fca`
- Vulkan SenseVoice target built successfully against the same pinned revision
- `git diff --check`: clean
- commit is SSH-signed and DCO-signed-off