### PR TITLE
fix(fun-asr-nano): normalize ISO language hints

### DIFF
--- a/funasr/models/fun_asr_nano/inference_vllm.py
+++ b/funasr/models/fun_asr_nano/inference_vllm.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 
 dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
 
+_LANGUAGE_PROMPT_ALIASES = {
+    "zh": "中文",
+    "en": "英文",
+    "ja": "日文",
+    "ko": "韩文",
+}
+
 
 def _resolve_vllm_dtype(dtype: str) -> str:
     """Use a numerically stable dtype for the Qwen3 language model."""
@@ -462,6 +469,8 @@ class FunASRNanoVLLM:
         itn: bool = True,
     ) -> str:
         """Build the ASR prompt string."""
+        if language:
+            language = _LANGUAGE_PROMPT_ALIASES.get(language.lower(), language)
         hotwords = hotwords or []
         if len(hotwords) > 0:
             hotwords_str = ", ".join(hotwords)

--- a/tests/test_fun_asr_nano_vllm_prompt.py
+++ b/tests/test_fun_asr_nano_vllm_prompt.py
@@ -1,0 +1,14 @@
+from funasr.models.fun_asr_nano.inference_vllm import FunASRNanoVLLM
+
+
+def test_iso_language_aliases_use_documented_prompt_names():
+    model = object.__new__(FunASRNanoVLLM)
+
+    assert model._build_prompt_text(language="zh") == "语音转写成中文："
+    assert model._build_prompt_text(language="en") == "语音转写成英文："
+
+
+def test_custom_language_prompt_is_preserved():
+    model = object.__new__(FunASRNanoVLLM)
+
+    assert model._build_prompt_text(language="粤语") == "语音转写成粤语："


### PR DESCRIPTION
## Summary
- normalize common ISO language hints (`zh`, `en`, `ja`, `ko`) to the documented Fun-ASR-Nano prompt names
- preserve custom language strings unchanged
- add isolated prompt construction regression coverage

## Validation
- `PYTHONPATH=. python -m pytest tests/test_fun_asr_nano_vllm_prompt.py tests/test_fun_asr_nano_vllm_dtype.py -q`
- `git diff --check`

Signed off by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>