### PR TITLE
docs(moss): expose AutoModel deployment contract

### DIFF
--- a/web-pages/product-site/data/deployments.json
+++ b/web-pages/product-site/data/deployments.json
@@ -13,7 +13,7 @@
       "models": ["OpenMOSS-Team/MOSS-Transcribe-Diarize (third-party Apache-2.0 model)"],
       "operating_systems": ["Linux"],
       "interfaces": ["OpenAI-compatible HTTP", "vLLM", "SGLang Omni", "Transformers"],
-      "tested": {"funasr": "ecosystem contract; third-party model@e8681d68", "runtime": "vLLM 0.23.1rc1.dev949+g68b4a1d58 / Torch 2.11.0+cu129 / H100 80GB", "verified": "2026-08-29"},
+      "tested": {"funasr": "AutoModel adapter@a3a2de0a; third-party model@e8681d68", "runtime": "Transformers 5.16.1 + vLLM 0.23.1rc1.dev949+g68b4a1d58 / Torch 2.11.0+cu129 / H100 80GB", "verified": "2026-08-29"},
       "commands": {
         "install": [
           "uv venv --python 3.12 .venv-moss && uv pip install --python .venv-moss/bin/python -U 'vllm[audio]' --torch-backend=auto --extra-index-url https://wheels.vllm.ai/68b4a1d582818e67adc903bf1b8fc5a5447da2fa/cu129",
@@ -28,7 +28,8 @@
         ],
         "smoke": [
           "curl -fsS http://127.0.0.1:8898/v1/audio/transcriptions -F file=@runtime/llama.cpp/tests/sample.wav -F model=moss-transcribe-diarize -F response_format=json -F temperature=0 | tee /tmp/moss-transcription.json",
-          "python - <<'PY'\nimport json\n\nwith open('/tmp/moss-transcription.json', encoding='utf-8') as stream:\n    payload = json.load(stream)\ntext = payload.get('text', '')\nassert text.strip(), payload\nassert '[S01]' in text, text\nprint(text)\nPY"
+          "python - <<'PY'\nimport json\n\nwith open('/tmp/moss-transcription.json', encoding='utf-8') as stream:\n    payload = json.load(stream)\ntext = payload.get('text', '')\nassert text.strip(), payload\nassert '[S01]' in text, text\nprint(text)\nPY",
+          "python - <<'PY'\nfrom funasr import AutoModel\n\nmodel = AutoModel(model='OpenMOSS-Team/MOSS-Transcribe-Diarize', backend='vllm', vllm_base_url='http://127.0.0.1:8898/v1', vllm_model='moss-transcribe-diarize', disable_update=True)\nresult = model.generate('runtime/llama.cpp/tests/sample.wav')[0]\nassert result['raw_text'] and result['sentence_info'], result\nprint(result['text'])\nprint(result['sentence_info'])\nPY"
         ]
       },
       "evidence": [
@@ -36,7 +37,8 @@
         {"label": "upstream source pinned at cb765f2", "url": "https://github.com/OpenMOSS/MOSS-Transcribe-Diarize/commit/cb765f2b0fe6f7a298aa2002e2281ae693d1f3c3"},
         {"label": "official model snapshot pinned at e8681d68", "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize/tree/e8681d68e7042738ffca8ac8212bc8fcb1131ab8"},
         {"label": "official vLLM and SGLang Omni serving guide", "url": "https://github.com/OpenMOSS/MOSS-Transcribe-Diarize/blob/cb765f2b0fe6f7a298aa2002e2281ae693d1f3c3/README.md"},
-        {"label": "FunASR ecosystem integration guide", "url": "https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize.md"}
+        {"label": "FunASR ecosystem integration guide", "url": "https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize.md"},
+        {"label": "FunASR AutoModel adapter merge and exact-head CI", "url": "https://github.com/modelscope/FunASR/pull/3558"}
       ],
       "benchmarks": [
         {
@@ -56,27 +58,27 @@
       "translations": {
         "zh": {
           "name": "MOSS 统一转写与说话人分离",
-          "summary": "在 FunASR 部署中心接入 OpenMOSS 发布的第三方 Apache-2.0 模型，一次生成长音频转写、时间戳和说话人标签。",
+          "summary": "通过 FunASR AutoModel 或 OpenAI 兼容服务接入 OpenMOSS 发布的第三方 Apache-2.0 模型，一次生成长音频转写、时间戳和说话人标签。",
           "fit": ["会议、访谈、播客和通话的多人长音频", "希望通过同一个模型输出文本、时间戳与说话人编号", "已有 NVIDIA GPU，并需要 OpenAI 兼容的音频转写接口"],
-          "not_fit": ["实时流式字幕或低延迟端点检测", "CPU、桌面边缘设备或 Windows 原生部署", "要求 FunASR 自有模型权重或 FunASR AutoModel API 的项目"],
-          "selection_reason": "模型端到端联合生成转写与说话人标签，用户不必再拼接外部 VAD、ASR 和 diarization 管线；vLLM 与 SGLang Omni 都提供 /v1/audio/transcriptions。",
+          "not_fit": ["实时流式字幕或低延迟端点检测", "CPU、桌面边缘设备或 Windows 原生部署", "要求 FunASR 自有模型权重的项目"],
+          "selection_reason": "模型端到端联合生成转写与说话人标签，用户不必再拼接外部 VAD、ASR 和 diarization 管线；FunASR AutoModel 为 Transformers 与 vLLM 提供统一的结构化结果。",
           "primary_limitation": "这是 OpenMOSS 的第三方模型，不是 FunASR 模型；“无需外部 VAD”不表示模型内部没有分块或分段。当前 vLLM 路径固定 nightly commit，升级前必须重跑真实多人长音频。",
           "status_label": "社区验证",
-          "operations": ["固定模型 revision、vLLM nightly commit、CUDA/Torch 与 trust_remote_code 审计结果", "用真实会议验证说话人一致性、重叠语音、长静音、时间戳和最大生成长度", "vLLM 的 json 返回原始 [Sxx] 标记文本；需要 verbose_json 结构化 speaker segments 时使用 SGLang Omni 并单独验证"],
+          "operations": ["固定模型 revision、FunASR adapter merge、vLLM nightly commit、CUDA/Torch 与 trust_remote_code 审计结果", "用真实会议验证说话人一致性、重叠语音、长静音、时间戳和最大生成长度", "FunASR AutoModel 保留 raw_text，并统一返回 text、timestamp 和带 spk 的 sentence_info；直接调用 vLLM 时 json 仍是原始 [Sxx] 标记文本"],
           "security": ["把服务绑定内网，由网关完成认证、TLS、限流及音频大小/时长限制", "固定并审计 trust_remote_code 对应的模型 revision，不执行浮动 main 代码", "隔离模型缓存、上传临时目录和生成日志，按数据保留策略清理原始音频"],
-          "troubleshooting": ["启动前确认 CUDA 12 使用 cu129 nightly 源，CUDA 13 使用上游文档列出的 cu130 源", "长音频被截断时提高 max_completion_tokens，并同时监控显存、延迟和输出完整性", "vLLM json 响应没有 segments 字段是当前接口边界；从 text 解析 [start][Sxx]text[end]，或改用 SGLang Omni verbose_json"]
+          "troubleshooting": ["启动前确认 CUDA 12 使用 cu129 nightly 源，CUDA 13 使用上游文档列出的 cu130 源", "长音频被截断时提高 max_completion_tokens，并同时监控显存、延迟和输出完整性", "直接调用 vLLM 时 json 没有 segments 字段是当前接口边界；使用 FunASR AutoModel 归一化结果，或改用并单独验证 SGLang Omni verbose_json"]
         },
         "en": {
           "name": "MOSS unified transcription and diarization",
-          "summary": "Use the third-party Apache-2.0 model published by OpenMOSS to produce long-form transcripts, timestamps, and speaker labels in one pass from the FunASR deployment center.",
+          "summary": "Use FunASR AutoModel or an OpenAI-compatible service with the third-party Apache-2.0 model published by OpenMOSS to produce long-form transcripts, timestamps, and speaker labels in one pass.",
           "fit": ["Multi-speaker meetings, interviews, podcasts, and calls", "One model output for text, timestamps, and speaker identifiers", "NVIDIA GPU deployments that need an OpenAI-compatible audio transcription endpoint"],
-          "not_fit": ["Realtime streaming captions or low-latency endpoint detection", "CPU, desktop-edge, or native Windows deployments", "Projects that require FunASR-owned model weights or the FunASR AutoModel API"],
-          "selection_reason": "The model jointly emits transcription and speaker labels so users do not need to assemble an external VAD, ASR, and diarization pipeline; both vLLM and SGLang Omni expose /v1/audio/transcriptions.",
+          "not_fit": ["Realtime streaming captions or low-latency endpoint detection", "CPU, desktop-edge, or native Windows deployments", "Projects that require FunASR-owned model weights"],
+          "selection_reason": "The model jointly emits transcription and speaker labels so users do not need to assemble an external VAD, ASR, and diarization pipeline; FunASR AutoModel provides one structured result across Transformers and vLLM.",
           "primary_limitation": "This is an OpenMOSS third-party model, not a FunASR model; no external VAD requirement does not imply an absence of internal segmentation. The vLLM path pins a nightly commit and must be revalidated on real long multi-speaker audio before upgrades.",
           "status_label": "Community verified",
-          "operations": ["Pin the model revision, vLLM nightly commit, CUDA/Torch stack, and trust_remote_code audit", "Validate speaker consistency, overlap, long silence, timestamps, and generation limits on real meetings", "vLLM json returns raw [Sxx]-tagged text; use and separately validate SGLang Omni verbose_json when structured speaker segments are required"],
+          "operations": ["Pin the model revision, FunASR adapter merge, vLLM nightly commit, CUDA/Torch stack, and trust_remote_code audit", "Validate speaker consistency, overlap, long silence, timestamps, and generation limits on real meetings", "FunASR AutoModel preserves raw_text and normalizes text, timestamp, and sentence_info with spk; direct vLLM json still returns raw [Sxx]-tagged text"],
           "security": ["Bind workers to a private network and put authentication, TLS, rate limits, and audio size/duration limits at the gateway", "Pin and audit the trust_remote_code model revision instead of executing a floating main revision", "Isolate model caches, upload directories, and generation logs; remove source audio according to retention policy"],
-          "troubleshooting": ["Use the cu129 nightly source for CUDA 12 and the upstream cu130 source for CUDA 13", "If long audio is truncated, raise max_completion_tokens while monitoring memory, latency, and output completeness", "A vLLM json response without segments is the current API boundary; parse [start][Sxx]text[end] from text or use SGLang Omni verbose_json"]
+          "troubleshooting": ["Use the cu129 nightly source for CUDA 12 and the upstream cu130 source for CUDA 13", "If long audio is truncated, raise max_completion_tokens while monitoring memory, latency, and output completeness", "A direct vLLM json response without segments is the current API boundary; normalize it with FunASR AutoModel or use and separately validate SGLang Omni verbose_json"]
         }
       }
     },

--- a/web-pages/product-site/tests/browser/product-site.spec.ts
+++ b/web-pages/product-site/tests/browser/product-site.spec.ts
@@ -178,6 +178,38 @@ for (const viewport of [
   { name: 'mobile', width: 390, height: 844 },
   { name: 'desktop', width: 1440, height: 900 },
 ]) {
+  test(`MOSS AutoModel deployment is stable at ${viewport.name}`, async ({ page }, testInfo) => {
+    await page.setViewportSize(viewport);
+    await page.goto('/deploy/moss-transcribe-diarize.html');
+
+    await expect(page.locator('h1')).toHaveText('MOSS 统一转写与说话人分离');
+    await expect(page.getByText('FunASR AutoModel', { exact: false }).first()).toBeVisible();
+    await expect(page.getByText('OpenMOSS', { exact: false }).first()).toBeVisible();
+    await expect(page.getByText('sentence_info', { exact: false }).first()).toBeVisible();
+    await expect(page.locator('a[href="https://github.com/modelscope/FunASR/pull/3558"]')).toBeVisible();
+    await expect(page.locator('a[href="/en/deploy/moss-transcribe-diarize.html"]')).toBeVisible();
+
+    const layout = await page.evaluate(() => ({
+      overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      commandWidths: [...document.querySelectorAll<HTMLElement>('.command-block')].map((node) => ({
+        parent: node.parentElement?.getBoundingClientRect().width ?? 0,
+        width: node.getBoundingClientRect().width,
+      })),
+    }));
+    expect(layout.overflow).toBeLessThanOrEqual(1);
+    expect(layout.commandWidths.every(({ parent, width }) => width <= parent + 1)).toBe(true);
+
+    await page.screenshot({
+      path: testInfo.outputPath(`moss-automodel-${viewport.name}.png`),
+      fullPage: true,
+    });
+  });
+}
+
+for (const viewport of [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'desktop', width: 1440, height: 900 },
+]) {
   test(`SenseVoice TensorRT deployment is stable at ${viewport.name}`, async ({ page }, testInfo) => {
     await page.setViewportSize(viewport);
     await page.goto('/deploy/sensevoice-tensorrt.html');

--- a/web-pages/product-site/tests/test_registry.py
+++ b/web-pages/product-site/tests/test_registry.py
@@ -107,8 +107,8 @@ def test_moss_transcribe_diarize_contract_tracks_third_party_upstream(valid_regi
         'OpenMOSS-Team/MOSS-Transcribe-Diarize (third-party Apache-2.0 model)'
     ]
     assert entry['tested'] == {
-        'funasr': 'ecosystem contract; third-party model@e8681d68',
-        'runtime': 'vLLM 0.23.1rc1.dev949+g68b4a1d58 / Torch 2.11.0+cu129 / H100 80GB',
+        'funasr': 'AutoModel adapter@a3a2de0a; third-party model@e8681d68',
+        'runtime': 'Transformers 5.16.1 + vLLM 0.23.1rc1.dev949+g68b4a1d58 / Torch 2.11.0+cu129 / H100 80GB',
         'verified': '2026-08-29',
     }
 
@@ -125,6 +125,10 @@ def test_moss_transcribe_diarize_contract_tracks_third_party_upstream(valid_regi
     assert '/v1/audio/transcriptions' in smoke
     assert 'response_format=json' in smoke
     assert '[S01]' in smoke
+    assert "from funasr import AutoModel" in smoke
+    assert "backend='vllm'" in smoke
+    assert "result['raw_text']" in smoke
+    assert "result['sentence_info']" in smoke
 
     evidence_urls = {item['url'] for item in entry['evidence']}
     assert 'https://github.com/OpenMOSS/MOSS-Transcribe-Diarize' in evidence_urls
@@ -136,13 +140,17 @@ def test_moss_transcribe_diarize_contract_tracks_third_party_upstream(valid_regi
         'https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize/tree/'
         'e8681d68e7042738ffca8ac8212bc8fcb1131ab8'
     ) in evidence_urls
+    assert 'https://github.com/modelscope/FunASR/pull/3558' in evidence_urls
 
     english = entry['translations']['en']
     assert 'OpenMOSS' in english['summary']
     assert 'third-party' in english['summary'].lower()
+    assert 'FunASR AutoModel' in english['summary']
     assert 'external VAD' in english['selection_reason']
-    assert 'verbose_json' in english['operations'][-1]
-    assert 'SGLang' in english['operations'][-1]
+    assert 'FunASR AutoModel' in english['selection_reason']
+    assert 'FunASR AutoModel API' not in ' '.join(english['not_fit'])
+    assert 'sentence_info' in english['operations'][-1]
+    assert 'raw_text' in english['operations'][-1]
     assert 'internal segmentation' in english['primary_limitation']
     assert 'FunASR model' in english['primary_limitation']
     assert any(


### PR DESCRIPTION
## Summary

- correct the MOSS deployment page now that FunASR `AutoModel` supports the third-party OpenMOSS model
- add a pinned vLLM `AutoModel` smoke command and document normalized `raw_text`, `timestamp`, and `sentence_info.spk` output
- preserve explicit OpenMOSS attribution, Apache-2.0 licensing, and the no-external-VAD boundary
- add registry guards and mobile/desktop browser coverage for the MOSS product page

## Verification

- `python -m pytest web-pages/product-site/tests -q` (95 passed)
- deterministic build twice, `validate.py` (108 pages each), no output diff
- Playwright product-site suite (28 passed, including MOSS mobile and desktop)
- `git diff --check`

## Evidence

- FunASR adapter merge: #3558 (`a3a2de0a`)
- model revision: `OpenMOSS-Team/MOSS-Transcribe-Diarize@e8681d68`
- vLLM revision: `68b4a1d582818e67adc903bf1b8fc5a5447da2fa`

The model and weights remain an OpenMOSS third-party project; this change only documents and tests the FunASR ecosystem adapter.
