### PR TITLE
docs: sync repository role guides with current release

### DIFF
--- a/docs/repository_roles.md
+++ b/docs/repository_roles.md
@@ -5,7 +5,7 @@ This document explains the responsibility boundaries, user entry points, and iss
 > **Directional roadmap, not a release promise.**
 > This document records shipped capabilities and active work, but does not commit to
 > future version numbers or dates. The current Python release is
-> [`funasr==1.4.11`](https://github.com/modelscope/FunASR/releases/tag/v1.4.11).
+> [`funasr==1.4.13`](https://github.com/modelscope/FunASR/releases/tag/v1.4.13).
 > Any future breaking release still requires a maintainer-approved milestone and
 > migration plan.
 

--- a/docs/repository_roles_zh.md
+++ b/docs/repository_roles_zh.md
@@ -4,7 +4,7 @@
 
 > **方向性路线图，不是版本承诺。**
 > 本文档记录已交付能力与正在推进的工作，但不承诺未来版本号或日期。当前 Python
-> 版本是 [`funasr==1.4.11`](https://github.com/modelscope/FunASR/releases/tag/v1.4.11)。
+> 版本是 [`funasr==1.4.13`](https://github.com/modelscope/FunASR/releases/tag/v1.4.13)。
 > 任何未来的 breaking release 仍需 maintainer 确认 milestone 与迁移方案。
 
 ---

--- a/tests/test_release_version_contract.py
+++ b/tests/test_release_version_contract.py
@@ -4,6 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_VERSION = "1.4.13"
 README_FILES = ("README.md", "README_zh.md", "README_ja.md", "README_ko.md")
+REPOSITORY_ROLE_FILES = ("docs/repository_roles.md", "docs/repository_roles_zh.md")
 
 
 def test_release_version_uses_required_carry_rule():
@@ -18,6 +19,14 @@ def test_release_version_uses_required_carry_rule():
 
 def test_release_is_recorded_in_all_top_level_readmes():
     for name in README_FILES:
+        text = (ROOT / name).read_text(encoding="utf-8")
+
+        assert f"funasr=={RELEASE_VERSION}" in text
+        assert f"releases/tag/v{RELEASE_VERSION}" in text
+
+
+def test_repository_role_guides_link_the_current_release():
+    for name in REPOSITORY_ROLE_FILES:
         text = (ROOT / name).read_text(encoding="utf-8")
 
         assert f"funasr=={RELEASE_VERSION}" in text


### PR DESCRIPTION
## Summary
- Synchronize English and Chinese repository-role guides with the released `funasr==1.4.13` package.
- Add a release-link contract so these guides cannot silently lag the current package version.

## Validation
- `python -m pytest -q tests/test_release_version_contract.py --disable-warnings --maxfail=1` (3 passed)
- `git diff --check`
