### PR TITLE
fix(realtime): preserve aligned long-segment partials

### DIFF
--- a/funasr/bin/realtime_ws.py
+++ b/funasr/bin/realtime_ws.py
@@ -13,6 +13,7 @@ Features:
 import asyncio
 from collections import deque
 import copy
+from difflib import SequenceMatcher
 import json
 import logging
 import os
@@ -1104,24 +1105,31 @@ class RealtimeASRSession:
             ):
                 final_cmp = _normalize_transcript(final_text)
                 recent_cmp = _normalize_transcript(recent_partial)
-                common_prefix_len = 0
-                for final_char, partial_char in zip(final_cmp, recent_cmp):
-                    if final_char != partial_char:
-                        break
-                    common_prefix_len += 1
-                diverged = common_prefix_len < min(len(final_cmp), len(recent_cmp))
+                matcher = SequenceMatcher(None, final_cmp, recent_cmp, autojunk=False)
+                matching_blocks = matcher.get_matching_blocks()
+                matched_chars = sum(block.size for block in matching_blocks)
+                final_coverage = matched_chars / max(1, len(final_cmp))
+                first_match = next(
+                    (block for block in matching_blocks if block.size), None
+                )
+                starts_aligned = bool(
+                    first_match and first_match.a <= 1 and first_match.b <= 2
+                )
+                diverged = final_cmp != recent_cmp
                 catastrophically_short = (
                     diverged
-                    and len(final_cmp) >= 2
+                    and len(final_cmp) >= 1
                     and len(recent_cmp) >= 24
                     and len(recent_cmp) >= len(final_cmp) * 3
-                    and common_prefix_len >= max(1, len(final_cmp) // 2)
+                    and starts_aligned
+                    and matched_chars >= max(1, len(final_cmp) // 2)
                 )
                 tail_regressed = (
                     diverged
                     and len(final_cmp) >= 16
                     and len(recent_cmp) - len(final_cmp) >= 4
-                    and common_prefix_len >= max(12, (len(final_cmp) * 3) // 4)
+                    and starts_aligned
+                    and final_coverage >= 0.75
                 )
                 if catastrophically_short or tail_regressed:
                     partial_text = recent_partial

--- a/tests/test_realtime_ws_service.py
+++ b/tests/test_realtime_ws_service.py
@@ -550,6 +550,48 @@ def test_long_segment_recovers_from_catastrophically_short_final():
     assert text == partial
 
 
+def test_long_segment_recovers_from_single_character_final():
+    module = load_service_module()
+    partial = (
+        "哎，不好意思，上午高雄交通比较混乱一点，我们不晓得我们有点。"
+        "胡总，各位长官。"
+    )
+    session = make_reported_long_segment_reconciliation_session(
+        module, partial, partial_end_ms=35328
+    )
+
+    text = session._reconcile_completed_segment_text(
+        "哎",
+        [2920, 36260],
+        decode_succeeded=True,
+    )
+
+    assert text == partial
+
+
+def test_long_segment_recovers_when_an_early_partial_correction_hides_tail_regression():
+    module = load_service_module()
+    partial = (
+        "哇，哎，不好意思，上午杭高雄的交通比较混乱一点，我们不晓得我们有点。"
+        "哎，好嘞，胡总各位长官。"
+    )
+    final = (
+        "哇，不好意思，上午高雄的交通比较混乱一点，我们不晓得我们有点。"
+        "哎，好嘞，"
+    )
+    session = make_reported_long_segment_reconciliation_session(
+        module, partial, partial_end_ms=14336
+    )
+
+    text = session._reconcile_completed_segment_text(
+        final,
+        [2920, 14420],
+        decode_succeeded=True,
+    )
+
+    assert text == partial
+
+
 def test_long_segment_keeps_distinct_short_final_without_prefix_alignment():
     module = load_service_module()
     partial = "会议取消，稍后另行通知，请各位等待后续的完整安排和确认消息。"


### PR DESCRIPTION
## Summary

- preserve a proven long-segment partial when the completed decode collapses to one character
- tolerate small early insertions/corrections when detecting a later tail regression
- retain the existing long-segment, same-boundary, repeated-observation, and near-tail safety gates

## Root cause

The reconciliation path required a final transcript to contain at least two normalized characters and compared the final result with the best observed partial using a strict common prefix. The reporter's latest 1.4.11 traces expose both gaps:

- a complete partial was followed by a one-character final (`哎`), which the minimum-length check rejected
- a complete partial and truncated final differed by a small early insertion/correction, so the strict prefix comparison never reached the missing tail

The updated check uses ordered matching blocks. Catastrophically short finals must still match at least half of their normalized characters, while tail regressions require at least 75% final coverage and an aligned start.

## Verification

Exact signed+DCO head: `9aec3eeb67263bffada3e9fcf6863fb909867fef`

- focused realtime / postprocess / file-finalization suites: 122 passed, 1 environment skip
- Python compilation and `git diff --check`: passed
- H100, complete Nano checkpoint, speaker path enabled, reporter's 14.432-second `test_audio.wav`: 8/8 final responses retained the `胡总...长官` tail; 0/8 collapsed to one character
- full WebSocket traces, server trigger logs, SHA-256 manifest, and rollback patch are saved in the publication backup

Related to #3302. The issue should remain open until the reporter retests the original deployment; merging this PR is not reporter confirmation.