### PR TITLE
docs: surface MOSS in use-case selection

### DIFF
--- a/docs/use_case_showcase.md
+++ b/docs/use_case_showcase.md
@@ -81,6 +81,7 @@ For a deeper comparison of SenseVoice, Paraformer, Fun-ASR-Nano, streaming runti
 | Mandarin production ASR | Paraformer-Large | Mature choice for Chinese speech recognition. |
 | LLM-based ASR experiments | Fun-ASR-Nano | Pair with the [vLLM guide](./vllm_guide.md) when throughput matters. |
 | Speaker-aware transcripts | SenseVoice or Paraformer with `spk_model="cam++"` | Useful for meetings, interviews, and customer calls. |
+| Offline long-form diarized transcripts | [MOSS-Transcribe-Diarize](./moss_transcribe_diarize.md) | Joint offline long audio transcription with timestamps and anonymous speaker labels; not a realtime WebSocket path. |
 | Live audio | Runtime WebSocket service | Validate chunking, VAD, and endpointing with real traffic. |
 
 ## Share your result

--- a/docs/use_case_showcase_zh.md
+++ b/docs/use_case_showcase_zh.md
@@ -81,6 +81,7 @@ curl http://localhost:8000/v1/audio/transcriptions \
 | 中文生产 ASR | Paraformer-Large | 中文语音识别的成熟选择。 |
 | LLM-based ASR 实验 | Fun-ASR-Nano | 吞吐敏感时配合 [vLLM 指南](./vllm_guide.md)。 |
 | 带说话人信息的转写 | SenseVoice 或 Paraformer + `spk_model="cam++"` | 适合会议、访谈、客服录音。 |
+| 离线长音频一体化转写与说话人标签 | [MOSS-Transcribe-Diarize](./moss_transcribe_diarize_zh.md) | 一次生成离线长音频转写、时间戳和匿名说话人标签；不是实时 WebSocket 路径。 |
 | 实时音频 | Runtime WebSocket 服务 | 用真实流量验证分块、VAD 和断句。 |
 
 ## 分享你的结果

--- a/tests/test_moss_transcribe_diarize_docs.py
+++ b/tests/test_moss_transcribe_diarize_docs.py
@@ -158,3 +158,25 @@ def test_openai_consumer_docs_expose_moss_alias_and_boundaries() -> None:
     spec = json.loads((root / "openapi.json").read_text(encoding="utf-8"))
     model = spec["components"]["schemas"]["TranscriptionRequest"]["properties"]["model"]
     assert "moss-transcribe-diarize" in model["enum"]
+
+
+def test_use_case_showcases_surface_offline_moss_diarization() -> None:
+    showcases = {
+        "docs/use_case_showcase.md": (
+            "Offline long-form diarized transcripts",
+            "offline long audio",
+            "anonymous speaker labels",
+        ),
+        "docs/use_case_showcase_zh.md": (
+            "离线长音频一体化转写与说话人标签",
+            "离线长音频",
+            "匿名说话人标签",
+        ),
+    }
+
+    for name, markers in showcases.items():
+        text = (ROOT / name).read_text()
+        assert "MOSS-Transcribe-Diarize" in text, name
+        assert "moss_transcribe_diarize" in text, name
+        for marker in markers:
+            assert marker in text, name


### PR DESCRIPTION
## Summary

- add the offline long-form MOSS-Transcribe-Diarize path to the English and Chinese use-case selection tables
- distinguish its timestamped anonymous-speaker output from the realtime WebSocket route
- add a regression contract for both public pages

## Validation

```text
python -m pytest -q tests/test_moss_transcribe_diarize_docs.py
12 passed
```

The broader docs command is currently blocked by main's stale `1.4.11` README assertion; that independent synchronization fix is already in #3607.