### PR TITLE
docs: expose MOSS LocalAI edge path

### DIFF
--- a/web-pages/product-site/data/deployments.json
+++ b/web-pages/product-site/data/deployments.json
@@ -8,11 +8,11 @@
       "maturity": "community-verified",
       "selector_rank": 12,
       "workloads": ["batch", "private-api"],
-      "hardware": ["nvidia-gpu", "kubernetes"],
+      "hardware": ["cpu", "nvidia-gpu", "desktop-edge-gpu", "kubernetes"],
       "priorities": ["throughput"],
       "models": ["OpenMOSS-Team/MOSS-Transcribe-Diarize (third-party Apache-2.0 model)"],
       "operating_systems": ["Linux"],
-      "interfaces": ["OpenAI-compatible HTTP", "vLLM", "SGLang Omni", "Transformers"],
+      "interfaces": ["OpenAI-compatible HTTP", "vLLM", "SGLang Omni", "Transformers", "LocalAI / moss-transcribe.cpp"],
       "tested": {"funasr": "AutoModel diarized_json adapter; third-party model@e8681d68", "runtime": "vLLM 0.27.1 / Torch 2.13.0+cu129 / H100 80GB", "verified": "2026-08-30"},
       "commands": {
         "install": [
@@ -40,7 +40,9 @@
         {"label": "vLLM official diarized_json response contract", "url": "https://github.com/vllm-project/vllm/pull/48543"},
         {"label": "verified vLLM 0.27.1 release", "url": "https://github.com/vllm-project/vllm/releases/tag/v0.27.1"},
         {"label": "FunASR ecosystem integration guide", "url": "https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize.md"},
-        {"label": "FunASR AutoModel adapter merge and exact-head CI", "url": "https://github.com/modelscope/FunASR/pull/3558"}
+        {"label": "FunASR AutoModel adapter merge and exact-head CI", "url": "https://github.com/modelscope/FunASR/pull/3558"},
+        {"label": "moss-transcribe.cpp third-party C++17 and GGUF runtime", "url": "https://github.com/localai-org/moss-transcribe.cpp"},
+        {"label": "LocalAI third-party moss-transcribe-cpp backend", "url": "https://github.com/mudler/LocalAI"}
       ],
       "benchmarks": [
         {
@@ -61,24 +63,24 @@
         "zh": {
           "name": "MOSS 统一转写与说话人分离",
           "summary": "通过 FunASR AutoModel 或 OpenAI 兼容服务接入 OpenMOSS 发布的第三方 Apache-2.0 模型，一次生成长音频转写、时间戳和说话人标签。",
-          "fit": ["会议、访谈、播客和通话的多人长音频", "希望通过同一个模型输出文本、时间戳与说话人编号", "已有 NVIDIA GPU，并需要 OpenAI 兼容的音频转写接口"],
-          "not_fit": ["实时流式字幕或低延迟端点检测", "CPU、桌面边缘设备或 Windows 原生部署", "要求 FunASR 自有模型权重的项目"],
-          "selection_reason": "模型端到端联合生成转写与说话人标签，用户不必再拼接外部 VAD、ASR 和 diarization 管线；FunASR AutoModel 为 Transformers 与 vLLM 提供统一的结构化结果。",
-          "primary_limitation": "这是 OpenMOSS 的第三方模型，不是 FunASR 模型；“无需外部 VAD”不表示模型内部没有分块或分段。当前 vLLM 路径固定 0.27.1 发布版，升级前必须重跑真实多人长音频。",
+          "fit": ["会议、访谈、播客和通话的多人长音频", "希望通过同一个模型输出文本、时间戳与说话人编号", "已有 NVIDIA GPU，并需要 OpenAI 兼容的音频转写接口", "通过 LocalAI / moss-transcribe.cpp 在 CPU 或桌面边缘 GPU 上运行第三方 GGUF 实现"],
+          "not_fit": ["实时流式字幕或低延迟端点检测", "要求 FunASR AutoModel 与 LocalAI C++ 路径输出完全相同结果的部署", "未经目标硬件复测的原生 Windows 部署", "要求 FunASR 自有模型权重的项目"],
+          "selection_reason": "模型端到端联合生成转写与说话人标签，用户不必再拼接外部 VAD、ASR 和 diarization 管线；FunASR AutoModel 为 Transformers 与 vLLM 提供统一的结构化结果，LocalAI 则提供独立的第三方 C++/GGUF 边缘路径。",
+          "primary_limitation": "这是 OpenMOSS 的第三方模型，不是 FunASR 模型；“无需外部 VAD”不表示模型内部没有分块或分段。当前 vLLM 路径固定 0.27.1 发布版，升级前必须重跑真实多人长音频；LocalAI / moss-transcribe.cpp 是独立的第三方重写，不能把其结果等同于 FunASR AutoModel 契约。",
           "status_label": "社区验证",
-          "operations": ["固定模型 revision、FunASR adapter merge、vLLM 0.27.1、CUDA/Torch 与 trust_remote_code 审计结果", "用真实会议验证说话人一致性、重叠语音、长静音、时间戳和最大生成长度", "FunASR AutoModel 可用 vLLM diarized_json 直接统一 text、timestamp 和带 spk 的 sentence_info；json 兼容路径仍在 raw_text 保留原始 [Sxx] 标记文本"],
+          "operations": ["固定模型 revision、FunASR adapter merge、vLLM 0.27.1、CUDA/Torch 与 trust_remote_code 审计结果", "用真实会议验证说话人一致性、重叠语音、长静音、时间戳和最大生成长度", "LocalAI 路径固定第三方 C++ backend 与 GGUF revision，并分别验证 CPU/GPU backend、量化精度和 OpenAI 接口响应", "FunASR AutoModel 可用 vLLM diarized_json 直接统一 text、timestamp 和带 spk 的 sentence_info；json 兼容路径仍在 raw_text 保留原始 [Sxx] 标记文本"],
           "security": ["把服务绑定内网，由网关完成认证、TLS、限流及音频大小/时长限制", "固定并审计 trust_remote_code 对应的模型 revision，不执行浮动 main 代码", "隔离模型缓存、上传临时目录和生成日志，按数据保留策略清理原始音频"],
           "troubleshooting": ["CUDA 12 使用已校验 SHA256 的 vLLM 0.27.1 cu129 wheel；其他 CUDA 栈需按上游发布资产重新验证", "长音频被截断时提高 max_completion_tokens，并同时监控显存、延迟和输出完整性", "需要结构化说话人 segments 时使用 vLLM diarized_json；旧 68b4a1d5 nightly 会返回 HTTP 400，json 只返回原始 [Sxx] 标签文本"]
         },
         "en": {
           "name": "MOSS unified transcription and diarization",
           "summary": "Use FunASR AutoModel or an OpenAI-compatible service with the third-party Apache-2.0 model published by OpenMOSS to produce long-form transcripts, timestamps, and speaker labels in one pass.",
-          "fit": ["Multi-speaker meetings, interviews, podcasts, and calls", "One model output for text, timestamps, and speaker identifiers", "NVIDIA GPU deployments that need an OpenAI-compatible audio transcription endpoint"],
-          "not_fit": ["Realtime streaming captions or low-latency endpoint detection", "CPU, desktop-edge, or native Windows deployments", "Projects that require FunASR-owned model weights"],
-          "selection_reason": "The model jointly emits transcription and speaker labels so users do not need to assemble an external VAD, ASR, and diarization pipeline; FunASR AutoModel provides one structured result across Transformers and vLLM.",
-          "primary_limitation": "This is an OpenMOSS third-party model, not a FunASR model; no external VAD requirement does not imply an absence of internal segmentation. The vLLM path pins release 0.27.1 and must be revalidated on real long multi-speaker audio before upgrades.",
+          "fit": ["Multi-speaker meetings, interviews, podcasts, and calls", "One model output for text, timestamps, and speaker identifiers", "NVIDIA GPU deployments that need an OpenAI-compatible audio transcription endpoint", "The third-party LocalAI / moss-transcribe.cpp GGUF path on CPU or desktop-edge GPUs"],
+          "not_fit": ["Realtime streaming captions or low-latency endpoint detection", "Deployments that require identical output from FunASR AutoModel and the LocalAI C++ path", "Native Windows deployments without validation on the target hardware", "Projects that require FunASR-owned model weights"],
+          "selection_reason": "The model jointly emits transcription and speaker labels so users do not need to assemble an external VAD, ASR, and diarization pipeline; FunASR AutoModel provides one structured result across Transformers and vLLM, while LocalAI exposes a separate third-party C++/GGUF edge path.",
+          "primary_limitation": "This is an OpenMOSS third-party model, not a FunASR model; no external VAD requirement does not imply an absence of internal segmentation. The vLLM path pins release 0.27.1 and must be revalidated on real long multi-speaker audio before upgrades. LocalAI / moss-transcribe.cpp is an independent third-party reimplementation, so its output is not the FunASR AutoModel contract.",
           "status_label": "Community verified",
-          "operations": ["Pin the model revision, FunASR adapter merge, vLLM 0.27.1, CUDA/Torch stack, and trust_remote_code audit", "Validate speaker consistency, overlap, long silence, timestamps, and generation limits on real meetings", "FunASR AutoModel can map vLLM diarized_json directly into text, timestamp, and sentence_info with spk; the json compatibility path still preserves raw [Sxx]-tagged text in raw_text"],
+          "operations": ["Pin the model revision, FunASR adapter merge, vLLM 0.27.1, CUDA/Torch stack, and trust_remote_code audit", "Validate speaker consistency, overlap, long silence, timestamps, and generation limits on real meetings", "For LocalAI, pin the third-party C++ backend and GGUF revision, then validate CPU/GPU backends, quantization accuracy, and the OpenAI response independently", "FunASR AutoModel can map vLLM diarized_json directly into text, timestamp, and sentence_info with spk; the json compatibility path still preserves raw [Sxx]-tagged text in raw_text"],
           "security": ["Bind workers to a private network and put authentication, TLS, rate limits, and audio size/duration limits at the gateway", "Pin and audit the trust_remote_code model revision instead of executing a floating main revision", "Isolate model caches, upload directories, and generation logs; remove source audio according to retention policy"],
           "troubleshooting": ["For CUDA 12, use the SHA256-verified vLLM 0.27.1 cu129 wheel; revalidate another CUDA stack against its upstream release asset", "If long audio is truncated, raise max_completion_tokens while monitoring memory, latency, and output completeness", "Use vLLM diarized_json for structured speaker segments; the old 68b4a1d5 nightly returns HTTP 400, while json only returns raw [Sxx]-tagged text"]
         }

--- a/web-pages/product-site/tests/test_registry.py
+++ b/web-pages/product-site/tests/test_registry.py
@@ -111,6 +111,8 @@ def test_moss_transcribe_diarize_contract_tracks_third_party_upstream(valid_regi
         'runtime': 'vLLM 0.27.1 / Torch 2.13.0+cu129 / H100 80GB',
         'verified': '2026-08-30',
     }
+    assert 'LocalAI / moss-transcribe.cpp' in entry['interfaces']
+    assert {'cpu', 'desktop-edge-gpu'} <= set(entry['hardware'])
 
     install = '\n'.join(entry['commands']['install'])
     assert 'vllm[audio]' in install
@@ -144,6 +146,8 @@ def test_moss_transcribe_diarize_contract_tracks_third_party_upstream(valid_regi
     ) in evidence_urls
     assert 'https://github.com/modelscope/FunASR/pull/3558' in evidence_urls
     assert 'https://github.com/vllm-project/vllm/pull/48543' in evidence_urls
+    assert 'https://github.com/localai-org/moss-transcribe.cpp' in evidence_urls
+    assert 'https://github.com/mudler/LocalAI' in evidence_urls
 
     english = entry['translations']['en']
     assert 'OpenMOSS' in english['summary']
@@ -158,6 +162,12 @@ def test_moss_transcribe_diarize_contract_tracks_third_party_upstream(valid_regi
     assert 'diarized_json' in english['troubleshooting'][-1]
     assert 'internal segmentation' in english['primary_limitation']
     assert 'FunASR model' in english['primary_limitation']
+    assert any('LocalAI' in item and 'GGUF' in item for item in english['fit'])
+    assert not any(
+        item == 'CPU, desktop-edge, or native Windows deployments'
+        for item in english['not_fit']
+    )
+    assert any('third-party C++' in item for item in english['operations'])
     assert any(
         benchmark['hardware'] == 'NVIDIA H100 80GB HBM3'
         and '15.1685 s' in benchmark['audio']


### PR DESCRIPTION
## Summary
- expose the third-party LocalAI / moss-transcribe.cpp GGUF path on the MOSS deployment page and selector
- distinguish the FunASR AutoModel contract from the independent C++ reimplementation
- add pinned upstream evidence and CPU / desktop-edge discovery without claiming unverified Windows support

## Verification
- python -m pytest -q web-pages/product-site/tests (95 passed)
- product-site build (29 pages)
- output validator (108 pages)
- generated Chinese and English MOSS pages contain the LocalAI evidence and interface markers
- git diff --check
