### PR TITLE
test(docs): require MOSS README model zoo entries

### DIFF
--- a/tests/test_moss_transcribe_diarize_docs.py
+++ b/tests/test_moss_transcribe_diarize_docs.py
@@ -156,6 +156,21 @@ def test_readmes_link_the_runnable_moss_service() -> None:
         assert "moss_transcribe_diarize" in text
 
 
+def test_readme_model_zoos_expose_moss_with_its_model_card_and_guide() -> None:
+    readmes = {
+        "README.md": "./docs/moss_transcribe_diarize.md",
+        "README_zh.md": "./docs/moss_transcribe_diarize_zh.md",
+        "README_ja.md": "./docs/moss_transcribe_diarize.md",
+        "README_ko.md": "./docs/moss_transcribe_diarize.md",
+    }
+
+    for name, guide in readmes.items():
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert "| **MOSS-Transcribe-Diarize** |" in text, name
+        assert "https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize" in text, name
+        assert guide in text, name
+
+
 def test_openai_consumer_docs_expose_moss_alias_and_boundaries() -> None:
     paths = [
         "CLIENTS.md",


### PR DESCRIPTION
## Summary

Protect MOSS discovery in all four README Model Zoo tables. The contract requires the table row, official OpenMOSS model card, and language-appropriate FunASR deployment guide.

## Validation

- python -m pytest tests/test_moss_transcribe_diarize_docs.py tests/test_docs_funasr_install_commands.py -q (33 passed)
- git diff --check