### PR TITLE
fix(vulkan): guard backend initialization failures

### DIFF
--- a/runtime/llama.cpp/sensevoice/funasr-sensevoice/funasr-sensevoice.cpp
+++ b/runtime/llama.cpp/sensevoice/funasr-sensevoice/funasr-sensevoice.cpp
@@ -94,10 +94,38 @@ static ggml_backend_dev_t find_gpu_backend_device(const std::string&backend_name
   return integrated_fallback;
 }
 
+static graph_backend initialize_device_backend(const std::string&name,ggml_backend_dev_t dev){
+  graph_backend out;
+  const char*dev_name=ggml_backend_dev_name(dev);
+  const char*dev_desc=ggml_backend_dev_description(dev);
+  fprintf(stderr,"initializing %s backend on %s (%s)\n",name.c_str(),dev_name,dev_desc);
+  fflush(stderr);
+  out.backend=ggml_backend_dev_init(dev,nullptr);
+  if(!out.backend){
+    fprintf(stderr,"failed to initialize %s backend on %s\n",name.c_str(),dev_name);
+    exit(1);
+  }
+  fprintf(stderr,"initialized %s backend on %s; resolving buffer type\n",name.c_str(),dev_name);
+  fflush(stderr);
+  out.buffer_type=ggml_backend_get_default_buffer_type(out.backend);
+  if(!out.buffer_type){
+    fprintf(stderr,"%s backend on %s has no default buffer type\n",name.c_str(),dev_name);
+    exit(1);
+  }
+  fprintf(stderr,"%s backend ready on %s\n",name.c_str(),dev_name);
+  fflush(stderr);
+  out.is_cpu=false;
+  return out;
+}
+
 static graph_backend make_graph_backend(const std::string&name){
   graph_backend out;
   if(name=="cpu"){
     out.backend=ggml_backend_cpu_init();
+    if(!out.backend){
+      fprintf(stderr,"failed to initialize cpu backend\n");
+      exit(1);
+    }
     out.buffer_type=ggml_backend_get_default_buffer_type(out.backend);
     out.is_cpu=true;
   } else if(name=="cuda"){
@@ -106,18 +134,14 @@ static graph_backend make_graph_backend(const std::string&name){
       fprintf(stderr,"CUDA backend requested, but no GPU backend is available; build with -DGGML_CUDA=ON\n");
       exit(1);
     }
-    out.backend=ggml_backend_dev_init(dev,nullptr);
-    out.buffer_type=ggml_backend_get_default_buffer_type(out.backend);
-    out.is_cpu=false;
+    return initialize_device_backend(name,dev);
   } else if(name=="vulkan"){
     ggml_backend_dev_t dev=find_gpu_backend_device("vulkan");
     if(!dev){
       fprintf(stderr,"Vulkan backend requested, but no Vulkan GPU backend is available; build with -DGGML_VULKAN=ON and install a Vulkan driver/ICD\n");
       exit(1);
     }
-    out.backend=ggml_backend_dev_init(dev,nullptr);
-    out.buffer_type=ggml_backend_get_default_buffer_type(out.backend);
-    out.is_cpu=false;
+    return initialize_device_backend(name,dev);
   } else {
     fprintf(stderr,"unsupported backend '%s' (expected cpu|cuda|vulkan)\n",name.c_str());
     exit(1);

--- a/runtime/llama.cpp/tests/test_backend_flags.py
+++ b/runtime/llama.cpp/tests/test_backend_flags.py
@@ -47,3 +47,30 @@ def test_sensevoice_prefers_discrete_gpu_and_falls_back_to_matching_igpu():
     assert selector.index(integrated_save) < selector.index(
         "return integrated_fallback"
     )
+
+
+def test_sensevoice_checks_backend_before_resolving_buffer_type():
+    source = SENSEVOICE.read_text(encoding="utf-8")
+    initializer = source.split(
+        "static graph_backend initialize_device_backend", maxsplit=1
+    )[1].split("static graph_backend make_graph_backend", maxsplit=1)[0]
+
+    init_call = "out.backend=ggml_backend_dev_init(dev,nullptr);"
+    null_check = "if(!out.backend)"
+    buffer_type = "ggml_backend_get_default_buffer_type(out.backend)"
+    assert init_call in initializer
+    assert null_check in initializer
+    assert buffer_type in initializer
+    assert initializer.index(init_call) < initializer.index(null_check)
+    assert initializer.index(null_check) < initializer.index(buffer_type)
+
+
+def test_sensevoice_flushes_device_initialization_boundaries_to_stderr():
+    source = SENSEVOICE.read_text(encoding="utf-8")
+    initializer = source.split(
+        "static graph_backend initialize_device_backend", maxsplit=1
+    )[1].split("static graph_backend make_graph_backend", maxsplit=1)[0]
+
+    assert "initializing %s backend on %s (%s)" in initializer
+    assert "initialized %s backend on %s; resolving buffer type" in initializer
+    assert "fflush(stderr);" in initializer


### PR DESCRIPTION
## Summary

- check a device backend for null before resolving its default buffer type
- print and flush the selected device plus initialization boundaries to stderr
- share the guarded initialization path between CUDA and Vulkan

## Why

FunASR #3479 now has two AMD Windows reproductions that stop immediately after Vulkan enumeration with `0xC0000005`. The current code can also call `ggml_backend_get_default_buffer_type(nullptr)` when `ggml_backend_dev_init()` fails, so its existing combined error check runs too late.

This change fixes that deterministic host-side bug and makes the next hardware stderr distinguish a crash inside `ggml_backend_dev_init()` from a failure after it returns. It does **not** claim that the AMD Windows Vulkan driver crash is fixed.

## Verification

- `python -m pytest -q runtime/llama.cpp/tests` -> 20 passed
- fresh Release CPU configure/build of `llama-funasr-sensevoice` -> passed
- exact-head incremental Release build -> passed
- `git diff --check origin/main...HEAD` -> passed
- signed commit and DCO sign-off verified locally

A bare repository-wide pytest collection was also attempted; it stops on existing collection/environment problems (vendored llama.cpp Appium/wget tests, missing ModelScope, NumPy 1.x extensions under NumPy 2.x, and script-style `test_*.py` arguments), unrelated to these two files.

Refs #3479