### PR TITLE
fix(realtime): accept bounded partial VAD overrun

### DIFF
--- a/funasr/bin/realtime_ws.py
+++ b/funasr/bin/realtime_ws.py
@@ -1099,7 +1099,8 @@ class RealtimeASRSession:
                 and recent_eligible
                 and recent_observations >= 2
                 and int(recent_start_ms) == int(seg[0])
-                and 0 <= tail_gap_ms <= max(100, decode_chunk_ms * 2)
+                and -max(100, decode_chunk_ms) <= tail_gap_ms
+                and tail_gap_ms <= max(100, decode_chunk_ms * 2)
                 and recent_partial
                 and not recent_hallucinated
             ):

--- a/tests/test_realtime_ws_service.py
+++ b/tests/test_realtime_ws_service.py
@@ -569,6 +569,48 @@ def test_long_segment_recovers_from_single_character_final():
     assert text == partial
 
 
+def test_long_segment_accepts_partial_slightly_past_vad_end():
+    module = load_service_module()
+    partial = (
+        "哎，不好意思，上午好，高雄交通比较混乱，影响人有点。"
+        "哎，哎，胡总，各位长官，大家好。"
+    )
+    session = make_reported_long_segment_reconciliation_session(
+        module, partial, partial_end_ms=126976
+    )
+    session.last_partial_start_ms = 114430
+    session.segment_best_partial_start_ms = 114430
+
+    text = session._reconcile_completed_segment_text(
+        "哎",
+        [114430, 126740],
+        decode_succeeded=True,
+    )
+
+    assert text == partial
+
+
+def test_long_segment_rejects_partial_far_past_vad_end():
+    module = load_service_module()
+    partial = (
+        "哎，不好意思，上午好，高雄交通比较混乱，影响人有点。"
+        "哎，哎，胡总，各位长官，大家好。"
+    )
+    session = make_reported_long_segment_reconciliation_session(
+        module, partial, partial_end_ms=128800
+    )
+    session.last_partial_start_ms = 114430
+    session.segment_best_partial_start_ms = 114430
+
+    text = session._reconcile_completed_segment_text(
+        "哎",
+        [114430, 126740],
+        decode_succeeded=True,
+    )
+
+    assert text == "哎"
+
+
 def test_long_segment_recovers_when_an_early_partial_correction_hides_tail_regression():
     module = load_service_module()
     partial = (


### PR DESCRIPTION
## Summary

- accept a proven long-segment partial when its decode endpoint is slightly later than the VAD endpoint
- bound the allowed overrun to one realtime decode chunk
- add exact regression coverage for the reporter's `114430/126976/126740ms` trace and a farther-overrun rejection test

## Root cause

The follow-up on #3302 used exact merge `2b6294d69e6588a63c0ce06300f1b55ded71ae58` and still locked a complete partial down to `哎`. The last partial covered `114430-126976ms`, while FSMN-VAD emitted `114430-126740ms`.

The long-segment reconciliation gate only accepted `tail_gap_ms >= 0`. Normal decode/VAD scheduling therefore rejected this candidate solely because it ended 236ms after the VAD boundary, before the single-character regression check could run.

The new lower bound allows at most one decode chunk of overrun. Existing exact start alignment, repeated observations, long-segment duration, text alignment, and hallucination gates remain unchanged. A partial more than two chunks past this concrete boundary remains rejected by regression coverage.

## Verification

Exact signed+DCO head: `980765099dea8d9f34ea2f10889b3ab1c3876173`

- before the fix, the exact reporter-offset test returned `哎`
- focused boundary tests: 2 passed
- realtime/postprocess/file-finalization/docs suites: 141 passed, 1 existing environment skip
- Python compilation and `git diff --check`: passed

Related to #3302. Merging this PR is not reporter confirmation; keep the issue open until the original file-upload and microphone paths are retested.

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>