### PR TITLE
docs: keep What's new concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,10 +333,9 @@ inference on physical Blackwell hardware.
 
 ## What's new
 
-- **FunASR 1.4.11** is the current PyPI release. It improves readable multilingual subtitles while preserving real model timestamps. Install with `python -m pip install -U "funasr==1.4.11"`. [Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
-- **MOSS-Transcribe-Diarize integration** adds long-form ASR, timestamps, and anonymous speaker labels in one generation, without an external VAD or speaker pipeline. FunASR supports local Transformers and existing vLLM/SGLang services; FunClip can export speaker-aware SRT and clips. [Deployment guide ->](./docs/moss_transcribe_diarize.md)
-- **llama.cpp runtime v0.2.6** provides verified prebuilt archives for ten Linux, macOS, and Windows targets, including dedicated Windows CUDA packages for RTX 30/40 and RTX 50 GPUs. [Download matrix ->](https://www.funasr.com/en/deploy/llama-cpp.html)
-- **Realtime serving is faster and more resilient**: compatible WebSocket sessions are batched instead of serialized, and queued decoding no longer closes healthy sessions by default. On the H100 regression workload, 12-client STOP p95 fell from 19.8 s to 0.4 s. [Production guide ->](./docs/vllm_guide.md)
+- **Latest release:** FunASR 1.4.11 improves multilingual subtitles while preserving model timestamps. Install with `python -m pip install -U "funasr==1.4.11"`. [Release notes ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
+- **New model integration:** MOSS-Transcribe-Diarize provides long-form ASR, timestamps, and anonymous speaker labels in one pass, without an external VAD or speaker pipeline. [Deployment guide ->](./docs/moss_transcribe_diarize.md)
+- **Production deployment:** use faster realtime vLLM serving or verified llama.cpp runtime v0.2.6 packages for Linux, macOS, and Windows. [vLLM guide ->](./docs/vllm_guide.md) · [runtime release ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6) · [downloads ->](https://www.funasr.com/en/deploy/llama-cpp.html)
 
 > See [GitHub Releases](https://github.com/modelscope/FunASR/releases) for the complete changelog and downloadable assets.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -99,10 +99,9 @@ Whisper は単一モデルですが、**FunASR はツールキット**です—�
 
 ## 最新情報
 
-- **FunASR 1.4.11** は現在の PyPI 安定版です。実際のモデル timestamp を保持しながら、多言語字幕の可読性を改善しました。更新：`python -m pip install -U "funasr==1.4.11"`。[Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
-- **MOSS-Transcribe-Diarize 連携**では、長時間音声の ASR、timestamp、匿名 speaker label を 1 回の生成で処理でき、外部 VAD や speaker pipeline は不要です。FunASR は local Transformers と既存の vLLM/SGLang service に対応し、FunClip は speaker 付き SRT と clip を出力できます。[Deployment guide ->](./docs/moss_transcribe_diarize.md)
-- **llama.cpp runtime v0.2.6** は Linux、macOS、Windows の 10 target 向け検証済み archive を提供し、RTX 30/40 と RTX 50 向け Windows CUDA package を分けて用意しています。[Download matrix ->](https://www.funasr.com/en/deploy/llama-cpp.html) · [Release ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6)
-- **Realtime serving の高速化と安定化**：互換 WebSocket session を直列処理せず batch 化し、decode queue によって正常な session を default で切断しないようにしました。H100 regression workload では 12-client STOP p95 が 19.8 秒から 0.4 秒に短縮しました。[Production guide ->](./docs/vllm_guide.md)
+- **最新リリース：** FunASR 1.4.11 はモデルの timestamp を保持しながら、多言語字幕を改善します。更新：`python -m pip install -U "funasr==1.4.11"`。[Release notes ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
+- **新しいモデル連携：** MOSS-Transcribe-Diarize は長時間 ASR、timestamp、匿名 speaker label を 1 回で処理し、外部 VAD や speaker pipeline を必要としません。[Deployment guide ->](./docs/moss_transcribe_diarize.md)
+- **本番デプロイ：** 高速な realtime vLLM serving、または Linux、macOS、Windows 向け llama.cpp runtime v0.2.6 package を利用できます。[vLLM guide ->](./docs/vllm_guide.md) · [runtime release ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6) · [downloads ->](https://www.funasr.com/en/deploy/llama-cpp.html)
 
 > 完全な変更履歴と download asset は [GitHub Releases](https://github.com/modelscope/FunASR/releases) を参照してください。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -99,10 +99,9 @@ Whisper는 단일 모델이지만, **FunASR는 툴킷**입니다. 용도에 맞�
 
 ## 최신 소식
 
-- **FunASR 1.4.11**은 현재 PyPI 안정 버전입니다. 실제 모델 timestamp를 유지하면서 다국어 자막의 가독성을 개선했습니다. 업데이트: `python -m pip install -U "funasr==1.4.11"`. [Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
-- **MOSS-Transcribe-Diarize 연동**은 긴 오디오의 ASR, timestamp, 익명 speaker label을 한 번의 생성으로 처리하므로 외부 VAD 또는 speaker pipeline이 필요하지 않습니다. FunASR은 local Transformers와 기존 vLLM/SGLang service를 지원하고, FunClip은 speaker별 SRT와 clip을 내보낼 수 있습니다. [Deployment guide ->](./docs/moss_transcribe_diarize.md)
-- **llama.cpp runtime v0.2.6**은 Linux, macOS, Windows 10개 target용 검증된 archive를 제공하며 RTX 30/40 및 RTX 50용 Windows CUDA package를 별도로 제공합니다. [Download matrix ->](https://www.funasr.com/en/deploy/llama-cpp.html) · [Release ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6)
-- **Realtime serving 성능과 안정성 개선**: 호환 WebSocket session을 직렬 처리하지 않고 batch 처리하며, decode queue 때문에 정상 session을 기본적으로 종료하지 않습니다. H100 regression workload에서 12-client STOP p95가 19.8초에서 0.4초로 줄었습니다. [Production guide ->](./docs/vllm_guide.md)
+- **최신 릴리스:** FunASR 1.4.11은 모델 timestamp를 유지하면서 다국어 자막을 개선합니다. 업데이트: `python -m pip install -U "funasr==1.4.11"`. [릴리스 노트 ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
+- **새 모델 연동:** MOSS-Transcribe-Diarize는 긴 오디오 ASR, timestamp, 익명 speaker label을 한 번에 처리하며 외부 VAD나 speaker pipeline이 필요하지 않습니다. [배포 가이드 ->](./docs/moss_transcribe_diarize.md)
+- **프로덕션 배포:** 더 빠른 realtime vLLM serving 또는 Linux, macOS, Windows용 llama.cpp runtime v0.2.6 package를 사용할 수 있습니다. [vLLM guide ->](./docs/vllm_guide.md) · [runtime release ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6) · [downloads ->](https://www.funasr.com/en/deploy/llama-cpp.html)
 
 > 전체 변경 기록과 download asset은 [GitHub Releases](https://github.com/modelscope/FunASR/releases)에서 확인할 수 있습니다.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -149,10 +149,9 @@ Whisper 是单个模型，**FunASR 是一个工具箱**——按场景挑模型�
 
 ## 最新动态
 
-- **FunASR 1.4.11** 是当前 PyPI 稳定版，重点改善多语言可读字幕，并保留模型真实时间戳。升级命令：`python -m pip install -U "funasr==1.4.11"`。[发布页 ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
-- **MOSS-Transcribe-Diarize 已接入生态**：一次生成同时完成长音频转写、时间戳和匿名说话人标签，无需外挂 VAD 或说话人流水线。FunASR 支持本地 Transformers 及已有 vLLM/SGLang 服务，FunClip 可导出带说话人的 SRT 和片段。[部署指南 ->](./docs/moss_transcribe_diarize_zh.md)
-- **llama.cpp runtime v0.2.6** 提供覆盖 Linux、macOS、Windows 十种目标的已验证预编译包，并为 RTX 30/40 与 RTX 50 显卡分别提供 Windows CUDA 包。[下载矩阵 ->](https://www.funasr.com/deploy/llama-cpp.html)
-- **实时服务更快、更稳定**：兼容的 WebSocket 会话改为批处理，排队解码也不再默认误关健康连接。在 H100 回归负载下，12 路客户端 STOP p95 从 19.8 秒降至 0.4 秒。[生产部署指南 ->](./docs/vllm_guide_zh.md)
+- **最新版本：** FunASR 1.4.11 改善多语言字幕，同时保留模型真实时间戳。升级：`python -m pip install -U "funasr==1.4.11"`。[发布说明 ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)
+- **新模型接入：** MOSS-Transcribe-Diarize 一次完成长音频转写、时间戳和匿名说话人标签，无需外挂 VAD 或说话人流水线。[部署指南 ->](./docs/moss_transcribe_diarize_zh.md)
+- **工业部署：** 可选更快的实时 vLLM 服务，或覆盖 Linux、macOS、Windows 的 llama.cpp runtime v0.2.6 预编译包。[vLLM 指南 ->](./docs/vllm_guide_zh.md) · [运行包发布页 ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6) · [下载 ->](https://www.funasr.com/deploy/llama-cpp.html)
 
 > 完整改动记录和可下载资产请查看 [GitHub Releases](https://github.com/modelscope/FunASR/releases)。
 


### PR DESCRIPTION
## Summary

- reduce the top-level What's new section from four detailed entries to three user-facing priorities
- keep the latest release, MOSS integration, and production deployment paths visible
- link detailed history and runtime boundaries instead of duplicating them in the README
- keep English, Chinese, Japanese, and Korean READMEs aligned

## Verification

- `PYTHONPATH=. python -m pytest -q tests/test_docs_funasr_install_commands.py` (18 passed)
- `git diff --check`

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>