### PR TITLE
docs: surface MOSS in model selection guides

### DIFF
--- a/docs/model_selection.md
+++ b/docs/model_selection.md
@@ -38,6 +38,7 @@ Switch to Paraformer when your workload is Mandarin-only and you want character-
 | Mandarin production ASR | Paraformer-Large | Mature Chinese ASR path with VAD and punctuation. | [Tutorial](./tutorial/README.md) |
 | English-only route in the OpenAI API example | `paraformer-en` alias | Smaller English route for API compatibility checks. | [OpenAI API example](../examples/openai_api/) |
 | LLM-based ASR or Chinese/English/Japanese + dialect experiments | Fun-ASR-Nano | LLM-based model path; use vLLM when decoder throughput matters. | [vLLM guide](./vllm_guide.md) |
+| Offline long-form ASR with anonymous diarization | MOSS-Transcribe-Diarize | One offline request returns transcription, timestamps, and per-recording anonymous speaker labels; it does not identify known people and needs no external VAD or speaker model. | [MOSS deployment guide](./moss_transcribe_diarize.md) |
 | Live captions or call-center streams | Runtime WebSocket service | Designed for long-lived streaming sessions and partial results. | [Runtime service docs](../runtime/readme.md) |
 | Batch archive processing | SenseVoice-Small or Paraformer-Large | Stable offline transcription path; caller owns manifests, retries, and logs. | [Batch ASR example](../examples/batch_asr_improved.py) |
 | Migration from Whisper/cloud ASR | SenseVoice-Small first, then benchmark alternatives | Gives a strong baseline before deeper model-specific tuning. | [Migration guide](./migration_from_whisper.md) |
