### PR TITLE
fix(vad): exclude idle time from dynamic silence schedule

### DIFF
--- a/funasr/models/fsmn_vad_streaming/dynamic_vad.py
+++ b/funasr/models/fsmn_vad_streaming/dynamic_vad.py
@@ -94,6 +94,18 @@ class DynamicStreamingVAD:
         self.confirmed_segments: List[List[int]] = []
         self.current_speech_start: Optional[int] = None
         self.accumulated_since_cut_ms: int = 0
+        self._total_audio_samples: int = 0
+        self._needs_stream_reset: bool = False
+
+    def _update_speech_duration(self):
+        if self.current_speech_start is None:
+            self.accumulated_since_cut_ms = 0
+        else:
+            # VAD start signals use the session clock, including preceding silence.
+            audio_end_ms = self._total_audio_samples * 1000 // self.sample_rate
+            self.accumulated_since_cut_ms = max(
+                0, audio_end_ms - int(self.current_speech_start)
+            )
 
     def _get_silence_threshold(self) -> int:
         """根据当前累积时长，从 schedule 中查询静音阈值。"""
@@ -123,11 +135,14 @@ class DynamicStreamingVAD:
             新确认的语音段列表，每段为 [start_ms, end_ms]。
             仅在检测到语音结束时返回非空列表。
         """
+        if self._needs_stream_reset:
+            self.reset()
         if audio_chunk.dim() > 1:
             audio_chunk = audio_chunk.squeeze()
 
         chunk_samples = len(audio_chunk)
-        self.accumulated_since_cut_ms += int(chunk_samples * 1000 / self.sample_rate)
+        self._total_audio_samples += chunk_samples
+        self._update_speech_duration()
 
         self._apply_dynamic_threshold()
         initial_cache_kwargs = {}
@@ -163,17 +178,22 @@ class DynamicStreamingVAD:
                 self.current_speech_start = None
                 self.accumulated_since_cut_ms = 0
 
+        self._update_speech_duration()
+        # Preserve final state for callers' tail fallback; reset before the next stream.
+        self._needs_stream_reset = is_final
         return new_confirmed
 
     def finalize(self) -> List[List[int]]:
         """结束流式处理，返回最后可能未结束的语音段。
 
