### PR TITLE
docs: distinguish native Transformers model downloads

### DIFF
--- a/.github/workflows/product-site.yml
+++ b/.github/workflows/product-site.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/_ext/**'
       - 'tests/test_sphinx_links.py'
       - 'tests/test_vllm_examples_contract.py'
+      - 'tests/test_readme_task_entrypoints.py'
       - 'model_zoo/**/*.md'
       - 'runtime/**/*.md'
       - 'examples/openai_api/**/*.md'
@@ -32,6 +33,7 @@ on:
       - 'docs/_ext/**'
       - 'tests/test_sphinx_links.py'
       - 'tests/test_vllm_examples_contract.py'
+      - 'tests/test_readme_task_entrypoints.py'
       - 'model_zoo/**/*.md'
       - 'runtime/**/*.md'
       - 'examples/openai_api/**/*.md'
@@ -88,6 +90,7 @@ jobs:
       - name: Run model-free documentation contracts
         run: >-
           python -m pytest
+          tests/test_readme_task_entrypoints.py
           tests/test_learning_docs_contract.py
           tests/test_reference_docs_contract.py
           tests/test_vllm_examples_contract.py

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ known-person identification. Model licenses are separate from the toolkit's MIT 
 
 | Model | Task | Languages | Params | Links |
 |-------|------|-----------|--------|-------|