@@ -94,6 +95,7 @@ For migration work, use the [migration benchmark example](../examples/migration/
 - With a GPU, default to Fun-ASR-Nano — the flagship LLM-based model for Chinese, English, Japanese, and Chinese dialects/accents, strongest on hard, contextual, and proper-noun-heavy audio. For the separate 31-language checkpoint, use Fun-ASR-MLT-Nano.
 - On CPU, or for multilingual + emotion workloads, use SenseVoice-Small (fast non-autoregressive, CPU-viable).
 - Use Paraformer when your production traffic is primarily Mandarin and you want timestamps or hotwords.
+- For offline long recordings that need anonymous per-recording speaker labels in the same request, use MOSS-Transcribe-Diarize; it is not a realtime WebSocket or known-person identification path.
 - Use the streaming runtime when partial results and long-lived connections matter more than a single final transcript.
 - Keep model aliases stable in production runbooks so benchmark results and bug reports are reproducible.
 - Open a [Deployment Help issue](https://github.com/modelscope/FunASR/issues/new?template=deployment_help.md) with model, device, command, logs, audio duration, and runtime path when you get stuck.

--- a/docs/model_selection_ja.md
+++ b/docs/model_selection_ja.md
@@ -28,6 +28,7 @@ result = model.generate(input="meeting.wav")
 | 中国語中心の本番 ASR | Paraformer-Large | VAD と句読点復元を組み合わせた成熟した中国語 ASR ルート。 | [Tutorial](./tutorial/README.md) |
 | OpenAI API 例の英語ルート | `paraformer-en` alias | OpenAI-style client で互換性を確認しやすい軽量な英語ルート。 | [OpenAI API example](../examples/openai_api/README_ja.md) |
 | LLM-based ASR や中英日 + 中国語方言・地域アクセントの評価 | Fun-ASR-Nano | LLM-based モデル。decoder throughput が重要なら vLLM を使います。 | [vLLM guide](./vllm_guide.md) |
+| オフライン長時間 ASR と匿名話者ラベル | MOSS-Transcribe-Diarize | 1 回のオフライン request で文字起こし、timestamps、録音内の匿名話者ラベルを返します。既知人物の識別ではなく、外部 VAD / speaker model も不要です。 | [MOSS deployment guide](./moss_transcribe_diarize.md) |
 | ライブ字幕やコールセンターストリーム | Runtime WebSocket service | 長時間接続、部分結果、エンドポイント検出に向いたランタイム。 | [Runtime service docs](../runtime/readme.md) |
 | Whisper / cloud ASR からの移行 | SenseVoice-Small で baseline を作り、必要に応じて比較 | まず強い標準ルートで評価してから、用途別に詰めるのが安全です。 | [Migration guide](./migration_from_whisper.md) |
 

--- a/docs/model_selection_ko.md
+++ b/docs/model_selection_ko.md
@@ -28,6 +28,7 @@ result = model.generate(input="meeting.wav")
 | 중국어 중심 프로덕션 ASR | Paraformer-Large | VAD와 문장부호 복원을 함께 쓰는 성숙한 중국어 ASR 경로입니다. | [Tutorial](./tutorial/README.md) |
 | OpenAI API 예제의 영어 경로 | `paraformer-en` alias | OpenAI-style client에서 호환성을 확인하기 쉬운 가벼운 영어 경로입니다. | [OpenAI API example](../examples/openai_api/README_ko.md) |
 | LLM-based ASR 또는 중영일 + 중국어 방언/지역 억양 평가 | Fun-ASR-Nano | LLM-based 모델입니다. decoder throughput이 중요하면 vLLM을 사용합니다. | [vLLM guide](./vllm_guide.md) |
+| 오프라인 장시간 ASR 및 익명 화자 라벨 | MOSS-Transcribe-Diarize | 한 번의 오프라인 request로 전사, timestamps, 녹음 내 익명 화자 라벨을 반환합니다. 알려진 인물을 식별하지 않으며 외부 VAD / speaker model도 필요하지 않습니다. | [MOSS deployment guide](./moss_transcribe_diarize.md) |
 | 라이브 자막 또는 콜센터 스트림 | Runtime WebSocket service | 장시간 연결, 부분 결과, endpointing에 맞춘 런타임입니다. | [Runtime service docs](../runtime/readme.md) |
 | Whisper / cloud ASR에서 전환 | SenseVoice-Small로 baseline을 만들고 필요하면 비교 | 강한 기본 경로로 먼저 평가한 뒤 용도별로 조정하는 편이 안전합니다. | [Migration guide](./migration_from_whisper.md) |
 

--- a/docs/model_selection_zh.md
+++ b/docs/model_selection_zh.md
@@ -38,6 +38,7 @@ result = model.generate(input="meeting.wav")
 | 中文生产 ASR | Paraformer-Large | 成熟中文 ASR 路径，可组合 VAD 和标点。 | [教程](./tutorial/README_zh.md) |
 | OpenAI API 示例中的英文路由 | `paraformer-en` alias | 适合在 OpenAI 风格客户端里验证较轻量英文路径。 | [OpenAI API 示例](../examples/openai_api/README_zh.md) |
 | LLM-based ASR 或中文/英文/日语 + 方言实验 | Fun-ASR-Nano | LLM-based 模型路径；解码吞吐敏感时配合 vLLM。 | [vLLM 指南](./vllm_guide.md) |
+| 离线长音频 ASR 与匿名说话人标签 | MOSS-Transcribe-Diarize | 一次离线请求返回转写、时间戳和录音内匿名说话人标签；不识别已知人物，也不需要外部 VAD 或说话人模型。 | [MOSS 部署指南](./moss_transcribe_diarize_zh.md) |
 | 实时字幕或客服流式音频 | Runtime WebSocket 服务 | 面向长连接流式会话和中间结果。 | [Runtime 服务文档](../runtime/readme_cn.md) |
 | 录音归档批处理 | SenseVoice-Small 或 Paraformer-Large | 稳定离线转写路径；调用方负责 manifest、重试和日志。 | [批处理示例](../examples/batch_asr_improved.py) |
 | 从 Whisper/云端 ASR 迁移 | 先用 SenseVoice-Small，再 benchmark 其他模型 | 先建立强基线，再做模型专项调优。 | [迁移指南](./migration_from_whisper_zh.md) |
@@ -94,6 +95,7 @@ SDK、JavaScript、工作流、Postman、OpenAPI、Docker 和 Kubernetes 路径�
 - demo、私有 API、Agent 语音输入和多语种场景优先试 SenseVoice-Small。
 - 中文生产流量优先试 Paraformer，尤其是希望走成熟非自回归 ASR 路径时。
 - 明确需要 LLM-based 模型路径或 vLLM 加速实验时，再试 Fun-ASR-Nano；如需单独的 31 语种覆盖，请改用 Fun-ASR-MLT-Nano。
+- 离线长录音需要同一次请求给出录音内匿名说话人标签时，使用 MOSS-Transcribe-Diarize；它不是实时 WebSocket 或已知人物身份识别路径。
 - 需要中间结果和长连接时，优先使用 streaming runtime，而不是普通 HTTP 转写接口。
 - 生产 runbook 中固定模型 alias，保证 benchmark 和问题复现可追踪。
 - 遇到阻塞时，用 [Deployment Help issue](https://github.com/modelscope/FunASR/issues/new?template=deployment_help.md) 提供模型、设备、命令、日志、音频时长和运行路径。

--- a/tests/test_moss_transcribe_diarize_docs.py
+++ b/tests/test_moss_transcribe_diarize_docs.py
@@ -167,8 +167,25 @@ def test_readme_model_zoos_expose_moss_with_its_model_card_and_guide() -> None:
     for name, guide in readmes.items():
         text = (ROOT / name).read_text(encoding="utf-8")
         assert "| **MOSS-Transcribe-Diarize** |" in text, name
-        assert "https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize" in text, name
+        assert (
+            "https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize" in text
+        ), name
         assert guide in text, name
+
+
+def test_model_selection_guides_surface_offline_moss_diarization() -> None:
+    guides = {
+        "model_selection.md": ("./moss_transcribe_diarize.md", "offline"),
+        "model_selection_zh.md": ("./moss_transcribe_diarize_zh.md", "离线"),
+        "model_selection_ja.md": ("./moss_transcribe_diarize.md", "オフライン"),
+        "model_selection_ko.md": ("./moss_transcribe_diarize.md", "오프라인"),
+    }
+
+    for name, (guide, offline_marker) in guides.items():
+        text = (ROOT / "docs" / name).read_text(encoding="utf-8")
+        assert "MOSS-Transcribe-Diarize" in text, name
+        assert guide in text, name
+        assert offline_marker in text, name
 
 
 def test_openai_consumer_docs_expose_moss_alias_and_boundaries() -> None:


### PR DESCRIPTION
Summary:
- add MOSS-Transcribe-Diarize to four model-selection decision tables
- state offline-only, anonymous per-recording labels, and no external VAD/speaker model boundary
- protect this entry with the MOSS documentation contract

Validation: python -m pytest tests/test_moss_transcribe_diarize_docs.py tests/test_docs_funasr_install_commands.py -q (34 passed)

Signed-off-by: zhifu.gzf <zhifu.gzf@users.noreply.github.com>