### PR TITLE
Support enforce-eager for realtime server

### DIFF
--- a/funasr/bin/realtime_ws.py
+++ b/funasr/bin/realtime_ws.py
@@ -1333,6 +1333,7 @@ def load_models(args):
             tensor_parallel_size=getattr(args, 'tensor_parallel_size', 1),
             gpu_memory_utilization=getattr(args, 'gpu_memory_utilization', 0.8),
             max_model_len=getattr(args, 'max_model_len', 2048),
+            enforce_eager=getattr(args, 'enforce_eager', False),
         )
         _vllm_engine = RealtimeBatchingEngine(
             engine,
@@ -1679,6 +1680,11 @@ def build_arg_parser():
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
     parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Disable vLLM compilation and CUDA graphs.",
+    )
     parser.add_argument("--ws-ping-interval", type=float, default=20.0,
                         help="WebSocket ping interval in seconds; <=0 disables keepalive pings.")
     parser.add_argument(


### PR DESCRIPTION
## Summary
Add support for enforce-eager parameter in funasr-realtime-server。

## Type of change

- [ ] Bug fix
- [ ] Documentation
- [ ] Example or demo
- [x] Runtime or deployment
- [ ] Benchmark or evaluation
- [ ] Model/training change

## Validation

<!-- Commands run, logs, screenshots, benchmark results, or why validation is not applicable. -->

- [x] `funasr-realtime-server --model FunAudioLLM/Fun-ASR-Nano-2512 --device cuda --tensor-parallel-size 1 --gpu-memory-utilization 0.85 --enforce-eager`
- [x] Docs or links checked
- [x] Runtime/deployment command tested

## User impact

GPU users of funasr-realtime-server who need to reduce memory footprint or debug inference issues, by allowing the server to run in eager mode instead of using CUDA graphs

## Notes for reviewers
This is an optional flag. If not provided, the server behavior remains unchanged (defaults to CUDA graph mode)
<!-- Compatibility notes, risks, follow-up work, or review focus. -->
