### PR TITLE
feat(server): support n8n OpenAI audio transcription

### DIFF
--- a/examples/openai_api/WORKFLOWS.md
+++ b/examples/openai_api/WORKFLOWS.md
@@ -122,6 +122,16 @@ Recommended HTTP Request settings:
 
 After the request, use `{{$json.text}}` as the transcript. If `verbose_json` is enabled, route `{{$json.segments}}` to subtitle, speaker, or QA steps.
 
+### n8n OpenAI Audio node
+
+The built-in OpenAI node can also run its Audio > Transcribe operation against
+FunASR. In OpenAI credentials, set Base URL to
+`http://<funasr-host>:8000/v1` and provide any non-empty API key. The node
+always sends `model=whisper-1`; FunASR maps that compatibility alias to the
+model selected when the server starts. This path is transcription-only. Use the
+HTTP Request node above when you need `verbose_json`, segments, or speaker
+labels.
+
 ## Webhook worker pattern
 
 Use this when the workflow engine cannot send multipart files reliably or when audio needs pre-processing.

--- a/examples/openai_api/WORKFLOWS_zh.md
+++ b/examples/openai_api/WORKFLOWS_zh.md
@@ -121,6 +121,14 @@ def transcribe_from_url(audio_url: str) -> dict:
 
 请求之后，使用 `{{$json.text}}` 作为转写文本。如果启用了 `verbose_json`，可以把 `{{$json.segments}}` 传给字幕、说话人分析或质检节点。
 
+### n8n OpenAI Audio 节点
+
+也可以让内置 OpenAI 节点的 Audio > Transcribe 操作调用 FunASR。在 OpenAI
+凭据中将 Base URL 设为 `http://<funasr-host>:8000/v1`，并填写任意非空 API
+key。该节点固定发送 `model=whisper-1`，FunASR 会将这个兼容别名映射到服务
+启动时选择的模型。此路径只返回转写文本；需要 `verbose_json`、分段或说话人
+标签时，仍使用上面的 HTTP Request 节点。
+
 ## Webhook worker 模式
 
 当工作流引擎不能稳定发送 multipart 文件，或音频需要预处理时，可以把转写封装成一个内部 webhook worker。

--- a/examples/openai_api/server.py
+++ b/examples/openai_api/server.py
@@ -32,6 +32,8 @@ app = FastAPI(title="FunASR OpenAI-Compatible API", version="1.0.0")
 
 MODEL_REGISTRY = {}
 DEVICE = "cpu"
