### PR TITLE
fix(download): preserve snapshot errors

### DIFF
--- a/funasr/download/runtime_sdk_download_tool.py
+++ b/funasr/download/runtime_sdk_download_tool.py
@@ -10,13 +10,23 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model-name", type=str, required=True)
     parser.add_argument("--export-dir", type=str, required=True)
-    parser.add_argument("--export", type=str2bool, default=True, help="whether to export model")
-    parser.add_argument("--type", type=str, default="onnx", help='["onnx", "torchscript", "bladedisc"]')
+    parser.add_argument(
+        "--export", type=str2bool, default=True, help="whether to export model"
+    )
+    parser.add_argument(
+        "--type", type=str, default="onnx", help='["onnx", "torchscript", "bladedisc"]'
+    )
     parser.add_argument("--device", type=str, default="cpu", help='["cpu", "cuda"]')
-    parser.add_argument("--quantize", type=str2bool, default=False, help="export quantized model")
-    parser.add_argument("--fallback-num", type=int, default=0, help="amp fallback number")
+    parser.add_argument(
+        "--quantize", type=str2bool, default=False, help="export quantized model"
+    )
+    parser.add_argument(
+        "--fallback-num", type=int, default=0, help="amp fallback number"
+    )
     parser.add_argument("--audio_in", type=str, default=None, help='["wav", "wav.scp"]')
-    parser.add_argument("--model_revision", type=str, default=None, help="model_revision")
+    parser.add_argument(
+        "--model_revision", type=str, default=None, help="model_revision"
+    )
     parser.add_argument("--calib_num", type=int, default=200, help="calib max num")
     args = parser.parse_args()
 
@@ -30,10 +40,11 @@ def main():
                 args.model_name, cache_dir=args.export_dir, revision=args.model_revision
             )
             output_dir = os.path.join(args.export_dir, args.model_name)
-        except:
-            raise "model_dir must be model_name in modelscope or local path downloaded from modelscope, but is {}".format(
-                model_dir
-            )
+        except Exception as error:
+            raise RuntimeError(
+                "model_dir must be a ModelScope model name or a local path, "
+                f"but got {model_dir!r}"
+            ) from error
     if args.export:
         model_file = os.path.join(model_dir, "model.onnx")
         if args.quantize:
@@ -48,11 +59,13 @@ def main():
             print("model is not exist, begin to export " + model_file)
             from funasr import AutoModel
 
-            export_model = AutoModel(model=args.model_name, output_dir=output_dir, device=args.device)
+            export_model = AutoModel(
+                model=args.model_name, output_dir=output_dir, device=args.device
+            )
             export_model.export(
-                    quantize=args.quantize,
-                    type=args.type,
-                    )
+                quantize=args.quantize,
+                type=args.type,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_sdk_download_tool.py
+++ b/tests/test_runtime_sdk_download_tool.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+import pytest
+
+from funasr.download.runtime_sdk_download_tool import main
+
+
+def test_snapshot_download_failure_preserves_original_cause(monkeypatch, tmp_path):
+    cause = RuntimeError("snapshot backend unavailable")
+    snapshot_module = types.ModuleType("modelscope.hub.snapshot_download")
+
+    def snapshot_download(*args, **kwargs):
+        raise cause
+
+    snapshot_module.snapshot_download = snapshot_download
+    monkeypatch.setitem(sys.modules, "modelscope", types.ModuleType("modelscope"))
+    monkeypatch.setitem(
+        sys.modules, "modelscope.hub", types.ModuleType("modelscope.hub")
+    )
+    monkeypatch.setitem(
+        sys.modules, "modelscope.hub.snapshot_download", snapshot_module
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "runtime_sdk_download_tool",
+            "--model-name",
+            "missing/model",
+            "--export-dir",
+            str(tmp_path),
+            "--export",
+            "False",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="missing/model") as caught:
+        main()
+
+    assert caught.value.__cause__ is cause


### PR DESCRIPTION
## Summary

- replace the remaining string-literal `raise` in the runtime SDK downloader with a typed `RuntimeError`
- preserve the original ModelScope snapshot exception as `__cause__`
- narrow the bare catch from `BaseException` to ordinary `Exception` failures
- add a CLI-boundary regression that exercises `main()` with a failing snapshot backend

## Root cause

When `snapshot_download()` failed, the broad handler executed `raise "..."`. Python rejected that string and replaced the actionable snapshot error with `TypeError: exceptions must derive from BaseException`, leaving no exception chain.

## Verification

- RED: new regression failed with the reproduced `TypeError` and no cause
- GREEN: `python -m pytest -q tests/test_runtime_sdk_download_tool.py tests/test_release_runtime_downloads.py` -> 24 passed
- `python -m black --check funasr/download/runtime_sdk_download_tool.py tests/test_runtime_sdk_download_tool.py`
- `python -m py_compile funasr/download/runtime_sdk_download_tool.py tests/test_runtime_sdk_download_tool.py`
- AST audit of all `funasr/**/*.py` -> 0 string-literal raises
- `git diff --check`

Related to #3523; this does not close the reporter's verification issue.

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>