### PR TITLE
ci(release): attach Python packages automatically

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -15,6 +15,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build and validate Python packages
+        run: |
+          set -euo pipefail
+          VERSION="$(cat funasr/version.txt)"
+          if [ "v${VERSION}" != "${{ github.ref_name }}" ]; then
+            echo "Tag ${{ github.ref_name }} does not match funasr/version.txt (${VERSION})" >&2
+            exit 1
+          fi
+          python -m pip install --upgrade build twine
+          export SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          python -m build
+          SDIST="dist/funasr-${VERSION}.tar.gz"
+          SDIST_ROOT="funasr-${VERSION}"
+          SDIST_TMP="$(mktemp -d)"
+          trap 'rm -rf "$SDIST_TMP"' EXIT
+          tar -xzf "$SDIST" -C "$SDIST_TMP"
+          tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" \
+            --owner=0 --group=0 --numeric-owner \
+            -C "$SDIST_TMP" -cf - "$SDIST_ROOT" \
+            | gzip -n > "${SDIST}.reproducible"
+          mv "${SDIST}.reproducible" "$SDIST"
+          python -m twine check dist/*
       - name: Create GitHub Release with auto-generated notes
         env:
           GH_TOKEN: ${{ github.token }}
@@ -22,6 +47,14 @@ jobs:
           if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
             gh release create "${{ github.ref_name }}" --generate-notes --verify-tag --title "${{ github.ref_name }}"
           fi
+      - name: Add Python packages to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            dist/funasr-*.whl \
+            dist/funasr-*.tar.gz \
+            --clobber
       - name: Add Runtime assets and downloads to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/test_release_runtime_downloads.py
+++ b/tests/test_release_runtime_downloads.py
@@ -116,6 +116,25 @@ def test_release_on_tag_workflow_uses_versioned_runtime_pointer():
     )
 
 
+def test_release_on_tag_workflow_builds_and_uploads_python_packages():
+    workflow = (ROOT / ".github" / "workflows" / "release-on-tag.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "python -m build" in workflow
+    assert "python -m twine check dist/*" in workflow
+    assert "SOURCE_DATE_EPOCH" in workflow
+    assert "git log -1 --format=%ct" in workflow
+    assert "tar --sort=name" in workflow
+    assert 'gzip -n' in workflow
+    assert "funasr/version.txt" in workflow
+    assert "github.ref_name" in workflow
+    assert "gh release upload" in workflow
+    assert "dist/funasr-*.whl" in workflow
+    assert "dist/funasr-*.tar.gz" in workflow
+    assert "--clobber" in workflow
+
+
 @pytest.mark.parametrize("mutation", ("missing", "unexpected"))
 def test_runtime_assets_rejects_non_exact_platform_matrix(mutation):
     module = load_release_script()


### PR DESCRIPTION
## Summary
- build the wheel and sdist on every v* tag
- reject tags that do not match funasr/version.txt
- run Twine metadata validation before publishing the GitHub Release
- attach both Python artifacts alongside the llama.cpp runtime matrix

## Verification
- new contract test failed before the workflow change
- tests/test_release_runtime_downloads.py: 24 passed
- release package/version tests: 3 passed
- workflow YAML parses successfully
- git diff --check

The GitHub-built artifacts become the exact files used for the matching PyPI publication, so both channels can share SHA-256 values.

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>