-| **Fun-ASR-Nano** | ASR | zh/en/ja + Chinese dialects and accents | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
+| **Fun-ASR-Nano** | ASR | zh/en/ja + Chinese dialects and accents | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [HF / Transformers](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) · [HF / FunASR](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
 | **Fun-ASR-MLT-Nano** | ASR | 31 languages | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) |
 | **SenseVoiceSmall** | ASR + emotion + events | zh/en/ja/ko/yue | 234M | [⭐](https://www.modelscope.cn/models/iic/SenseVoiceSmall) [🤗](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) [GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) [paper](https://arxiv.org/abs/2407.04051) |
 | **MOSS-Transcribe-Diarize** | Third-party OpenMOSS: offline ASR + timestamps + anonymous speakers | See official card | See official card | [🤗](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) [guide](./docs/moss_transcribe_diarize.md) |

--- a/README_ja.md
+++ b/README_ja.md
@@ -140,7 +140,7 @@ FunASR はアダプターを提供します。統合経路はオフラインで�
 
 | モデル | タスク | 言語 | パラメータ | リンク |
 |--------|--------|------|-----------|--------|
-| **Fun-ASR-Nano** | 認識 | 中/英/日 + 中国語方言 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
+| **Fun-ASR-Nano** | 認識 | 中/英/日 + 中国語方言 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [HF / Transformers](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) · [HF / FunASR](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
 | **Fun-ASR-MLT-Nano** | 認識 | 31言語 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) |
 | **SenseVoiceSmall** | 認識 + 感情 + イベント | 中/英/日/韓/粤 | 234M | [⭐](https://www.modelscope.cn/models/iic/SenseVoiceSmall) [🤗](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) [GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) |
 | **MOSS-Transcribe-Diarize** | 第三者 OpenMOSS：オフライン認識 + タイムスタンプ + 匿名話者 | 公式モデルカードを参照 | 公式モデルカードを参照 | [🤗](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) [ガイド](./docs/moss_transcribe_diarize.md) |

--- a/README_ko.md
+++ b/README_ko.md
@@ -139,7 +139,7 @@ FunASR는 어댑터를 제공합니다. 통합 경로는 오프라인이고 익�
 
 | 모델 | 작업 | 언어 | 파라미터 | 링크 |
 |------|------|------|---------|------|
-| **Fun-ASR-Nano** | 인식 | 중/영/일 + 중국어 방언 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
+| **Fun-ASR-Nano** | 인식 | 중/영/일 + 중국어 방언 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [HF / Transformers](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) · [HF / FunASR](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
 | **Fun-ASR-MLT-Nano** | 인식 | 31개 언어 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) |
 | **SenseVoiceSmall** | 인식 + 감정 + 이벤트 | 중/영/일/한/광둥어 | 234M | [⭐](https://www.modelscope.cn/models/iic/SenseVoiceSmall) [🤗](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) [GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) |
 | **MOSS-Transcribe-Diarize** | 제3자 OpenMOSS: 오프라인 인식 + 타임스탬프 + 익명 화자 | 공식 모델 카드 참조 | 공식 모델 카드 참조 | [🤗](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) [가이드](./docs/moss_transcribe_diarize.md) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -192,7 +192,7 @@ pip install -e ./
 
 | 模型 | 任务 | 语言 | 参数量 | 链接 |
 |------|------|------|--------|------|
-| **Fun-ASR-Nano** | 识别 | 中/英/日 + 中文方言 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
+| **Fun-ASR-Nano** | 识别 | 中/英/日 + 中文方言 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) [HF / Transformers](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) · [HF / FunASR](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) [GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) |
 | **Fun-ASR-MLT-Nano** | 识别 | 31 种语言 | 800M | [⭐](https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-MLT-Nano-2512) [🤗](https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512) |
 | **SenseVoiceSmall** | 识别 + 情感 + 事件 | 中/英/日/韩/粤 | 234M | [⭐](https://www.modelscope.cn/models/iic/SenseVoiceSmall) [🤗](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) [GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) [论文](https://arxiv.org/abs/2407.04051) |
 | **MOSS-Transcribe-Diarize** | 第三方 OpenMOSS：离线识别 + 时间戳 + 匿名说话人 | 以官方模型卡为准 | 以官方模型卡为准 | [🤗](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) [指南](./docs/moss_transcribe_diarize_zh.md) |

--- a/tests/test_readme_task_entrypoints.py
+++ b/tests/test_readme_task_entrypoints.py
@@ -157,6 +157,21 @@ def test_relative_links_and_internal_navigation_resolve(name):
             assert unquote(target.fragment) in anchors, (name, link["href"])
 
 
+@pytest.mark.parametrize("name", LANGUAGES)
+def test_model_zoo_distinguishes_native_transformers_and_toolkit_downloads(name):
+    body = section(name, LANGUAGES[name][3])
+    rows = {row.find("td").get_text(strip=True): row for row in body.select("tr")
+            if row.find("td")}
+    links = {link.get_text(strip=True): link.get("href")
+             for link in rows["Fun-ASR-Nano"].select("a[href]")}
+    assert links.get("HF / Transformers") == "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf"
+    assert links.get("HF / FunASR") == "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512"
+    assert links.get("GGUF") == "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF"
+    mlt_links = {link.get("href") for link in rows["Fun-ASR-MLT-Nano"].select("a[href]")}
+    assert "https://huggingface.co/FunAudioLLM/Fun-ASR-MLT-Nano-2512" in mlt_links
+    assert "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf" not in mlt_links
+
+
 def test_speaker_field_explanation_has_implementation_evidence():
     camp = ast.parse(read("funasr/models/campplus/model.py"))
     assert any(isinstance(node, ast.Constant) and node.value == "spk_embedding" for node in ast.walk(camp))


### PR DESCRIPTION
## Summary
Make the native Transformers checkpoint discoverable directly in all four language README model download entries, rather than only inside a code example. Label the native -hf artifact as HF / Transformers and retain the original artifact as HF / FunASR. Keep MLT, ModelScope and GGUF links distinct.

All fenced examples, weights/runtime code, capability descriptions and three-item news remain unchanged. This is not native timestamps/diarization/streaming support or a new runtime release.

## Verification
- Four new Model Zoo checks failed before editing. Final README contracts: 33 passed; the exact expanded workflow documentation-contract command: 313 passed, 3 deliberate existing deselections. Add this previously unexecuted README suite to the existing CI command and both event path filters; no skip or assertion weakening.
- GitHub's actual GFM rendering verified labeled download links across both repositories' eight READMEs. HF API confirms native/original/MLT/GGUF libraries are transformers/funasr/funasr/gguf respectively.
- All eight README code fences are byte-identical. Website build has the same 271 hashes as current production; no deployment needed.
- Independent review found no P1/P2. Before-push backup, verified signed bundle, signature and DCO retained.
