### PR TITLE
docs: refresh ecosystem growth snapshot

### DIFF
--- a/docs/community_growth_20k.md
+++ b/docs/community_growth_20k.md
@@ -34,14 +34,14 @@ This plan focuses on useful adoption work rather than vanity marketing: if more 
 
 ## Current campaign snapshot
 
-As of 2026-09-02 13:48 UTC, the ecosystem has 37,060 combined GitHub stars, or 5,836 additional stars since the 31,224 baseline. Exceeding the +20,000 target requires another 14,164 stars to reach at least 51,224 by 2026-09-30, or roughly 506 stars/day across the remaining 28 days. Public PyPI reports 59,903 downloads over the latest 7 days and 448,764 over the latest 30 days.
+As of 2026-09-03 09:22 UTC, the ecosystem has 37,080 combined GitHub stars, or 5,856 additional stars since the 31,224 baseline. Exceeding the +20,000 target requires another 14,144 stars to reach at least 51,224 by 2026-09-30, or roughly 524 stars/day across the remaining 27 days. Public PyPI reports 61,684 downloads over the latest 7 days and 440,232 over the latest 30 days (through 2026-09-02).
 
 | Repository | Stars | Forks | Open issues | Open PRs | Last push |
 |---|---:|---:|---:|---:|---|
-| `modelscope/FunASR` | 20,132 | 2,011 | 22 | 0 | 2026-09-02 |
-| `QwenAudio/Fun-ASR` | 1,511 | 148 | 6 | 0 | 2026-09-02 |
-| `QwenAudio/SenseVoice` | 9,208 | 816 | 7 | 0 | 2026-08-31 |
-| `modelscope/FunClip` | 6,209 | 741 | 5 | 0 | 2026-09-01 |
+| `modelscope/FunASR` | 20,141 | 2,014 | 22 | 0 | 2026-09-03 |
+| `QwenAudio/Fun-ASR` | 1,517 | 149 | 6 | 0 | 2026-09-02 |
+| `QwenAudio/SenseVoice` | 9,211 | 817 | 7 | 0 | 2026-08-31 |
+| `modelscope/FunClip` | 6,211 | 742 | 5 | 0 | 2026-09-01 |
 
 ### 2026-08-21 FunASR v1.4.3 stable release
 


### PR DESCRIPTION
Summary:
- refresh the +20k ecosystem snapshot from the current GitHub and PyPI metrics
- record 37,080 combined stars, +5,856 from baseline, and 14,144 remaining
- preserve historical release evidence and update only the current snapshot

Validation: collected with scripts/collect_growth_metrics.py --ecosystem; diff check passed.

Signed-off-by: zhifu.gzf <zhifu.gzf@users.noreply.github.com>