### PR TITLE
feat(site): route workflow users to focused repositories

### DIFF
--- a/web-pages/product-site/assets/css/site.css
+++ b/web-pages/product-site/assets/css/site.css
@@ -352,6 +352,56 @@ img {
   max-width: 900px;
 }
 
+.repository-router-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.repository-router-links a {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px 16px;
+  min-height: 112px;
+  padding: 18px 0 0;
+  border-top: 3px solid var(--green);
+  color: inherit;
+  text-decoration: none;
+}
+
+.repository-router-links a:nth-child(2) {
+  border-color: #d08a21;
+}
+
+.repository-router-links a:nth-child(3) {
+  border-color: #d84b55;
+}
+
+.repository-router-links span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.repository-router-links strong {
+  font-size: 18px;
+  line-height: 1.35;
+}
+
+.repository-router-links img {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  width: 20px;
+  height: 20px;
+  align-self: center;
+  transition: transform 160ms ease;
+}
+
+.repository-router-links a:hover img,
+.repository-router-links a:focus-visible img {
+  transform: translateX(4px);
+}
+
 .selector {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -1251,11 +1301,13 @@ td a {
   }
 
   .responsibility-grid,
-  .ecosystem-repositories {
+  .ecosystem-repositories,
+  .repository-router-links {
     gap: 24px;
   }
 
-  .ecosystem-repositories {
+  .ecosystem-repositories,
+  .repository-router-links {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1458,6 +1510,7 @@ td a {
 
   .responsibility-grid,
   .ecosystem-repositories,
+  .repository-router-links,
   .deploy-grid {
     grid-template-columns: 1fr;
   }

--- a/web-pages/product-site/templates/home.html
+++ b/web-pages/product-site/templates/home.html
@@ -27,6 +27,31 @@
   </div>
 </section>
 
+<section class="section repository-router" data-section="repository-router">
+  <div class="section-heading compact-heading">
+    <p class="eyebrow">{{ '生态路由' if language == 'zh' else 'Ecosystem routing' }}</p>
+    <h2>{{ '按工作流进入专用仓库' if language == 'zh' else 'Choose the focused repository' }}</h2>
+    <p>{{ '部署路径适用于 FunASR 运行时；当需求由模型能力或视频工作流定义时，直接进入对应仓库。' if language == 'zh' else 'Deployment paths serve the FunASR runtime. When the requirement is defined by model capability or a video workflow, start in the focused repository.' }}</p>
+  </div>
+  <div class="repository-router-links">
+    <a href="/go/fun-asr">
+      <span>Fun-ASR</span>
+      <strong>{{ '高精度与 31 语种转写' if language == 'zh' else 'High-accuracy and 31-language transcription' }}</strong>
+      <img src="{{ assets['lucide/arrow-right.svg'] }}" alt="">
+    </a>
+    <a href="/go/sensevoice">
+      <span>SenseVoice</span>
+      <strong>{{ '多语种、情感与音频事件' if language == 'zh' else 'Languages, emotion, and audio events' }}</strong>
+      <img src="{{ assets['lucide/arrow-right.svg'] }}" alt="">
+    </a>
+    <a href="/go/funclip">
+      <span>FunClip</span>
+      <strong>{{ '从语音定位到视频剪辑' if language == 'zh' else 'From speech localization to video clipping' }}</strong>
+      <img src="{{ assets['lucide/arrow-right.svg'] }}" alt="">
+    </a>
+  </div>
+</section>
+
 <section id="deployment-selector" class="section selector-section" data-section="deployment-selector">
   <div class="section-heading">
     <p class="eyebrow">{{ '部署选择器' if language == 'zh' else 'Deployment selector' }}</p>

--- a/web-pages/product-site/tests/test_output.py
+++ b/web-pages/product-site/tests/test_output.py
@@ -69,6 +69,35 @@ def test_homepage_routes_each_project_by_workload(built_site, relative, markers)
         assert marker in text
 
 
+@pytest.mark.parametrize(
+    ('relative', 'heading', 'routes'),
+    (
+        (
+            'index.html',
+            '按工作流进入专用仓库',
+            ('/go/fun-asr', '/go/sensevoice', '/go/funclip'),
+        ),
+        (
+            'en/index.html',
+            'Choose the focused repository',
+            ('/go/fun-asr', '/go/sensevoice', '/go/funclip'),
+        ),
+    ),
+)
+def test_homepage_surfaces_focused_repository_router_before_deployment_choice(
+    built_site, relative, heading, routes
+):
+    soup = read_soup(built_site / relative)
+    router = soup.select_one('[data-section="repository-router"]')
+    selector = soup.select_one('[data-section="deployment-selector"]')
+
+    assert router
+    assert selector
+    assert router.get_text(' ', strip=True).find(heading) >= 0
+    assert list(soup.select('section')).index(router) < list(soup.select('section')).index(selector)
+    assert tuple(link['href'] for link in router.select('a[href]')) == routes
+
+
 def test_every_deployment_page_has_operational_contract(built_site):
     registry = load_registry(SITE_ROOT / 'data' / 'deployments.json')
 


### PR DESCRIPTION
## Summary
- add a compact workflow router before the deployment selector
- direct transcription, multilingual audio understanding, and speech-guided clipping users to Fun-ASR, SenseVoice, and FunClip
- add rendered-output coverage for route order and stable redirect targets

## Verification
- `python -m pytest -q web-pages/product-site/tests/test_output.py -k focused_repository_router --disable-warnings --maxfail=1`
- `python web-pages/product-site/build.py --output /tmp/funasr-router-site`
- `python web-pages/product-site/validate.py /tmp/funasr-router-site`

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>