### PR TITLE
test(docs): track FunASR 1.4.14 release

### DIFF
--- a/tests/test_docs_funasr_install_commands.py
+++ b/tests/test_docs_funasr_install_commands.py
@@ -341,8 +341,8 @@ def test_top_level_readmes_surface_current_release_and_edge_runtime():
     }
 
     for name, text in readmes.items():
-        assert 'python -m pip install -U "funasr==1.4.13"' in text, name
-        assert "https://github.com/modelscope/FunASR/releases/tag/v1.4.13" in text, name
+        assert 'python -m pip install -U "funasr==1.4.14"' in text, name
+        assert "https://github.com/modelscope/FunASR/releases/tag/v1.4.14" in text, name
         assert "runtime-llamacpp-v0.2.6" in text, name
 
     assert "https://www.funasr.com/en/deploy/llama-cpp.html" in readmes["README.md"]
@@ -386,7 +386,7 @@ def test_repository_roadmap_tracks_current_delivery_and_open_work():
     ]
 
     for text in docs:
-        assert "1.4.13" in text
+        assert "1.4.14" in text
         assert "v1.3.26" not in text
         assert "runtime-llamacpp-v0.2.6" in text
         assert "MOSS-Transcribe-Diarize" in text


### PR DESCRIPTION
## Summary

- update stale documentation release assertions from 1.4.13 to 1.4.14
- keep the runtime v0.2.6 asset contract unchanged

## Verification

- focused regression: 4 passed
- related release/documentation suite: 210 passed
- independent review: no findings
- signed commit with DCO trailer