### PR TITLE
test(release): track current llama.cpp runtime

### DIFF
--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -343,7 +343,7 @@ def test_top_level_readmes_surface_current_release_and_edge_runtime():
     for name, text in readmes.items():
         assert 'python -m pip install -U "funasr==1.4.6"' in text, name
         assert "https://github.com/modelscope/FunASR/releases/tag/v1.4.6" in text, name
-        assert "runtime-llamacpp-v0.2.3" in text, name
+        assert "runtime-llamacpp-v0.2.5" in text, name
 
     assert "https://www.funasr.com/en/deploy/llama-cpp.html" in readmes["README.md"]
     assert "https://www.funasr.com/deploy/llama-cpp.html" in readmes["README_zh.md"]
@@ -358,7 +358,7 @@ def test_top_level_readmes_surface_current_release_and_edge_runtime():
             "funasr-llamacpp-windows-x64-cuda.zip",
         ):
             assert (
-                f"releases/download/runtime-llamacpp-v0.2.3/{asset}" in text
+                f"releases/download/runtime-llamacpp-v0.2.5/{asset}" in text
             ), name
         assert "releases/download/runtime-llamacpp-v0.2.1/" not in text, name
 

--- a/tests/test_release_runtime_downloads.py
+++ b/tests/test_release_runtime_downloads.py
@@ -107,7 +107,7 @@ def test_release_on_tag_workflow_uses_versioned_runtime_pointer():
     assert "runtime/llama.cpp/current-release.txt" in workflow
     assert '--runtime-tag "$RUNTIME_TAG"' in workflow
     assert runtime_pointer.read_text(encoding="utf-8").strip() == (
-        "runtime-llamacpp-v0.2.3"
+        "runtime-llamacpp-v0.2.5"
     )
 
 


### PR DESCRIPTION
## Summary
- update current-release README assertions from runtime-llamacpp-v0.2.3 to v0.2.5
- update the release workflow pointer assertion to match runtime/llama.cpp/current-release.txt
- keep historical release coverage unchanged

## Verification
- `PYTHONPATH=. python -m pytest -q tests/test_docs_funasr_install_commands.py tests/test_release_runtime_downloads.py`
- 39 passed
- signed commit with DCO sign-off

This fixes a stale exact-head test expectation after the v0.2.5 runtime publication; it does not change runtime code or release assets.