+DEFAULT_MODEL = "sensevoice"
+N8N_OPENAI_MODEL_ALIAS = "whisper-1"
 
 MODEL_CONFIGS = {
     "sensevoice": {
@@ -95,6 +97,13 @@ def clean_text(text: str) -> str:
     return re.sub(r'<\|[^|]*\|>', '', text).strip()
 
 
+def resolve_openai_transcription_model(requested_model: str) -> str:
+    """Map n8n's fixed OpenAI transcription model to the started model."""
+    if requested_model == N8N_OPENAI_MODEL_ALIAS:
+        return DEFAULT_MODEL
+    return requested_model
+
+
 @app.post("/v1/audio/transcriptions")
 async def transcribe(
     file: UploadFile = File(...),
@@ -111,6 +120,8 @@ async def transcribe(
     - language: Optional language hint
     - response_format: json or verbose_json
     """
+    model = resolve_openai_transcription_model(model)
+
     # Validate model
     if model not in MODEL_CONFIGS:
         raise HTTPException(
@@ -199,8 +210,9 @@ def main():
     parser.add_argument("--model", default="sensevoice", help="Pre-load model at startup")
     args = parser.parse_args()
 
-    global DEVICE
+    global DEFAULT_MODEL, DEVICE
     DEVICE = args.device
+    DEFAULT_MODEL = args.model
 
     # Pre-load default model
     load_model(args.model)

--- a/funasr/bin/_server_app.py
+++ b/funasr/bin/_server_app.py
@@ -35,6 +35,7 @@ PACKAGE_VERSION = (Path(__file__).resolve().parents[1] / "version.txt").read_tex
 _LANGUAGE_TAG_RE = re.compile(r"<\|(zh|en|yue|ja|ko)\|>")
 MOSS_MODEL_REVISION = "e8681d68e7042738ffca8ac8212bc8fcb1131ab8"
 NATIVE_DIARIZATION_MODELS = {"moss-transcribe-diarize"}
+N8N_OPENAI_MODEL_ALIAS = "whisper-1"
 
 
 def extract_language_from_asr_text(text):
@@ -53,6 +54,13 @@ def resolve_transcription_language(requested_language, result):
     if isinstance(detected_language, str) and detected_language:
         return detected_language
     return "unknown"
+
+
+def resolve_openai_transcription_model(requested_model, default_model):
+    """Map n8n's fixed OpenAI transcription model to the server default."""
+    if requested_model == N8N_OPENAI_MODEL_ALIAS:
+        return default_model
+    return requested_model
 
 
 def _split_text_for_openai_segments(text: str, max_chars: int = 80):
@@ -233,6 +241,7 @@ def create_app(
     app.state.fallback_models = {}
     app.state.model_path = model_path
     app.state.hub = hub
+    app.state.openai_transcription_model = "custom" if model_path else preload_model
 
     normalized_origins = []
     for origin in cors_origins or []:
@@ -480,6 +489,9 @@ def create_app(
     ):
         content = await file.read()
         t0 = time.perf_counter()
+        model = resolve_openai_transcription_model(
+            model, app.state.openai_transcription_model
+        )
 
         if model == "fun-asr-nano":
             _load_vllm_engine()

--- a/tests/test_openai_api_n8n_compat.py
+++ b/tests/test_openai_api_n8n_compat.py
@@ -1,0 +1,25 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_PATH = REPO_ROOT / "examples" / "openai_api" / "server.py"
+
+
+def load_example_server():
+    module_name = "funasr_example_openai_server_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_example_server_maps_n8n_whisper_alias_to_started_model():
+    module = load_example_server()
+    module.DEFAULT_MODEL = "moss-transcribe-diarize"
+
+    assert module.resolve_openai_transcription_model("whisper-1") == "moss-transcribe-diarize"
+    assert module.resolve_openai_transcription_model("sensevoice") == "sensevoice"

--- a/tests/test_server_app_openai_segments.py
+++ b/tests/test_server_app_openai_segments.py
@@ -237,6 +237,29 @@ def test_verbose_json_reports_sensevoice_detected_language(monkeypatch):
     ]
 
 
+def test_n8n_whisper_model_alias_uses_preloaded_model(monkeypatch):
+    module = load_server_app(monkeypatch)
+    DummyAutoModel = install_dummy_funasr(monkeypatch)
+    monkeypatch.setattr(module.sf, "info", lambda path: types.SimpleNamespace(duration=1.25))
+    app = module.create_app(device="cpu", preload_model="sensevoice")
+    transcribe = app.routes[("POST", "/v1/audio/transcriptions")]
+
+    response = asyncio.run(
+        transcribe(
+            file=DummyUpload(),
+            model="whisper-1",
+            language=None,
+            response_format="json",
+            spk=False,
+        )
+    )
+
+    assert response == {"text": "transcript"}
+    assert [instance["model"] for instance in DummyAutoModel.instances] == [
+        "iic/SenseVoiceSmall"
+    ]
+
+
 def test_openai_verbose_json_preserves_speaker_labels(monkeypatch):
     module = load_server_app(monkeypatch)
 


### PR DESCRIPTION
## Summary

- Map the n8n OpenAI Audio node fixed whisper-1 transcription model to the model selected at FunASR server startup.
- Apply the same compatibility behavior to both funasr-server and examples/openai_api/server.py.
- Preserve strict rejection for every other unknown model alias.
- Document native n8n OpenAI Audio credentials beside the existing HTTP Request recipe.

## Validation

PYTHONPATH=. python -m pytest tests/test_openai_api_n8n_compat.py tests/test_server_app_openai_segments.py tests/test_moss_transcribe_diarize_docs.py -q
35 passed
python -m compileall -q funasr/bin/_server_app.py examples/openai_api/server.py
git diff --check

## User impact

n8n built-in OpenAI Audio Transcribe can target either supported self-hosted FunASR server through its Base URL override. It remains transcription-only; use the HTTP Request recipe for verbose JSON, timestamps, or speaker labels.