### PR TITLE
docs: clarify native vLLM transcription path

### DIFF
--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -100,7 +100,10 @@ native checkpoint 传给 `AutoModelVLLM` 或
 官方 `model.pt`、`config.yaml` 与 `Qwen3-0.6B/` 目录，因而会拒绝 native layout。
 
 原生 `vllm serve` 的转写 API 不会自动获得 FunASR WebSocket 服务的 VAD、partial
-预览、会话状态或说话人处理。需要实时行为时，请按 vLLM 的
+预览、会话状态或说话人处理，因此 native Fun-ASR 模型没有可用的实时转写会话。
+即使对 `/v1/realtime` 发起 WebSocket 握手，也不能据此判断模型支持实时转写；当前
+vLLM 服务会拒绝这类握手，Uvicorn 通常显示 `403 Forbidden`。这是当前实现的拒绝表现，
+不是稳定的 API 契约，也不应据此编写支持性探测。需要实时行为时，请按 vLLM 的
 [realtime speech-to-text 示例](https://docs.vllm.ai/en/latest/examples/speech_to_text/realtime/)
 在应用侧实现音频分段、请求调度与可替换预览；需要 FunASR 已实现的 WebSocket
 协议时，继续使用上文的官方 checkpoint + `serve_realtime_ws.py` 路径。

--- a/docs/vllm_guide_zh_v2.md
+++ b/docs/vllm_guide_zh_v2.md
@@ -84,12 +84,26 @@ model = AutoModelVLLM(
 
 #### B. vLLM 原生转写路径
 
-vLLM 的支持模型表把
+vLLM 原生 `FunASRForConditionalGeneration` 路径使用完整的 native checkpoint，
+不是上文的 FunASR `model.pt` 布局。官方维护的模型为
+[`FunAudioLLM/Fun-ASR-Nano-2512-vllm`](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-vllm)：
+
+```bash
+vllm serve FunAudioLLM/Fun-ASR-Nano-2512-vllm --port 8000
+```
+
+vLLM 的支持模型表也曾使用
 [`allendou/Fun-ASR-Nano-2512-vllm`](https://huggingface.co/allendou/Fun-ASR-Nano-2512-vllm)
-列为原生 `FunASRForConditionalGeneration` 架构的示例。这是托管在官方
-FunAudioLLM 组织之外的社区转换完整 checkpoint。只有明确选择 vLLM 原生转写
-接口时，才应按该模型卡与 vLLM 文档使用它；不要用它替换下文 FunASR
-`AutoModelVLLM` 示例中的官方 checkpoint。
+这一社区转换示例。它同样必须通过 `vllm serve` 的原生接口使用；不要把任一
+native checkpoint 传给 `AutoModelVLLM` 或
+`examples/industrial_data_pretraining/fun_asr_nano/serve_realtime_ws.py`。后两者预期
+官方 `model.pt`、`config.yaml` 与 `Qwen3-0.6B/` 目录，因而会拒绝 native layout。
+
+原生 `vllm serve` 的转写 API 不会自动获得 FunASR WebSocket 服务的 VAD、partial
+预览、会话状态或说话人处理。需要实时行为时，请按 vLLM 的
+[realtime speech-to-text 示例](https://docs.vllm.ai/en/latest/examples/speech_to_text/realtime/)
+在应用侧实现音频分段、请求调度与可替换预览；需要 FunASR 已实现的 WebSocket
+协议时，继续使用上文的官方 checkpoint + `serve_realtime_ws.py` 路径。
 
 **硬件**：GPU ≥ 8GB VRAM，CUDA ≥ 11.8。推荐 16GB+。
 

--- a/tests/test_vllm_model_source_docs.py
+++ b/tests/test_vllm_model_source_docs.py
@@ -29,3 +29,17 @@ def test_vllm_guides_distinguish_official_and_native_model_paths(relpath):
 
     for marker in required_markers:
         assert marker in text, f"{relpath} is missing {marker}"
+
+
+def test_v2_guide_keeps_native_vllm_and_funasr_realtime_paths_separate():
+    text = (ROOT / "docs/vllm_guide_zh_v2.md").read_text(encoding="utf-8")
+
+    required_markers = [
+        "FunAudioLLM/Fun-ASR-Nano-2512-vllm",
+        "vllm serve FunAudioLLM/Fun-ASR-Nano-2512-vllm --port 8000",
+        "serve_realtime_ws.py",
+        "realtime speech-to-text",
+    ]
+
+    for marker in required_markers:
+        assert marker in text, f"docs/vllm_guide_zh_v2.md is missing {marker}"

--- a/tests/test_vllm_model_source_docs.py
+++ b/tests/test_vllm_model_source_docs.py
@@ -39,6 +39,8 @@ def test_v2_guide_keeps_native_vllm_and_funasr_realtime_paths_separate():
         "vllm serve FunAudioLLM/Fun-ASR-Nano-2512-vllm --port 8000",
         "serve_realtime_ws.py",
         "realtime speech-to-text",
+        "没有可用的实时转写会话",
+        "不是稳定的 API 契约",
     ]
 
     for marker in required_markers:


### PR DESCRIPTION
## Summary
- document the official native vLLM checkpoint and its vllm serve entry point
- prevent mixing native checkpoint layout with FunASR AutoModelVLLM or serve_realtime_ws.py
- point realtime native-vLLM users to vLLM's application-side example
- add a regression contract for this boundary

Related to #3203. The roadmap issue stays open for reporter feedback.

## Verification
- PYTHONPATH=. /cpfs_speech/user/zhifu.gzf/.cache/funasr-ops/venvs/funasr-pr-review-20260829/bin/python -m pytest -q tests/test_vllm_model_source_docs.py
  - 4 passed
- git diff --check

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>
