### PR TITLE
docs: add MOSS to model zoo indexes

### DIFF
--- a/model_zoo/readme.md
+++ b/model_zoo/readme.md
@@ -30,3 +30,9 @@ FunASR has open-sourced a large number of pre-trained models on industrial data.
 |                     ct-punc <br> ( [⭐](https://modelscope.cn/models/iic/punc_ct-transformer_cn-en-common-vocab471067-large/summary) [🤗](https://huggingface.co/funasr/ct-punc) )                      |                           punctuation restoration                           |    100M, Mandarin and English    |    1.1G    |
 |                          fsmn-vad <br> ( [⭐](https://modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-pytorch/summary) [🤗](https://huggingface.co/funasr/fsmn-vad) )                          |                          voice activity detection                           | 5000 hours, Mandarin and English |    0.4M    |
 |                          fa-zh <br> ( [⭐](https://modelscope.cn/models/damo/speech_timestamp_prediction-v1-16k-offline/summary) [🤗]() )                           |                            timestamp prediction                             |       5000 hours, Mandarin       |    38M     |
+
+### Third-party Unified Transcription and Diarization
+
+| Model Name | Task Details | Publisher | Parameters |
+|:----------:|:------------:|:---------:|:----------:|
+| [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) | Offline transcription, timestamps, and anonymous per-recording speaker labels in one request. It is not a realtime or known-person identification model. See the [deployment guide](../docs/moss_transcribe_diarize.md). | OpenMOSS | See official model card |

--- a/model_zoo/readme_zh.md
+++ b/model_zoo/readme_zh.md
@@ -24,3 +24,9 @@
 |    paraformer-zh-streaming <br> ( [⭐](https://modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-online/summary) [🤗](https://huggingface.co/funasr/paraformer-zh-streaming) )    |        语音识别，实时        |  60000小时，中文  | 220M |
 | paraformer-zh-streaming-small <br> ( [⭐](https://www.modelscope.cn/models/iic/speech_paraformer_asr_nat-zh-cn-16k-common-vocab8404-online/summary) [🤗]() ) |        语音识别，实时        |  60000小时，中文  | 220M |
 | paraformer-en <br> ( [⭐](https://www.modelscope.cn/models/damo/speech_paraformer-large-vad-punc_asr_nat-en-16k-common-vocab10020/summary) [🤗]() )       |       语音识别，非实时        |  50000小时，英文  | 220M |
+
+### 第三方统一转写与说话人分离
+
+| 模型名字 | 任务详情 | 发布方 | 模型参数 |
+|:--------:|:--------:|:------:|:--------:|
+| [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) | 单次离线请求输出转写、时间戳和录音内匿名说话人标签；不是实时服务或已知人物身份识别。参见[部署指南](../docs/moss_transcribe_diarize_zh.md)。 | OpenMOSS | 以官方模型卡为准 |

--- a/tests/test_moss_transcribe_diarize_docs.py
+++ b/tests/test_moss_transcribe_diarize_docs.py
@@ -173,6 +173,21 @@ def test_readme_model_zoos_expose_moss_with_its_model_card_and_guide() -> None:
         assert guide in text, name
 
 
+def test_model_zoo_indexes_expose_moss_with_its_model_card_and_guide() -> None:
+    indexes = {
+        "model_zoo/readme.md": "../docs/moss_transcribe_diarize.md",
+        "model_zoo/readme_zh.md": "../docs/moss_transcribe_diarize_zh.md",
+    }
+
+    for name, guide in indexes.items():
+        text = (ROOT / name).read_text(encoding="utf-8")
+        assert "MOSS-Transcribe-Diarize" in text, name
+        assert (
+            "https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize" in text
+        ), name
+        assert guide in text, name
+
+
 def test_model_selection_guides_surface_offline_moss_diarization() -> None:
     guides = {
         "model_selection.md": ("./moss_transcribe_diarize.md", "offline"),


### PR DESCRIPTION
Summary:
- surface MOSS-Transcribe-Diarize in the standalone English and Chinese Model Zoo indexes
- distinguish its offline anonymous speaker-label output from realtime or known-person identification
- add a regression contract for those indexes

Validation: python -m black --check tests/test_moss_transcribe_diarize_docs.py; python -m pytest tests/test_moss_transcribe_diarize_docs.py tests/test_docs_funasr_install_commands.py -q (35 passed)

Signed-off-by: zhifu.gzf <zhifu.gzf@users.noreply.github.com>