-        调用此方法后，VAD 状态会被重置。
-        如果当前有正在进行的语音段，会被强制结束。
+        本次状态保留到下一次 feed，便于调用方补齐未返回结束信号的尾段。
+        下一次 feed 会重置状态，开始新的流。
 
         Returns:
             最后确认的语音段列表。
         """
+        if self._needs_stream_reset:
+            return []
         # Feed empty with is_final=True to flush
         empty = torch.zeros(int(self.sample_rate * 0.01), dtype=torch.float32)
         return self.feed(empty, is_final=True)
@@ -228,3 +248,5 @@ class DynamicStreamingVAD:
         self.confirmed_segments = []
         self.current_speech_start = None
         self.accumulated_since_cut_ms = 0
+        self._total_audio_samples = 0
+        self._needs_stream_reset = False

--- a/tests/test_dynamic_streaming_vad.py
+++ b/tests/test_dynamic_streaming_vad.py
@@ -82,5 +82,166 @@ class TestDynamicStreamingVadFirstCall(unittest.TestCase):
         self.assertEqual(one_chunk_segments, [])
 
 
+class _SignalModel(_ThresholdAwareModel):
+    def __init__(self, signals):
+        super().__init__()
+        self.signals = iter(signals)
+        self.thresholds = []
+
+    def generate(self, input, cache, **kwargs):
+        if not cache:
+            self.model.init_cache(cache, **kwargs)
+        self.thresholds.append(
+            cache["stats"].max_end_sil_frame_cnt_thresh
+            + self.model.vad_opts.speech_to_sil_time_thres
+        )
+        return [{"value": next(self.signals, [])}]
+
+
+class TestDynamicStreamingVadSpeechDuration(unittest.TestCase):
+    def test_initial_silence_does_not_advance_speech_schedule(self):
+        vad = DynamicStreamingVAD(_SignalModel([[]]))
+
+        vad.feed(torch.zeros(60 * 16000))
+
+        self.assertEqual(vad.current_duration_ms, 0)
+        self.assertEqual(vad.current_threshold_ms, 2000)
+
+    def test_speech_after_initial_silence_uses_short_utterance_threshold(self):
+        model = _SignalModel([[], [[60000, -1]]])
+        vad = DynamicStreamingVAD(model)
+        vad.feed(torch.zeros(60 * 16000))
+
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(model.thresholds, [2000, 2000])
+        self.assertEqual(vad.current_duration_ms, 1000)
+        self.assertEqual(vad.current_threshold_ms, 2000)
+
+    def test_inter_utterance_silence_does_not_age_next_utterance(self):
+        model = _SignalModel([[[0, -1]], [[-1, 1000]], [], [[22000, -1]]])
+        vad = DynamicStreamingVAD(model)
+        vad.feed(torch.ones(16000))
+        vad.feed(torch.zeros(2 * 16000))
+        vad.feed(torch.zeros(19 * 16000))
+
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(model.thresholds[-1], 2000)
+        self.assertEqual(vad.current_duration_ms, 1000)
+
+    def test_duration_uses_detected_start_and_keeps_long_speech_schedule(self):
+        vad = DynamicStreamingVAD(_SignalModel([[], [[6000, -1]], []]))
+        vad.feed(torch.zeros(5 * 16000))
+        vad.feed(torch.ones(2 * 16000))
+        self.assertEqual(vad.current_duration_ms, 1000)
+
+        vad.feed(torch.ones(6 * 16000))
+
+        self.assertEqual(vad.current_duration_ms, 7000)
+        self.assertEqual(vad.current_threshold_ms, 1500)
+
+    def test_submillisecond_packets_do_not_lose_elapsed_samples(self):
+        vad = DynamicStreamingVAD(_SignalModel([[[0, -1]], [], []]))
+        for count in (1, 15, 160):
+            vad.feed(torch.ones(count))
+
+        self.assertEqual(vad.current_duration_ms, 11)
+
+    def test_last_open_signal_in_packet_defines_current_duration(self):
+        vad = DynamicStreamingVAD(_SignalModel([[[0, 1000], [2000, -1]]]))
+
+        self.assertEqual(vad.feed(torch.ones(10 * 16000)), [[0, 1000]])
+
+        self.assertEqual(vad.current_duration_ms, 8000)
+        self.assertEqual(vad.current_threshold_ms, 1500)
+
+    def test_reset_starts_a_new_sample_clock(self):
+        vad = DynamicStreamingVAD(_SignalModel([[], [[0, -1]]]))
+        vad.feed(torch.zeros(60 * 16000))
+        vad.reset()
+
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(vad.current_duration_ms, 1000)
+        self.assertEqual(vad.current_threshold_ms, 2000)
+
+    def test_backdated_start_in_previous_packet_counts_entire_segment(self):
+        vad = DynamicStreamingVAD(_SignalModel([[], [[4800, -1]]]))
+        vad.feed(torch.zeros(5 * 16000))
+
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(vad.current_duration_ms, 1200)
+
+    def test_start_end_start_in_one_packet_uses_last_start(self):
+        vad = DynamicStreamingVAD(
+            _SignalModel([[[1000, -1], [-1, 2000], [3000, -1]]])
+        )
+
+        self.assertEqual(vad.feed(torch.ones(10 * 16000)), [[1000, 2000]])
+        self.assertEqual(vad.current_speech_start, 3000)
+        self.assertEqual(vad.current_duration_ms, 7000)
+
+    def test_finalize_without_end_preserves_start_for_service_fallback(self):
+        vad = DynamicStreamingVAD(_SignalModel([[[500, -1]], []]))
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(vad.finalize(), [])
+
+        self.assertEqual(vad.current_speech_start, 500)
+        self.assertTrue(vad.is_speaking)
+
+    def test_feed_after_finalize_starts_a_new_stream(self):
+        model = _SignalModel([[], [], [[0, -1]]])
+        vad = DynamicStreamingVAD(model)
+        vad.feed(torch.zeros(60 * 16000))
+        vad.finalize()
+
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(vad.current_duration_ms, 1000)
+        self.assertEqual(model.thresholds[-1], 2000)
+
+    def test_feed_after_direct_final_clears_previous_stream(self):
+        model = _SignalModel([[[0, 1000], [2000, -1]], [[0, -1]]])
+        vad = DynamicStreamingVAD(model)
+        self.assertEqual(vad.feed(torch.ones(60 * 16000), is_final=True), [[0, 1000]])
+        self.assertEqual(vad.current_speech_start, 2000)
+        old_cache = vad.cache
+
+        vad.feed(torch.ones(16000))
+
+        self.assertEqual(vad.current_duration_ms, 1000)
+        self.assertEqual(vad.confirmed_segments, [])
+        self.assertIsNot(vad.cache, old_cache)
+        self.assertEqual(model.thresholds[-1], 2000)
+
+    def test_repeated_finalize_preserves_final_state_without_feeding_again(self):
+        model = _SignalModel([[[0, 100], [500, -1]], []])
+        vad = DynamicStreamingVAD(model)
+        vad.feed(torch.ones(16000))
+        vad.finalize()
+        final_cache = vad.cache
+
+        self.assertEqual(vad.finalize(), [])
+
+        self.assertEqual(vad.current_speech_start, 500)
+        self.assertEqual(vad.confirmed_segments, [[0, 100]])
+        self.assertIs(vad.cache, final_cache)
+        self.assertEqual(len(model.thresholds), 2)
+
+    def test_finalize_after_process_preserves_results_and_fallback_state(self):
+        model = _SignalModel([[[0, 30]], [[80, -1]]])
+        vad = DynamicStreamingVAD(model)
+        self.assertEqual(vad.process(torch.ones(1920)), [[0, 30]])
+
+        self.assertEqual(vad.finalize(), [])
+
+        self.assertEqual(vad.confirmed_segments, [[0, 30]])
+        self.assertEqual(vad.current_speech_start, 80)
+        self.assertEqual(len(model.thresholds), 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Keep the dynamic FSMN silence schedule tied to the current detected speech segment instead of time spent waiting for speech. Related to #3302; this PR deliberately does not close that report.

- Track total input samples and derive elapsed speech time from the VAD's absolute start timestamp. Initial and inter-utterance silence no longer ages the next utterance; fractional-millisecond packets retain their samples.
- Preserve backdated starts and the last open segment when one feed returns several signals.
- Reset stream state on the next feed after EOS, while preserving final state for the realtime service's tail fallback. Repeated `finalize()` is idempotent.
- Leave the silence schedule, noise threshold, compensation, model weights and ASR decoding unchanged.

## Verification

On ind-gpu8, using PyTorch 2.8.0+cu128 with CPU FSMN inference:

```sh
python -m pytest -q tests/test_dynamic_streaming_vad.py \
  tests/test_realtime_ws_service.py tests/test_realtime_ws_benchmark.py \
  tests/test_fsmn_vad_dynamic_silence.py tests/test_fsmn_vad_streaming_buffers.py
```

**122 passed**, no skips. The wrapper suite includes 16 tests. The original idle-duration defect and both EOS compatibility defects were reproduced as failing assertions before their respective fixes. `git diff --check` passes; independent static review found no remaining actionable issue.

Real-model controlled check: pinned FSMN snapshot `v2.0.4`, first 30 seconds of the reporter's `YT-02.mp3`, mono 16 kHz, 256 ms transport packets, three seconds of trailing silence. Compare the same clip with zero vs 60 seconds of preceding silence:

| Wrapper | No initial silence | 60 seconds of initial silence |
| --- | --- | --- |
| Before | 2 segments | 3 segments |
| After | 2 segments | 2 segments |

After subtracting the prefixed silence, the fixed segment boundaries are `[[0, 17690], [24140, 30280]]` and `[[-220, 17690], [24140, 30280]]` ms. The 220 ms onset difference is VAD lookback into the prefixed silence; not every boundary is asserted identical.

## Scope And Follow-Up

This uses the original playback file, **not the reporter's captured microphone PCM**, and does not measure ASR transcription accuracy. It establishes an idle-time-dependent VAD segmentation defect, not complete resolution of microphone truncation. The 42-second decode warning in the report remains a separate investigation. No arbitrary transport-packetization invariance or hardware fix is claimed; #3302 stays open for real microphone validation.
