### PR TITLE
test(docs): track current roadmap release

### DIFF
--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -386,7 +386,7 @@ def test_repository_roadmap_tracks_current_delivery_and_open_work():
     ]
 
     for text in docs:
-        assert "1.4.11" in text
+        assert "1.4.13" in text
         assert "v1.3.26" not in text
         assert "runtime-llamacpp-v0.2.6" in text
         assert "MOSS-Transcribe-Diarize" in text


### PR DESCRIPTION
Updates the roadmap contract to validate the currently documented `funasr==1.4.13` release.

Validation:
- `python -m pytest tests/test_moss_transcribe_diarize_docs.py tests/test_moss_transcribe_diarize_model.py tests/test_markdown_relative_links.py tests/test_readme_deployment_hub_links.py tests/test_docs_funasr_install_commands.py -q` (55 passed)
- `git diff --check`

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>