### PR TITLE
docs: refresh ecosystem growth snapshot

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -34,14 +34,14 @@ This plan focuses on useful adoption work rather than vanity marketing: if more 
 
 ## Current campaign snapshot
 
-As of 2026-09-02 12:29 UTC, the ecosystem has 37,058 combined GitHub stars, or 5,834 additional stars since the 31,224 baseline. Exceeding the +20,000 target requires another 14,166 stars to reach at least 51,224 by 2026-09-30, or roughly 506 stars/day across the remaining 28 days. Public PyPI reports 59,903 downloads over the latest 7 days and 448,764 over the latest 30 days.
+As of 2026-09-02 13:48 UTC, the ecosystem has 37,060 combined GitHub stars, or 5,836 additional stars since the 31,224 baseline. Exceeding the +20,000 target requires another 14,164 stars to reach at least 51,224 by 2026-09-30, or roughly 506 stars/day across the remaining 28 days. Public PyPI reports 59,903 downloads over the latest 7 days and 448,764 over the latest 30 days.
 
 | Repository | Stars | Forks | Open issues | Open PRs | Last push |
 |---|---:|---:|---:|---:|---|
-| `modelscope/FunASR` | 20,131 | 2,011 | 22 | 0 | 2026-09-02 |
-| `QwenAudio/Fun-ASR` | 1,510 | 148 | 6 | 0 | 2026-09-02 |
-| `QwenAudio/SenseVoice` | 9,206 | 816 | 7 | 0 | 2026-08-31 |
-| `modelscope/FunClip` | 6,208 | 741 | 5 | 0 | 2026-09-01 |
+| `modelscope/FunASR` | 20,132 | 2,011 | 22 | 0 | 2026-09-02 |
+| `QwenAudio/Fun-ASR` | 1,511 | 148 | 6 | 0 | 2026-09-02 |
+| `QwenAudio/SenseVoice` | 9,208 | 816 | 7 | 0 | 2026-08-31 |
+| `modelscope/FunClip` | 6,209 | 741 | 5 | 0 | 2026-09-01 |
 
 ### 2026-08-21 FunASR v1.4.3 stable release
 


### PR DESCRIPTION
Refresh the campaign snapshot from the GitHub repository API at 2026-09-02 13:48 UTC.

- Combined stars: 37,060; baseline gain: 5,836; strict remaining gap: 14,164.
- Synchronizes the four repository rows with current stars, forks, open-issue counts, and last-push dates.

Validation:
- python -m pytest -q tests/test_growth_plan_doc.py tests/test_openai_api_docker_validation.py (22 passed)
- git diff --check

Signed commit: f59477ebd6720f5e9cd4652f323c9e315c465314