### PR TITLE
fix: prevent NumPy 2 ABI mismatches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ requirements = {
         "scipy>=1.4.1",
         "librosa",
         "soundfile>=0.12.1",
-        "numpy",
+        # Keep the scientific stack ABI-compatible with the supported SciPy wheels.
+        "numpy<2",
         "PyYAML>=5.1.2",
         "tqdm",
         "requests",

--- a/tests/test_pypi_metadata.py
+++ b/tests/test_pypi_metadata.py
@@ -32,3 +32,9 @@ def test_package_keywords_surface_deployment_discovery_terms():
         '"llama-cpp"',
     ]:
         assert keyword in text
+
+
+def test_core_dependencies_prevent_numpy_two_abi_mismatches():
+    text = _setup_text()
+
+    assert '"numpy<2"' in text


### PR DESCRIPTION
## Summary
- constrain the core NumPy dependency to the supported NumPy 1 ABI
- add a packaging contract test for the bound

## Validation
- `python -m pytest -q tests/test_pypi_metadata.py tests/test_top_level_import.py tests/test_moss_transcribe_diarize_model.py tests/test_moss_transcribe_diarize_docs.py tests/test_server_app_openai_segments.py tests/test_docs_funasr_install_commands.py` (73 passed)
- `python -m pip wheel --no-deps --wheel-dir /tmp/funasr-numpy-abi-wheel .`
- wheel metadata contains `Requires-Dist: numpy<2`

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>