### PR TITLE
docs: add Open WebUI MOSS service recipe

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -101,7 +101,7 @@ Whisper は単一モデルですが、**FunASR はツールキット**です—�
 
 - **MOSS-Transcribe-Diarize** を FunASR service、Docker、Kubernetes、vLLM/SGLang workflow、FunClip に統合し、長時間 ASR、timestamp、匿名 speaker label を一度に処理できます。[MOSS をデプロイ ->](./docs/moss_transcribe_diarize.md)
 - **FunASR 1.4.12** は、audio compute が FP16 のときの Fun-ASR-Nano vLLM 出力を安定化します。Qwen3 decoder は BF16 を使い、BF16 非対応 GPU では FP32 を選択できます。`python -m pip install -U "funasr==1.4.12"`。[Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.12)
-- **Production deployment** に、より高速で安定した realtime serving と、Linux、macOS、Windows の 10 target 向け llama.cpp package を追加しました。[GPU service ->](./docs/vllm_guide.md) · [CPU / edge package ->](https://www.funasr.com/en/deploy/llama-cpp.html)
+- **Production deployment** に、より高速で安定した realtime serving と、Linux、macOS、Windows の 10 target 向け llama.cpp package を追加しました。[GPU service ->](./docs/vllm_guide.md) · [CPU / edge package ->](https://www.funasr.com/en/deploy/llama-cpp.html) · [v0.2.6 binaries ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6)
 
 > 完全な変更履歴と download asset は [GitHub Releases](https://github.com/modelscope/FunASR/releases) を参照してください。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -101,7 +101,7 @@ Whisper는 단일 모델이지만, **FunASR는 툴킷**입니다. 용도에 맞�
 
 - **MOSS-Transcribe-Diarize**를 FunASR service, Docker, Kubernetes, vLLM/SGLang workflow, FunClip에 통합해 긴 오디오 ASR, timestamp, 익명 speaker label을 한 번에 처리합니다. [MOSS 배포 ->](./docs/moss_transcribe_diarize.md)
 - **FunASR 1.4.12**는 audio compute가 FP16일 때 Fun-ASR-Nano vLLM 출력을 안정화합니다. Qwen3 decoder는 BF16을 사용하며 BF16 미지원 GPU에서는 FP32를 선택할 수 있습니다. `python -m pip install -U "funasr==1.4.12"`. [Release ->](https://github.com/modelscope/FunASR/releases/tag/v1.4.12)
-- **Production deployment**에 더 빠르고 안정적인 realtime serving과 Linux, macOS, Windows 10개 target용 llama.cpp package를 추가했습니다. [GPU service ->](./docs/vllm_guide.md) · [CPU / edge package ->](https://www.funasr.com/en/deploy/llama-cpp.html)
+- **Production deployment**에 더 빠르고 안정적인 realtime serving과 Linux, macOS, Windows 10개 target용 llama.cpp package를 추가했습니다. [GPU service ->](./docs/vllm_guide.md) · [CPU / edge package ->](https://www.funasr.com/en/deploy/llama-cpp.html) · [v0.2.6 binaries ->](https://github.com/modelscope/FunASR/releases/tag/runtime-llamacpp-v0.2.6)
 
 > 전체 변경 기록과 download asset은 [GitHub Releases](https://github.com/modelscope/FunASR/releases)에서 확인할 수 있습니다.
 

--- a/docs/moss_transcribe_diarize.md
+++ b/docs/moss_transcribe_diarize.md
@@ -116,6 +116,19 @@ The response contains `text`, audio `duration`, and `segments` with `start`,
 `spk=true`; if a generic client sends it, the service still uses MOSS's native
 labels and does not start a second diarization pipeline.
 
+### Open WebUI
+
+[Open WebUI](https://github.com/open-webui/open-webui) can use this service as
+an OpenAI-compatible speech-to-text provider. In **Admin Panel > Settings >
+Audio**, select the OpenAI STT engine, set **OpenAI API Base URL** to
+`http://funasr:8000/v1` (or the reachable host address), select
+`moss-transcribe-diarize`, and keep the request format as `multipart`. Open
+WebUI then sends the selected model, optional language, and complete audio file
+to `/v1/audio/transcriptions`.
+
+MOSS remains an offline long-form model: this enables file transcription in
+Open WebUI, not a realtime microphone/WebSocket diarization path.
+
 For a reproducible GPU container, build from the repository root with
 `examples/openai_api/docker-compose.moss.yml`. Kubernetes operators can build
 the same `funasr-moss-api:local` image and apply

--- a/docs/moss_transcribe_diarize_zh.md
+++ b/docs/moss_transcribe_diarize_zh.md
@@ -104,6 +104,17 @@ curl -fsS http://127.0.0.1:8000/v1/audio/transcriptions \
 `speaker` 标签的 `segments`。请求不需要设置 `spk=true`；即使通用客户端传入
 该字段，服务也只使用 MOSS 原生标签，不会启动第二套说话人流水线。
 
+### Open WebUI
+
+[Open WebUI](https://github.com/open-webui/open-webui) 可将该服务配置为 OpenAI
+兼容的语音转写提供方。在 **Admin Panel > Settings > Audio** 中选择 OpenAI STT
+engine，将 **OpenAI API Base URL** 设为 `http://funasr:8000/v1`（或可访问的主机
+地址），模型选择 `moss-transcribe-diarize`，请求格式保持 `multipart`。Open WebUI
+会把模型、可选语言和完整音频文件提交到 `/v1/audio/transcriptions`。
+
+MOSS 仍是离线长音频模型：这里提供的是 Open WebUI 文件转写，不是实时麦克风或
+WebSocket 说话人分离路径。
+
 GPU 容器可在仓库根目录使用
 `examples/openai_api/docker-compose.moss.yml` 构建。Kubernetes 运维可构建同一
 `funasr-moss-api:local` 镜像，再应用

--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -341,8 +341,8 @@ def test_top_level_readmes_surface_current_release_and_edge_runtime():
     }
 
     for name, text in readmes.items():
-        assert 'python -m pip install -U "funasr==1.4.11"' in text, name
-        assert "https://github.com/modelscope/FunASR/releases/tag/v1.4.11" in text, name
+        assert 'python -m pip install -U "funasr==1.4.12"' in text, name
+        assert "https://github.com/modelscope/FunASR/releases/tag/v1.4.12" in text, name
         assert "runtime-llamacpp-v0.2.6" in text, name
 
     assert "https://www.funasr.com/en/deploy/llama-cpp.html" in readmes["README.md"]

--- a/tests/test_moss_transcribe_diarize_docs.py
+++ b/tests/test_moss_transcribe_diarize_docs.py
@@ -52,6 +52,9 @@ def test_moss_guides_pin_upstream_and_separate_serving_contracts(guide: Path) ->
         "6561ee553c8f762aac4ebd65439d3414820761b547fa3a2edcea43b86a2abc02",
         "779899a3ce937dd7352b4db1ea53e3f6aa2cfef7109de0249082223c936f9372",
         "localai-org/moss-transcribe.cpp",
+        "Open WebUI",
+        "OpenAI API Base URL",
+        "/v1/audio/transcriptions",
     ):
         assert marker in text, f"{guide.name} is missing {marker}"
 


### PR DESCRIPTION
## Summary

- document the exact Open WebUI OpenAI-STT configuration for the MOSS-Transcribe-Diarize service in English and Chinese
- state the multipart request contract and the offline long-form boundary; this is not a realtime microphone or WebSocket diarization route
- add regression coverage for the MOSS recipe and synchronize multilingual README release/runtime links

## Validation

```text
python -m pytest -q tests/test_moss_transcribe_diarize_docs.py tests/test_docs_funasr_install_commands.py tests/test_server_app_openai_segments.py
51 passed
```

The recipe is derived from Open WebUI's current OpenAI STT multipart request contract. It does not claim an end-to-end Open WebUI runtime test.