### PR TITLE
docs: align multilingual model and serving guides

### DIFF
--- a/docs/deployment_matrix_ja.md
+++ b/docs/deployment_matrix_ja.md
@@ -12,7 +12,7 @@
 | Docker Compose API | 再現可能な local smoke test、小さな internal service | [OpenAI API Docker docs](../examples/openai_api/README_ja.md#docker-デプロイ) | デフォルトは CPU。CUDA を使う前に CUDA-capable image へ調整してください。 |
 | Kubernetes API | Cluster service 向け internal speech API | [Kubernetes template](../examples/openai_api/kubernetes/) | private `ClusterIP` から開始。公開範囲を広げる前に auth、TLS、network policy、GPU scheduling を追加します。 |
 | Runtime WebSocket service | Live captions、meeting、call-center stream | [Runtime service docs](../runtime/readme.md) | partial result、endpointing、long-lived audio stream が重要な場合に使います。 |
-| vLLM acceleration | Fun-ASR-Nano の LLM-based ASR throughput 向上 | [vLLM guide](./vllm_guide.md) | LLM decoder throughput 向け。non-autoregressive Paraformer には適用しません。 |
+| vLLM acceleration | Fun-ASR-Nano の native ファイル文字起こし、または split-engine デコード | [公式 native 検証（英語）](./vllm_official_native_validation.md)、[split-engine guide](./vllm_guide.md) | 2 つの経路は checkpoint と API が異なります。非自己回帰の Paraformer には適用しません。 |
 | MOSS-Transcribe-Diarize | 長時間の複数話者 transcription、timestamp、speaker label | [Third-party MOSS guide](./moss_transcribe_diarize.md) | OpenMOSS の Apache-2.0 model を FunASR `AutoModel` に統合済みです。local HF（`backend="hf"`）、vLLM（`backend="vllm"`）、または SGLang Omni（`backend="sglang"`）を選択できます。model の公開・保守主体は OpenMOSS のままです。 |
 | MCP server | Claude/Cursor/desktop agent の speech tool | [MCP example](../examples/mcp_server/) | ASR 結果を local tool として Agent に渡したい場合に便利です。 |
 | Subtitle generator | 長時間 audio/video から SRT/VTT 作成 | [Subtitle example](../examples/subtitle/) | readability が重要な場合は verbose segment と speaker label を使います。 |
@@ -20,13 +20,31 @@
 
 ## よくある選択
 
+### Fun-ASR-Nano を vLLM で動かしたい
+
+- **Split-engine**: 基本モデル `FunAudioLLM/Fun-ASR-Nano-2512` を使い、FunASR 側で音声を処理して LLM decoder を vLLM で実行します。[split-engine guide](./vllm_guide.md)を参照してください。
+- **Native**: vLLM 自身が音声モデルを実行します。公式 checkpoint は `FunAudioLLM/Fun-ASR-Nano-2512-vllm` です。基本モデル用の設定や checkpoint と相互に置き換えないでください。
+
+[公式 native 検証記録（英語）](./vllm_official_native_validation.md)は、モデル revision
+`a4362c943d48951f98ca2a62181cc028970270c5`、vLLM 0.27.1、既存の H100 環境での機能確認です。
+モデル revision は FunASR パッケージのバージョンではありません。依存関係を含む準備・起動手順は検証記録を参照してください。
+
+確認した API はファイル入力の `/v1/audio/transcriptions` です。`/v1/realtime`、クリーンインストール、長時間音声、話者分離、本番の処理容量はこの検証の対象ではありません。FunASR SDK や別の checkpoint の検証として扱わず、実運用の音声・負荷で別途評価してください。
+
 ### 5分で FunASR を試したい
 
 ブラウザだけで試すなら [Colab クイックスタート](../examples/colab/README_ja.md) を使います。ローカルで作業する場合は README の Python API から始めます。どのモデルを使うか迷う場合は [モデル選択ガイド](./model_selection_ja.md) を参照してください。
 
 ### Cloud transcription の local replacement が欲しい
 
-OpenAI 互換 API を使います。`/v1/audio/transcriptions`、`/v1/models`、`/health`、Swagger docs を提供します。まず `sensevoice` で smoke test を実行し、既存 SDK や HTTP client を [OpenAI API example](../examples/openai_api/README_ja.md) に合わせて接続してください。
+OpenAI 互換 API を使います。主な入口は次のとおりです。
+
+- `/v1/audio/transcriptions`: ファイル文字起こし
+- `/v1/models`: モデル一覧
+- `/health`: ヘルスチェック
+- Swagger docs: API の確認
+
+まず `sensevoice` で smoke test を実行し、既存 SDK や HTTP client を [OpenAI API example](../examples/openai_api/README_ja.md) に合わせて接続してください。
 
 ### 再現可能な container demo が欲しい
 

--- a/docs/deployment_matrix_ko.md
+++ b/docs/deployment_matrix_ko.md
@@ -12,7 +12,7 @@
 | Docker Compose API | 재현 가능한 local smoke test, 작은 internal service | [OpenAI API Docker docs](../examples/openai_api/README_ko.md#docker-배포) | 기본은 CPU입니다. CUDA를 쓰기 전에 CUDA-capable image로 조정하세요. |
 | Kubernetes API | Cluster service용 internal speech API | [Kubernetes template](../examples/openai_api/kubernetes/) | private `ClusterIP`부터 시작합니다. 범위를 넓히기 전에 auth, TLS, network policy, GPU scheduling을 추가하세요. |
 | Runtime WebSocket service | Live captions, meeting, call-center stream | [Runtime service docs](../runtime/readme.md) | partial result, endpointing, long-lived audio stream이 중요할 때 사용합니다. |
-| vLLM acceleration | Fun-ASR-Nano의 LLM-based ASR throughput 향상 | [vLLM guide](./vllm_guide.md) | LLM decoder throughput용입니다. non-autoregressive Paraformer에는 적용되지 않습니다. |
+| vLLM acceleration | Fun-ASR-Nano의 native 파일 전사 또는 split-engine 디코딩 | [공식 native 검증(영문)](./vllm_official_native_validation.md), [split-engine guide](./vllm_guide.md) | 두 경로는 checkpoint와 API가 다릅니다. 비자기회귀 Paraformer에는 적용되지 않습니다. |
 | MOSS-Transcribe-Diarize | 긴 다중 화자 transcription, timestamp, speaker label | [Third-party MOSS guide](./moss_transcribe_diarize.md) | OpenMOSS의 Apache-2.0 model이며 FunASR `AutoModel`에 통합되어 있습니다. local HF(`backend="hf"`), vLLM(`backend="vllm"`) 또는 SGLang Omni(`backend="sglang"`)를 선택할 수 있습니다. model의 공개 및 유지 관리는 계속 OpenMOSS가 담당합니다. |
 | MCP server | Claude/Cursor/desktop agent speech tool | [MCP example](../examples/mcp_server/) | ASR 결과를 local tool로 Agent에 전달할 때 유용합니다. |
 | Subtitle generator | 긴 audio/video에서 SRT/VTT 생성 | [Subtitle example](../examples/subtitle/) | readability가 중요하면 verbose segment와 speaker label을 사용합니다. |
@@ -20,13 +20,31 @@
 
 ## 자주 쓰는 선택
 
+### Fun-ASR-Nano를 vLLM으로 실행하고 싶다
+
+- **Split-engine**: 기본 모델 `FunAudioLLM/Fun-ASR-Nano-2512`를 사용하며, FunASR가 오디오를 처리하고 LLM decoder를 vLLM에서 실행합니다. [split-engine guide](./vllm_guide.md)를 참고하세요.
+- **Native**: vLLM 자체가 오디오 모델을 실행합니다. 공식 checkpoint는 `FunAudioLLM/Fun-ASR-Nano-2512-vllm`입니다. 기본 모델용 설정이나 checkpoint와 서로 바꾸어 사용하지 마세요.
+
+[공식 native 검증 기록(영문)](./vllm_official_native_validation.md)은 모델 revision
+`a4362c943d48951f98ca2a62181cc028970270c5`, vLLM 0.27.1, 기존 H100 환경에서의 기능 확인입니다.
+모델 revision은 FunASR 패키지 버전이 아닙니다. 의존성을 포함한 준비 및 실행 절차는 검증 기록을 참고하세요.
+
+확인한 API는 파일 입력의 `/v1/audio/transcriptions`입니다. `/v1/realtime`, 클린 설치, 긴 오디오, 화자 분리, 프로덕션 처리 용량은 검증 대상이 아닙니다. 이를 FunASR SDK나 다른 checkpoint의 검증으로 간주하지 말고, 실제 운영 오디오와 부하로 별도 평가하세요.
+
 ### 5분 안에 FunASR을 시험하고 싶다
 
 브라우저만으로 확인하려면 [Colab 빠른 시작](../examples/colab/README_ko.md)을 사용하세요. 로컬에서 작업하려면 README의 Python API부터 시작합니다. 어떤 모델을 고를지 고민된다면 [모델 선택 가이드](./model_selection_ko.md)를 참고하세요.
 
 ### Cloud transcription의 local replacement가 필요하다
 
-OpenAI 호환 API를 사용하세요. `/v1/audio/transcriptions`, `/v1/models`, `/health`, Swagger docs를 제공합니다. 먼저 `sensevoice`로 smoke test를 실행하고 기존 SDK나 HTTP client를 [OpenAI API example](../examples/openai_api/README_ko.md)에 맞춰 연결하세요.
+OpenAI 호환 API를 사용하세요. 주요 진입점은 다음과 같습니다.
+
+- `/v1/audio/transcriptions`: 파일 전사
+- `/v1/models`: 모델 목록
+- `/health`: 상태 확인
+- Swagger docs: API 확인
+
+먼저 `sensevoice`로 smoke test를 실행하고 기존 SDK나 HTTP client를 [OpenAI API example](../examples/openai_api/README_ko.md)에 맞춰 연결하세요.
 
 ### 재현 가능한 container demo가 필요하다
 

--- a/docs/model_selection.md
+++ b/docs/model_selection.md
@@ -4,7 +4,7 @@ Use this guide when you are choosing a first model, comparing FunASR with Whispe
 
 ## Fast default path
 
-If you have a GPU, start with the flagship **Fun-ASR-Nano** — an LLM-based ASR model (SenseVoice encoder + a Qwen3 decoder) for Chinese, English, and Japanese, plus Chinese dialect groups and regional accents, with strong accuracy on hard cases, context, and proper nouns:
+For GPU evaluation of Chinese, English, Japanese, or Chinese dialects and regional accents, start with the flagship **Fun-ASR-Nano** (SenseVoice encoder + Qwen3 decoder). Compare it on your own audio before choosing a production model:
 
 ```python
 from funasr import AutoModel
@@ -14,7 +14,7 @@ result = model.generate(input="meeting.wav")
 print(result[0]["text"])
 ```
 
-On CPU, or when you want multilingual + emotion/event tags and speaker-aware meeting transcripts in one fast non-autoregressive pass, use **SenseVoice-Small**:
+For non-autoregressive multilingual ASR with emotion/event tags, or a CPU evaluation path, start with **SenseVoice-Small**. The example below adds separate VAD and speaker-processing stages for meeting transcripts; speaker diarization is not a SenseVoice output from the same recognition pass:
 
 ```python
 from funasr import AutoModel
@@ -27,6 +27,11 @@ model = AutoModel(
 )
 result = model.generate(input="meeting.wav")
 ```
+
+SenseVoice produces transcription and rich tags. `fsmn-vad` locates speech;
+`cam++` produces speaker embeddings, which the pipeline clusters into anonymous
+labels within a recording. These labels do not identify registered people and
+are not stable identities across recordings.
 
 Switch to Paraformer when your workload is Mandarin-only and you want character-level timestamps or hotwords.
 
@@ -47,12 +52,15 @@ Switch to Paraformer when your workload is Mandarin-only and you want character-
 
 The `examples/openai_api` server exposes short aliases so application teams do not need to know model repository IDs:
 
-| Alias | Underlying path | Use when |
-|---|---|---|
-| `sensevoice` | `iic/SenseVoiceSmall` | You want the default private speech API with multilingual ASR, event tags, and good CPU/GPU behavior. |
-| `paraformer` | `paraformer-zh` with VAD and punctuation | You want a Mandarin-oriented production route. |
-| `paraformer-en` | `paraformer-en` with VAD | You want a compact English route in OpenAI-style clients. |
-| `fun-asr-nano` | `FunAudioLLM/Fun-ASR-Nano-2512` | You are evaluating LLM-based ASR for Chinese, English, Japanese, and Chinese dialect/accent coverage, or want to test vLLM acceleration. |
+- **`sensevoice`** uses `iic/SenseVoiceSmall` for multilingual HTTP transcription on CPU/GPU. Returned text has rich tags removed.
+- **`paraformer`** uses `paraformer-zh` with VAD and punctuation for a Mandarin-oriented route.
+- **`paraformer-en`** uses `paraformer-en` with VAD for English transcription in OpenAI-style clients.
+- **`fun-asr-nano`** uses `FunAudioLLM/Fun-ASR-Nano-2512` for evaluating Chinese, English, Japanese, and Chinese dialect/accent coverage. Select a compatible runtime when evaluating vLLM acceleration.
+
+The example HTTP service cleans both top-level `text` and segment `text` in
+`verbose_json`; that format does not restore emotion/event tags. If you need
+the original tags, use the Python SDK and preserve the returned `text` before
+display postprocessing. See the [raw-tag recipe](./speaker_emotion.md).
 
 For Ascend NPU deployments, treat `fun-asr-nano` separately from SenseVoice / Paraformer. The Fun-ASR-Nano PyTorch `AutoModel` path has community compatibility evidence on 310P3 after the NPU autocast fix, but it was much slower than CPU in that smoke test; `AutoModelVLLM` still depends on vLLM-Ascend operator support and has hit Qwen3 rotary / `TransData` failures. Use CUDA/vLLM, standard PyTorch CPU/GPU, or GGUF runtime for production unless you are actively validating an Ascend backend.
 
@@ -92,7 +100,7 @@ For migration work, use the [migration benchmark example](../examples/migration/
 
 ## Practical recommendations
 
-- With a GPU, default to Fun-ASR-Nano — the flagship LLM-based model for Chinese, English, Japanese, and Chinese dialects/accents, strongest on hard, contextual, and proper-noun-heavy audio. For the separate 31-language checkpoint, use Fun-ASR-MLT-Nano.
+- With a GPU, evaluate Fun-ASR-Nano for Chinese, English, Japanese, and Chinese dialects/accents. Include difficult audio, context and proper nouns in your own comparison. For the separate 31-language checkpoint, use Fun-ASR-MLT-Nano.
 - On CPU, or for multilingual + emotion workloads, use SenseVoice-Small (fast non-autoregressive, CPU-viable).
 - Use Paraformer when your production traffic is primarily Mandarin and you want timestamps or hotwords.
 - For offline long recordings that need anonymous per-recording speaker labels in the same request, use MOSS-Transcribe-Diarize; it is not a realtime WebSocket or known-person identification path.

--- a/docs/model_selection_ja.md
+++ b/docs/model_selection_ja.md
@@ -18,7 +18,9 @@ model = AutoModel(
 result = model.generate(input="meeting.wav")
 ```
 
-デモ、プライベート API、多言語文字起こし、話者付き会議録、Agent 音声入力の最初の選択肢として使いやすいモデルです。中国語本番精度、ストリーミング遅延、LLM-based ASR 評価など明確な要件が出たときだけ切り替えてください。
+デモ、プライベート API、多言語文字起こし、Agent 音声入力の評価をここから始められます。上の会議録の例では、SenseVoice の ASR・感情/イベントタグとは別に、`fsmn-vad` で音声区間を検出し、`cam++` の話者埋め込みをクラスタリングします。話者ラベルは録音内の匿名番号で、登録済み人物の識別や録音間で固定された ID ではありません。対象言語と実際の音声でモデルを比較してください。
+
+**Fun-ASR-Nano-2512** は中国語・英語・日本語と中国語方言/地域アクセントの評価候補です。**Fun-ASR-MLT-Nano** は別の checkpoint です。必要な言語の対応を各モデルカードで確認し、Nano の対応範囲と混同しないでください。
 
 ## 判断表
 
@@ -36,12 +38,15 @@ result = model.generate(input="meeting.wav")
 
 `examples/openai_api` server は短い alias を提供します。アプリケーション側はモデル repository ID を知らなくても利用できます。
 
-| Alias | 中身 | 使う場面 |
-|---|---|---|
-| `sensevoice` | `iic/SenseVoiceSmall` | 多言語 ASR、イベントタグ、CPU/GPU 両対応の標準プライベート音声 API。 |
-| `paraformer` | `paraformer-zh` + VAD + punctuation | 中国語中心の本番ルート。 |
-| `paraformer-en` | `paraformer-en` + VAD | OpenAI-style client の英語互換性チェック。 |
-| `fun-asr-nano` | `FunAudioLLM/Fun-ASR-Nano-2512` | LLM-based ASR の中英日・中国語方言/地域アクセント評価、または vLLM acceleration の確認。 |
+- **`sensevoice`**: `iic/SenseVoiceSmall` による CPU/GPU での多言語 HTTP 文字起こしです。返却テキストからリッチタグは除去されます。
+- **`paraformer`**: `paraformer-zh` に VAD と句読点復元を組み合わせた中国語向けの経路です。
+- **`paraformer-en`**: `paraformer-en` と VAD を使う、OpenAI-style client 向けの英語文字起こしです。
+- **`fun-asr-nano`**: `FunAudioLLM/Fun-ASR-Nano-2512` による中英日・中国語方言/地域アクセントの評価経路です。vLLM acceleration を試す場合は互換性のある runtime を選んでください。
+
+この HTTP サンプルはトップレベルの `text` と `verbose_json` の各 segment の
+`text` を整形するため、形式を変えても感情/イベントタグは復元されません。
+元のタグが必要なら Python SDK を使い、表示用の後処理より前に返却された `text`
+を保存してください。[元のタグを保存するレシピ（英語）](./speaker_emotion.md)を参照してください。
 
 接続前にサービスを確認します。
 

--- a/docs/model_selection_ko.md
+++ b/docs/model_selection_ko.md
@@ -18,7 +18,9 @@ model = AutoModel(
 result = model.generate(input="meeting.wav")
 ```
 
-데모, 프라이빗 API, 다국어 전사, 화자 포함 회의록, Agent 음성 입력의 첫 선택지로 사용하기 좋습니다. 중국어 프로덕션 정확도, 스트리밍 지연 시간, LLM-based ASR 평가처럼 명확한 요구가 있을 때만 다른 경로로 전환하세요.
+데모, 프라이빗 API, 다국어 전사, Agent 음성 입력을 여기서 평가할 수 있습니다. 위 회의록 예제는 SenseVoice의 ASR 및 감정/이벤트 태그와 별도로, `fsmn-vad`로 음성 구간을 찾고 `cam++`의 화자 임베딩을 클러스터링합니다. 화자 라벨은 녹음 내 익명 번호이며, 등록된 인물의 식별이나 녹음 간 고정 ID가 아닙니다. 대상 언어와 실제 오디오로 모델을 비교하세요.
+
+**Fun-ASR-Nano-2512**의 중국어·영어·일본어 및 중국어 방언/지역 억양 지원이 한국어 지원을 뜻하지는 않습니다. **Fun-ASR-MLT-Nano**는 별도 checkpoint입니다. 한국어를 포함한 대상 언어의 지원 범위는 각 모델 카드를 확인하고, Nano의 범위와 혼동하지 마세요.
 
 ## 결정 표
 
@@ -36,12 +38,15 @@ result = model.generate(input="meeting.wav")
 
 `examples/openai_api` server는 짧은 alias를 제공합니다. 애플리케이션 팀은 모델 repository ID를 몰라도 사용할 수 있습니다.
 
-| Alias | 내부 경로 | 사용 시점 |
-|---|---|---|
-| `sensevoice` | `iic/SenseVoiceSmall` | 다국어 ASR, 이벤트 태그, CPU/GPU 동작이 균형 잡힌 기본 프라이빗 음성 API. |
-| `paraformer` | `paraformer-zh` + VAD + punctuation | 중국어 중심 프로덕션 경로. |
-| `paraformer-en` | `paraformer-en` + VAD | OpenAI-style client의 영어 호환성 확인. |
-| `fun-asr-nano` | `FunAudioLLM/Fun-ASR-Nano-2512` | LLM-based ASR의 중영일·중국어 방언/지역 억양 평가, 또는 vLLM acceleration 확인. |
+- **`sensevoice`**: `iic/SenseVoiceSmall`을 사용하는 CPU/GPU 다국어 HTTP 전사입니다. 반환 텍스트에서 리치 태그는 제거됩니다.
+- **`paraformer`**: `paraformer-zh`에 VAD와 문장부호 복원을 결합한 중국어 경로입니다.
+- **`paraformer-en`**: `paraformer-en`과 VAD를 사용하는 OpenAI-style client용 영어 전사입니다.
+- **`fun-asr-nano`**: `FunAudioLLM/Fun-ASR-Nano-2512`로 중영일·중국어 방언/지역 억양을 평가합니다. vLLM acceleration을 시험할 때는 호환되는 runtime을 선택하세요.
+
+이 HTTP 예제는 최상위 `text`와 `verbose_json`의 각 segment `text`를 정리하므로,
+형식을 바꿔도 감정/이벤트 태그가 복원되지 않습니다. 원래 태그가 필요하면 Python SDK를
+사용하고 표시용 후처리 전에 반환된 `text`를 보존하세요.
+[원본 태그 보존 레시피(영문)](./speaker_emotion.md)를 참고하세요.
 
 클라이언트를 연결하기 전에 서비스를 확인하세요.
 

--- a/docs/model_selection_zh.md
+++ b/docs/model_selection_zh.md
@@ -4,7 +4,7 @@
 
 ## 默认快速路径
 
-如果有 GPU，先从旗舰 **Fun-ASR-Nano** 开始 —— 基于 LLM 的识别模型（SenseVoice 编码器 + Qwen3 解码），覆盖中文、英文、日语，以及 7 种中文方言和 26 种地域口音，在难例、上下文和专名上精度最强：
+如果有 GPU，需要评估中文、英文、日语或中文方言和地域口音，可以先试旗舰 **Fun-ASR-Nano**（SenseVoice 编码器 + Qwen3 解码器）。确定生产模型前，请用自己的音频做对比：
 
 ```python
 from funasr import AutoModel
@@ -14,7 +14,7 @@ result = model.generate(input="meeting.wav")
 print(result[0]["text"])
 ```
 
-在 CPU 上，或当你想要多语种 + 情感/事件标签、带说话人信息的会议转写一次完成时，用 **SenseVoice-Small**：
+需要非自回归多语种 ASR、情感/事件标签，或先在 CPU 上评估时，可以从 **SenseVoice-Small** 开始。下面的会议转写示例另外组合了 VAD 和说话人处理阶段；说话人分离不是 SenseVoice 单次识别直接提供的能力：
 
 ```python
 from funasr import AutoModel
@@ -27,6 +27,9 @@ model = AutoModel(
 )
 result = model.generate(input="meeting.wav")
 ```
+
+SenseVoice 生成转写和富文本标签；`fsmn-vad` 定位语音，`cam++` 提取说话人向量，
+再由处理流水线聚类得到录音内的匿名编号。这些编号不识别已注册人物，也不是跨录音稳定的身份。
 
 当你的场景是纯中文、需要字级时间戳或热词时，切换到 Paraformer。
 
@@ -47,12 +50,14 @@ result = model.generate(input="meeting.wav")
 
 `examples/openai_api` 服务提供短别名，应用团队不需要了解具体模型仓库 ID：
 
-| Alias | 底层路径 | 适合场景 |
-|---|---|---|
-| `sensevoice` | `iic/SenseVoiceSmall` | 默认私有语音 API，多语种 ASR、事件标签和 CPU/GPU 行为较均衡。 |
-| `paraformer` | `paraformer-zh` + VAD + 标点 | 中文生产流量优先尝试。 |
-| `paraformer-en` | `paraformer-en` + VAD | OpenAI 风格客户端里的英文轻量路由。 |
-| `fun-asr-nano` | `FunAudioLLM/Fun-ASR-Nano-2512` | 评估 LLM-based ASR 的中文、英文、日语与中文方言/口音覆盖，或测试 vLLM 加速。 |
+- **`sensevoice`** 使用 `iic/SenseVoiceSmall`，用于 CPU/GPU 多语种 HTTP 转写；返回文本已移除富文本标签。
+- **`paraformer`** 使用 `paraformer-zh`，组合 VAD 和标点，适合评估中文转写。
+- **`paraformer-en`** 使用 `paraformer-en`，组合 VAD，提供 OpenAI 风格客户端的英文转写路径。
+- **`fun-asr-nano`** 使用 `FunAudioLLM/Fun-ASR-Nano-2512`，评估中文、英文、日语与中文方言/口音覆盖；测试 vLLM 加速时须选择兼容的运行路径。
+
+示例 HTTP 服务会清理顶层 `text` 和 `verbose_json` 中各分段的 `text`；
+切换到该格式不会恢复情感/事件标签。需要原始标签时，请使用 Python SDK，
+在展示后处理前保存返回的 `text`，参见[原始标签示例](./speaker_emotion_zh.md)。
 
 如果部署目标是昇腾 NPU，请把 `fun-asr-nano` 和 SenseVoice / Paraformer 分开看。Fun-ASR-Nano 的 PyTorch `AutoModel` 路径在修复 NPU autocast 后已有 310P3 社区兼容性 smoke 结果，但该测试明显慢于 CPU；`AutoModelVLLM` 仍依赖 vLLM-Ascend 算子支持，并已遇到 Qwen3 rotary / `TransData` 失败。生产部署优先使用 CUDA/vLLM、标准 PyTorch CPU/GPU 或 GGUF runtime，除非你正在主动验证 Ascend 后端。
 

--- a/web-pages/product-site/tests/browser/model-selection-tags.spec.ts
+++ b/web-pages/product-site/tests/browser/model-selection-tags.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+for (const width of [390, 1440]) {
+  for (const language of ['zh', 'en']) {
+    test(`Model selection to raw tag recipe: ${language} ${width}px`, async ({ page }, testInfo) => {
+      const prefix = language === 'en' ? '/en' : '';
+      const errors: string[] = [];
+      page.on('pageerror', error => errors.push(error.message));
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(`${prefix}/docs/model-selection.html`);
+      const recipe = page.locator(`.docs-article a[href="${prefix}/docs/speaker-emotion.html"]`);
+      await expect(recipe).toHaveCount(1);
+      await recipe.scrollIntoViewIfNeeded();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth - innerWidth)).toBeLessThanOrEqual(1);
+      await page.screenshot({ path: testInfo.outputPath('http-aliases.png') });
+      await recipe.click();
+      await expect(page).toHaveURL(new RegExp(`${prefix}/docs/speaker-emotion.html$`));
+      const code = page.locator('.docs-article pre').filter({ hasText: 'raw_tagged_text' });
+      await expect(code).toHaveCount(1);
+      await code.scrollIntoViewIfNeeded();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth - innerWidth)).toBeLessThanOrEqual(1);
+      expect(errors).toEqual([]);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Correct four-language model selection: example HTTP text removes SenseVoice rich tags, including verbose segments; link the SDK raw-tag recipe.
- Separate ASR/tag generation from VAD, speaker embeddings and anonymous clustering. Remove unsupported strongest-accuracy wording.
- Align Japanese/Korean vLLM selection with split-engine versus official-native checkpoints, file API, pinned revision and existing-environment verification limits.
- Replace cramped alias tables with readable lists; preserve language suitability and all existing links/headings. Add working model-selection-to-recipe browser navigation coverage.

## Verification
- Final59 focused tests and45 Sphinx link tests pass; the signed head is retested before push.
- Product build validates180 HTML pages and exports established GitHub Pages aliases. Signed-head build is byte-identical to tested output.
- Four product zh/en390/1440 browser cases pass after the missing navigation link was reproduced as a failing test.
- Eight additional local Sphinx JA/KO390/1440 cases pass: target navigation, zero page overflow and no JS errors. A47px legacy-page overflow was traced to inline endpoint text and fixed with endpoint bullets.
- Final mobile and desktop screenshots inspected. Sphinx retains31 historical warnings.
- Independent read-only source review has no remaining blocking findings; no GitHub maintainer approval is claimed.

Documentation only: no runtime change, model inference, PyPI release, new www JA/KO routes or issue closure. Signed DCO and rollback/source/evidence backups retained.