### PR TITLE
Fix tiny-gap semantic boundaries in readable SRT

### DIFF
--- a/funasr/cli.py
+++ b/funasr/cli.py
@@ -80,6 +80,7 @@ def merge_subtitle_segments(
     """Group sentence timestamps into bounded, readable subtitle cues."""
     def can_follow(left, right):
         left_text = str(left.get("text", ""))
+        right_text = str(right.get("text", ""))
         gap_ms = right.get("start", 0) - left.get("end", 0)
         left_speaker = left.get("speaker", left.get("spk"))
         right_speaker = right.get("speaker", right.get("spk"))
@@ -89,6 +90,13 @@ def merge_subtitle_segments(
             and (
                 left_text.rstrip().endswith(SUBTITLE_CONTINUATION_PUNCTUATION)
                 or _subtitle_body_length(left_text) <= 2
+                or (
+                    gap_ms <= min(max_gap_ms, 100)
+                    and _subtitle_body_length(right_text) > 2
+                    and right_text.rstrip().endswith(
+                        SUBTITLE_CONTINUATION_PUNCTUATION
+                    )
+                )
             )
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,41 @@ def test_merge_subtitle_segments_keeps_continuation_chain_with_its_ending():
     ]
 
 
+def test_merge_subtitle_segments_repacks_false_sentence_boundary_after_tiny_gap():
+    segments = [
+        {"start": 148930, "end": 149830, "text": "就在八月二十五日，"},
+        {
+            "start": 150010,
+            "end": 151930,
+            "text": "上汽大通直接向平台发起投诉，",
+        },
+        {
+            "start": 152170,
+            "end": 153970,
+            "text": "投诉对象是那些转述基金会。",
+        },
+        {"start": 154030, "end": 155050, "text": "声明的自媒体文章，"},
+        {
+            "start": 155470,
+            "end": 157330,
+            "text": "上汽大通的投诉内容写的很清楚，",
+        },
+    ]
+
+    assert cli.merge_subtitle_segments(segments) == [
+        {
+            "start": 148930,
+            "end": 151930,
+            "text": "就在八月二十五日，上汽大通直接向平台发起投诉，",
+        },
+        {
+            "start": 152170,
+            "end": 157330,
+            "text": "投诉对象是那些转述基金会。声明的自媒体文章，上汽大通的投诉内容写的很清楚，",
+        },
+    ]
+
+
 def test_merge_subtitle_segments_groups_two_character_sentence():
     segments = [
         {"start": 12450, "end": 12690, "text": "突然。"},


### PR DESCRIPTION
## Summary

- repack subtitle chains across a terminal punctuation mark only when the acoustic gap is at most 100 ms
- require the following fragment to be a non-trivial continuation, preserving short and speaker-changing hard boundaries
- add the exact timestamp sequence reported in #3539 as a regression test

Related to #3539. This PR intentionally does **not** close the issue; reporter verification is still required.

## Root cause

Readable SRT grouping treated every terminal punctuation mark as an unconditional chain boundary. In the reporter's first sample, CT-Punc emitted a false full stop after `投诉对象是那些转述基金会。`, followed only 60 ms later by `声明的自媒体文章，`. Because the chain was split before bounded packing, the noun phrase could never be repacked together.

The new condition is deliberately narrow: same speaker, no more than 100 ms, and a following continuation fragment longer than two body characters. Existing maximum cue duration and character limits still apply.

## Verification

Exact head: `db959d30103121595bde24d2f33133e632490e2c`

```text
PYTHONPATH=. .../bin/python -m pytest -q   tests/test_cli.py   tests/test_generate_subtitle.py   tests/test_docs_funasr_install_commands.py   tests/test_release_runtime_downloads.py

51 passed in 15.51s
```

Real H100 smoke, FunASR 1.4.6, SenseVoiceSmall + FSMN-VAD + CT-Punc:

- sample 1 (309.547 s): 76 -> 75 cues; the 153.97/154.03 split is repacked as `投诉对象是那些转述基金会。声明的自媒体文章，上汽大通的投诉内容写的很清楚，`
- sample 2 (379.624 s): 98 -> 96 cues; only two additional bounded semantic chains were combined
- lexical ASR errors such as `光恩负义` and `金蝉脱胶` remain model-recognition issues and are not claimed fixed here

## Rollback evidence

- patch SHA256: `25f17805ccb7ab2ffc5aeb2d728664876d71d655c8d362d74ad232be268b0d59`
- real-audio SRT evidence SHA256: `a29d85199fde03121a1d2f951ff902f578447f8047bec0066443a44c3f7995e5`