### PR TITLE
web: refresh ecosystem star count

### DIFF
--- a/web-pages/product-site/legacy/ecosystem.html
+++ b/web-pages/product-site/legacy/ecosystem.html
@@ -75,7 +75,7 @@ footer a{color:#60a5fa}
 <div class="stat-bar">
 <div class="stat"><div class="stat-num">50+</div><div class="stat-label">集成项目</div></div>
 <div class="stat"><div class="stat-num">31</div><div class="stat-label">MLT-Nano 语种</div></div>
-<div class="stat"><div class="stat-num">36K+</div><div class="stat-label">GitHub Stars</div></div>
+<div class="stat"><div class="stat-num">37K+</div><div class="stat-label">GitHub Stars</div></div>
 <div class="stat"><div class="stat-num">100万+</div><div class="stat-label">月安装量</div></div>
 </div>
 

--- a/web-pages/product-site/legacy/en/ecosystem.html
+++ b/web-pages/product-site/legacy/en/ecosystem.html
@@ -76,7 +76,7 @@ footer a{color:#60a5fa}
 <div class="stat-bar">
 <div class="stat"><div class="stat-num">50+</div><div class="stat-label">Integrations</div></div>
 <div class="stat"><div class="stat-num">31</div><div class="stat-label">MLT-Nano Languages</div></div>
-<div class="stat"><div class="stat-num">36K+</div><div class="stat-label">GitHub Stars</div></div>
+<div class="stat"><div class="stat-num">37K+</div><div class="stat-label">GitHub Stars</div></div>
 <div class="stat"><div class="stat-num">1M+</div><div class="stat-label">pip installs/month</div></div>
 </div>
 

--- a/web-pages/product-site/tests/test_output.py
+++ b/web-pages/product-site/tests/test_output.py
@@ -422,7 +422,7 @@ def test_ecosystem_refresh_tracks_current_release_and_merged_native_runtime(
     soup = read_soup(built_site / relative)
     text = soup.get_text(' ', strip=True)
 
-    assert '36K+' in text
+    assert '37K+' in text
     assert soup.select_one(
         'a[href="https://github.com/modelscope/FunClip/releases/tag/v2.1.1"]'
     )


### PR DESCRIPTION
## Summary
- Refresh the public ecosystem social-proof counter from 36K+ to 37K+ GitHub stars in both languages.
- Update the built-site contract to prevent the visible count from drifting back.

## Validation
- `python -m pytest -q web-pages/product-site/tests/test_output.py --disable-warnings --maxfail=1` (49 passed)
- `git diff --check`
