### PR TITLE
docs: add a concise community discovery entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 
 No local setup? Open the [Colab quickstart](./examples/colab/) to transcribe a public sample or upload your own audio in a browser.
 
+Found FunASR useful? [Star the project](https://github.com/modelscope/FunASR) so more builders can find it.
+
 ```bash
 # CPU-only installs can use the default PyPI wheels.
 pip install torch torchaudio

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,6 +32,8 @@
 
 不想先配置本地环境？可以打开 [Colab 快速体验](./examples/colab/README_zh.md) 在浏览器里转写公开样例或上传自己的音频。
 
+FunASR 对你有帮助？欢迎 [Star 项目](https://github.com/modelscope/FunASR)，让更多开发者找到它。
+
 ```bash
 pip install torch torchaudio
 pip install funasr

--- a/tests/test_readme_deployment_hub_links.py
+++ b/tests/test_readme_deployment_hub_links.py
@@ -16,3 +16,24 @@ def test_deployment_hub_is_in_readme_primary_navigation(readme: str, label: str)
     link = f'<a href="{DEPLOYMENT_HUB_URL}">{label}</a>'
 
     assert primary_navigation.count(link) == 1
+
+
+@pytest.mark.parametrize(
+    ("readme", "community_line"),
+    (
+        (
+            "README.md",
+            "Found FunASR useful? [Star the project](https://github.com/modelscope/FunASR) so more builders can find it.",
+        ),
+        (
+            "README_zh.md",
+            "FunASR 对你有帮助？欢迎 [Star 项目](https://github.com/modelscope/FunASR)，让更多开发者找到它。",
+        ),
+    ),
+)
+def test_quickstart_has_a_concise_community_discovery_entrypoint(
+    readme: str, community_line: str
+) -> None:
+    quickstart = "\n".join((ROOT / readme).read_text(encoding="utf-8").splitlines()[:45])
+
+    assert quickstart.count(community_line) == 1


### PR DESCRIPTION
## Summary
- add one optional, bilingual Star link directly after the browser quickstart
- keep the existing primary navigation intact
- add a narrow README contract test to prevent either language from losing the entrypoint

## Validation
- `python -m pytest tests/test_readme_deployment_hub_links.py -q` (4 passed)
- `git diff --check`

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>